### PR TITLE
fix(ingestion_pipeline): concurrency does not work when spawned

### DIFF
--- a/swiftide/src/traits.rs
+++ b/swiftide/src/traits.rs
@@ -89,7 +89,7 @@ pub trait SimplePrompt: Debug + Send + Sync {
 #[cfg_attr(test, automock)]
 #[async_trait]
 /// Persists nodes
-pub trait Persist: Send + Sync {
+pub trait Persist: Debug + Send + Sync {
     async fn setup(&self) -> Result<()>;
     async fn store(&self, node: IngestionNode) -> Result<IngestionNode>;
     async fn batch_store(&self, nodes: Vec<IngestionNode>) -> IngestionStream;


### PR DESCRIPTION
Currency does did not work as expected. When spawning via `Tokio::spawn` the future would be polled directly, and any concurrency setting would not be respected. Because it had to be removed, improved tracing for each step as well.
