### PR TITLE
feat: more transformers

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,3 +21,7 @@ path = "fastembed.rs"
 [[example]]
 name = "ingest-redis"
 path = "ingest_into_redis.rs"
+
+[[example]]
+name = "ingest-markdown-metadata"
+path = "ingest_markdown_lots_of_metadata.rs"

--- a/examples/ingest_markdown_lots_of_metadata.rs
+++ b/examples/ingest_markdown_lots_of_metadata.rs
@@ -1,0 +1,63 @@
+//! # [Swiftide] Ingesting the Swiftide README with lots of metadata
+//!
+//! This example demonstrates how to ingest the Swiftide README with lots of metadata.
+//!
+//! The pipeline will:
+//! - Load the README.md file from the current directory
+//! - Chunk the file into pieces of 20 to 1024 bytes
+//! - Generate questions and answers for each chunk
+//! - Generate a summary for each chunk
+//! - Generate a title for each chunk
+//! - Generate keywords for each chunk
+//! - Embed each chunk
+//! - Store the nodes in Qdrant
+//!
+//! [Swiftide]: https://github.com/bosun-ai/swiftide
+//! [examples]: https://github.com/bosun-ai/swiftide/blob/master/examples
+
+use swiftide::{
+    ingestion,
+    integrations::{self, qdrant::Qdrant},
+    loaders::FileLoader,
+    transformers::{
+        ChunkMarkdown, Embed, MetadataKeywords, MetadataQAText, MetadataSummary, MetadataTitle,
+    },
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    let openai_client = integrations::openai::OpenAI::builder()
+        .default_embed_model("text-embedding-3-small")
+        .default_prompt_model("gpt-4o")
+        .build()?;
+
+    let qdrant_url = std::env::var("QDRANT_URL")
+        .as_deref()
+        .unwrap_or("http://localhost:6334")
+        .to_owned();
+
+    ingestion::IngestionPipeline::from_loader(
+        FileLoader::new("README.md").with_extensions(&["md"]),
+    )
+    .with_concurrency(1)
+    .then_chunk(ChunkMarkdown::with_chunk_range(20..2048))
+    .then(MetadataQAText::new(openai_client.clone()))
+    .then(MetadataSummary::new(openai_client.clone()))
+    .then(MetadataTitle::new(openai_client.clone()))
+    .then(MetadataKeywords::new(openai_client.clone()))
+    .then_in_batch(10, Embed::new(openai_client.clone()))
+    .log_all()
+    .filter_errors()
+    .then_store_with(
+        Qdrant::try_from_url(qdrant_url)?
+            .batch_size(50)
+            .vector_size(1536)
+            .collection_name("swiftide-examples".to_string())
+            .build()?,
+    )
+    .run()
+    .await?;
+    Ok(())
+}

--- a/swiftide/src/ingestion/ingestion_node.rs
+++ b/swiftide/src/ingestion/ingestion_node.rs
@@ -19,6 +19,7 @@
 //! need to be processed together.
 use std::{
     collections::HashMap,
+    fmt::Debug,
     hash::{Hash, Hasher},
     path::PathBuf,
 };
@@ -30,7 +31,7 @@ use serde::{Deserialize, Serialize};
 /// `IngestionNode` encapsulates all necessary information for a single unit of data being processed
 /// in the ingestion pipeline. It includes fields for an identifier, file path, data chunk, optional
 /// vector representation, and metadata.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct IngestionNode {
     /// Optional identifier for the node.
     pub id: Option<u64>,
@@ -42,6 +43,25 @@ pub struct IngestionNode {
     pub vector: Option<Vec<f32>>,
     /// Metadata associated with the node.
     pub metadata: HashMap<String, String>,
+}
+
+impl Debug for IngestionNode {
+    /// Formats the node for debugging purposes.
+    ///
+    /// This method is used to provide a human-readable representation of the node when debugging.
+    /// The vector field is displayed as the number of elements in the vector if present.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IngestionNode")
+            .field("id", &self.id)
+            .field("path", &self.path)
+            .field("chunk", &self.chunk)
+            .field("metadata", &self.metadata)
+            .field(
+                "vector",
+                &self.vector.as_ref().map(|v| format!("[{}]", v.len())),
+            )
+            .finish()
+    }
 }
 
 impl IngestionNode {

--- a/swiftide/src/ingestion/ingestion_node.rs
+++ b/swiftide/src/ingestion/ingestion_node.rs
@@ -45,6 +45,16 @@ pub struct IngestionNode {
 }
 
 impl IngestionNode {
+    /// Creates a new instance of `IngestionNode` with the specified data chunk.
+    ///
+    /// The other fields are set to their default values.
+    pub fn new(chunk: impl Into<String>) -> IngestionNode {
+        IngestionNode {
+            chunk: chunk.into(),
+            ..Default::default()
+        }
+    }
+
     /// Converts the node into an embeddable string format.
     ///
     /// The embeddable format consists of the metadata formatted as key-value pairs, each on a new line,

--- a/swiftide/src/integrations/openai/simple_prompt.rs
+++ b/swiftide/src/integrations/openai/simple_prompt.rs
@@ -24,7 +24,7 @@ impl SimplePrompt for OpenAI {
     /// - Returns an error if the model is not set in the default options.
     /// - Returns an error if the request to the OpenAI API fails.
     /// - Returns an error if the response does not contain the expected content.
-    #[tracing::instrument(skip(self), err)]
+    #[tracing::instrument(skip_all, err)]
     async fn prompt(&self, prompt: &str) -> Result<String> {
         // Retrieve the model from the default options, returning an error if not set.
         let model = self

--- a/swiftide/src/traits.rs
+++ b/swiftide/src/traits.rs
@@ -79,6 +79,7 @@ pub trait EmbeddingModel: Send + Sync {
     async fn embed(&self, input: Vec<String>) -> Result<Embeddings>;
 }
 
+#[cfg_attr(test, automock)]
 #[async_trait]
 /// Given a string prompt, queries an LLM
 pub trait SimplePrompt: Debug + Send + Sync {

--- a/swiftide/src/transformers/metadata_keywords.rs
+++ b/swiftide/src/transformers/metadata_keywords.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+
+use crate::{ingestion::IngestionNode, SimplePrompt, Transformer};
+use anyhow::Result;
+use async_trait::async_trait;
+use derive_builder::Builder;
+use indoc::indoc;
+
+/// This module defines the `MetadataKeywords` struct and its associated methods,
+/// which are used for generating metadata in the form of keywords
+/// for a given text. It interacts with a client (e.g., OpenAI) to generate
+/// the keywords based on the text chunk in an `IngestionNode`.
+
+/// `MetadataKeywords` is responsible for generating keywords
+/// for a given text chunk. It uses a templated prompt to interact with a client
+/// that implements the `SimplePrompt` trait.
+#[derive(Debug, Clone, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct MetadataKeywords {
+    #[builder(setter(custom))]
+    client: Arc<dyn SimplePrompt>,
+    #[builder(default = "default_prompt()")]
+    prompt: String,
+    #[builder(default)]
+    concurrency: Option<usize>,
+}
+
+impl MetadataKeywords {
+    pub fn builder() -> MetadataKeywordsBuilder {
+        MetadataKeywordsBuilder::default()
+    }
+
+    pub fn from_client(client: impl SimplePrompt + 'static) -> MetadataKeywordsBuilder {
+        MetadataKeywordsBuilder::default().client(client).to_owned()
+    }
+    /// Creates a new instance of `MetadataKeywords`.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - An implementation of the `SimplePrompt` trait.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `MetadataKeywords`.
+    pub fn new(client: impl SimplePrompt + 'static) -> Self {
+        Self {
+            client: Arc::new(client),
+            prompt: default_prompt(),
+            concurrency: None,
+        }
+    }
+
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = Some(concurrency);
+        self
+    }
+}
+
+/// Generates the default prompt template for extracting keywords.
+///
+/// # Returns
+///
+/// A string containing the default prompt template.
+fn default_prompt() -> String {
+    indoc! {r#"
+
+            # Task
+            Your task is to generate a descriptive, concise keywords for the given text
+
+            # Constraints 
+            * Only respond in the example format
+            * Respond with a keywords that are representative of the text
+            * Only include keywords that are literally included in the text
+            * Respond with a comma-separated list of keywords
+
+            # Example
+            Respond in the following example format and do not include anything else:
+
+            ```
+            <keyword>,<other-keyword>
+            ```
+
+            # Text
+            ```
+            {text}
+            ```
+
+        "#}
+    .to_string()
+}
+
+impl MetadataKeywordsBuilder {
+    pub fn client(&mut self, client: impl SimplePrompt + 'static) -> &mut Self {
+        self.client = Some(Arc::new(client));
+        self
+    }
+}
+
+#[async_trait]
+impl Transformer for MetadataKeywords {
+    /// Transforms an `IngestionNode` by extracting a keywords
+    /// based on the text chunk within the node.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The `IngestionNode` containing the text chunk to process.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the transformed `IngestionNode` with added metadata,
+    /// or an error if the transformation fails.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the client fails to generate
+    /// a keywords from the provided prompt.
+    #[tracing::instrument(skip_all, name = "transformers.metadata_keywords")]
+    async fn transform_node(&self, mut node: IngestionNode) -> Result<IngestionNode> {
+        let prompt = self.prompt.replace("{text}", &node.chunk);
+
+        let response = self.client.prompt(&prompt).await?;
+
+        node.metadata.insert("Keywords".to_string(), response);
+
+        Ok(node)
+    }
+
+    fn concurrency(&self) -> Option<usize> {
+        self.concurrency
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::MockSimplePrompt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_metadata_keywords() {
+        let mut client = MockSimplePrompt::new();
+
+        client
+            .expect_prompt()
+            .returning(|_| Ok("important,keywords".to_string()));
+
+        let transformer = MetadataKeywords::builder().client(client).build().unwrap();
+        let node = IngestionNode::new("Some text");
+
+        let result = transformer.transform_node(node).await.unwrap();
+
+        assert_eq!(
+            result.metadata.get("Keywords").unwrap(),
+            "important,keywords"
+        );
+    }
+}

--- a/swiftide/src/transformers/metadata_qa_code.rs
+++ b/swiftide/src/transformers/metadata_qa_code.rs
@@ -142,3 +142,29 @@ impl Transformer for MetadataQACode {
         self.concurrency
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::MockSimplePrompt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_metadata_qacode() {
+        let mut client = MockSimplePrompt::new();
+
+        client
+            .expect_prompt()
+            .returning(|_| Ok("Q1: Hello\nA1: World".to_string()));
+
+        let transformer = MetadataQACode::builder().client(client).build().unwrap();
+        let node = IngestionNode::new("Some text");
+
+        let result = transformer.transform_node(node).await.unwrap();
+
+        assert_eq!(
+            result.metadata.get("Questions and Answers").unwrap(),
+            "Q1: Hello\nA1: World"
+        );
+    }
+}

--- a/swiftide/src/transformers/metadata_qa_text.rs
+++ b/swiftide/src/transformers/metadata_qa_text.rs
@@ -143,3 +143,29 @@ impl Transformer for MetadataQAText {
         self.concurrency
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::MockSimplePrompt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_metadata_qacode() {
+        let mut client = MockSimplePrompt::new();
+
+        client
+            .expect_prompt()
+            .returning(|_| Ok("Q1: Hello\nA1: World".to_string()));
+
+        let transformer = MetadataQAText::builder().client(client).build().unwrap();
+        let node = IngestionNode::new("Some text");
+
+        let result = transformer.transform_node(node).await.unwrap();
+
+        assert_eq!(
+            result.metadata.get("Questions and Answers").unwrap(),
+            "Q1: Hello\nA1: World"
+        );
+    }
+}

--- a/swiftide/src/transformers/metadata_summary.rs
+++ b/swiftide/src/transformers/metadata_summary.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use crate::{ingestion::IngestionNode, SimplePrompt, Transformer};
+use anyhow::Result;
+use async_trait::async_trait;
+use derive_builder::Builder;
+use indoc::indoc;
+
+/// This module defines the `MetadataSummary` struct and its associated methods,
+/// which are used for generating metadata in the form of a summary
+/// for a given text. It interacts with a client (e.g., OpenAI) to generate
+/// the summary based on the text chunk in an `IngestionNode`.
+
+/// `MetadataSummary` is responsible for generating a summary
+/// for a given text chunk. It uses a templated prompt to interact with a client
+/// that implements the `SimplePrompt` trait.
+#[derive(Debug, Clone, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct MetadataSummary {
+    #[builder(setter(custom))]
+    client: Arc<dyn SimplePrompt>,
+    #[builder(default = "default_prompt()")]
+    prompt: String,
+    #[builder(default)]
+    concurrency: Option<usize>,
+}
+
+impl MetadataSummary {
+    pub fn builder() -> MetadataSummaryBuilder {
+        MetadataSummaryBuilder::default()
+    }
+
+    pub fn from_client(client: impl SimplePrompt + 'static) -> MetadataSummaryBuilder {
+        MetadataSummaryBuilder::default().client(client).to_owned()
+    }
+    /// Creates a new instance of `MetadataSummary`.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - An implementation of the `SimplePrompt` trait.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `MetadataSummary`.
+    pub fn new(client: impl SimplePrompt + 'static) -> Self {
+        Self {
+            client: Arc::new(client),
+            prompt: default_prompt(),
+            concurrency: None,
+        }
+    }
+
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = Some(concurrency);
+        self
+    }
+}
+
+/// Generates the default prompt template for extracting a summary.
+///
+/// # Returns
+///
+/// A string containing the default prompt template.
+fn default_prompt() -> String {
+    indoc! {r#"
+
+            # Task
+            Your task is to generate a descriptive, concise summary for the given text
+
+            # Constraints 
+            * Only respond in the example format
+            * Respond with a summary that is accurate and descriptive without fluff
+            * Only include information that is included in the text
+
+            # Example
+            Respond in the following example format and do not include anything else:
+
+            ```
+            <summary>
+            ```
+
+            # Text
+            ```
+            {text}
+            ```
+
+        "#}
+    .to_string()
+}
+
+impl MetadataSummaryBuilder {
+    pub fn client(&mut self, client: impl SimplePrompt + 'static) -> &mut Self {
+        self.client = Some(Arc::new(client));
+        self
+    }
+}
+
+#[async_trait]
+impl Transformer for MetadataSummary {
+    /// Transforms an `IngestionNode` by extracting a summary
+    /// based on the text chunk within the node.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The `IngestionNode` containing the text chunk to process.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the transformed `IngestionNode` with added metadata,
+    /// or an error if the transformation fails.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the client fails to generate
+    /// a summary from the provided prompt.
+    #[tracing::instrument(skip_all, name = "transformers.metadata_summary")]
+    async fn transform_node(&self, mut node: IngestionNode) -> Result<IngestionNode> {
+        let prompt = self.prompt.replace("{text}", &node.chunk);
+
+        let response = self.client.prompt(&prompt).await?;
+
+        node.metadata.insert("Summary".to_string(), response);
+
+        Ok(node)
+    }
+
+    fn concurrency(&self) -> Option<usize> {
+        self.concurrency
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::MockSimplePrompt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_metadata_summary() {
+        let mut client = MockSimplePrompt::new();
+
+        client
+            .expect_prompt()
+            .returning(|_| Ok("A Summary".to_string()));
+
+        let transformer = MetadataSummary::builder().client(client).build().unwrap();
+        let node = IngestionNode::new("Some text");
+
+        let result = transformer.transform_node(node).await.unwrap();
+
+        assert_eq!(result.metadata.get("Summary").unwrap(), "A Summary");
+    }
+}

--- a/swiftide/src/transformers/metadata_title.rs
+++ b/swiftide/src/transformers/metadata_title.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use crate::{ingestion::IngestionNode, SimplePrompt, Transformer};
+use anyhow::Result;
+use async_trait::async_trait;
+use derive_builder::Builder;
+use indoc::indoc;
+
+/// This module defines the `MetadataTitle` struct and its associated methods,
+/// which are used for generating metadata in the form of a title
+/// for a given text. It interacts with a client (e.g., OpenAI) to generate
+/// these questions and answers based on the text chunk in an `IngestionNode`.
+
+/// `MetadataTitle` is responsible for generating a title
+/// for a given text chunk. It uses a templated prompt to interact with a client
+/// that implements the `SimplePrompt` trait.
+#[derive(Debug, Clone, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct MetadataTitle {
+    #[builder(setter(custom))]
+    client: Arc<dyn SimplePrompt>,
+    #[builder(default = "default_prompt()")]
+    prompt: String,
+    #[builder(default)]
+    concurrency: Option<usize>,
+}
+
+impl MetadataTitle {
+    pub fn builder() -> MetadataTitleBuilder {
+        MetadataTitleBuilder::default()
+    }
+
+    pub fn from_client(client: impl SimplePrompt + 'static) -> MetadataTitleBuilder {
+        MetadataTitleBuilder::default().client(client).to_owned()
+    }
+    /// Creates a new instance of `MetadataTitle`.
+    ///
+    /// # Arguments
+    ///
+    /// * `client` - An implementation of the `SimplePrompt` trait.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `MetadataTitle`.
+    pub fn new(client: impl SimplePrompt + 'static) -> Self {
+        Self {
+            client: Arc::new(client),
+            prompt: default_prompt(),
+            concurrency: None,
+        }
+    }
+
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = Some(concurrency);
+        self
+    }
+}
+
+/// Generates the default prompt template for generating questions and answers.
+///
+/// # Returns
+///
+/// A string containing the default prompt template.
+fn default_prompt() -> String {
+    indoc! {r#"
+
+            # Task
+            Your task is to generate a descriptive, concise title for the given text
+
+            # Constraints 
+            * Only respond in the example format
+            * Respond with a title that is accurate and descriptive without fluff
+
+            # Example
+            Respond in the following example format and do not include anything else:
+
+            ```
+            <title>
+            ```
+
+            # Text
+            ```
+            {text}
+            ```
+
+        "#}
+    .to_string()
+}
+
+impl MetadataTitleBuilder {
+    pub fn client(&mut self, client: impl SimplePrompt + 'static) -> &mut Self {
+        self.client = Some(Arc::new(client));
+        self
+    }
+}
+
+#[async_trait]
+impl Transformer for MetadataTitle {
+    /// Transforms an `IngestionNode` by generating questions and answers
+    /// based on the text chunk within the node.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - The `IngestionNode` containing the text chunk to process.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the transformed `IngestionNode` with added metadata,
+    /// or an error if the transformation fails.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the client fails to generate
+    /// questions and answers from the provided prompt.
+    #[tracing::instrument(skip_all, name = "transformers.metadata_title")]
+    async fn transform_node(&self, mut node: IngestionNode) -> Result<IngestionNode> {
+        let prompt = self.prompt.replace("{text}", &node.chunk);
+
+        let response = self.client.prompt(&prompt).await?;
+
+        node.metadata.insert("Title".to_string(), response);
+
+        Ok(node)
+    }
+
+    fn concurrency(&self) -> Option<usize> {
+        self.concurrency
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::MockSimplePrompt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_metadata_title() {
+        let mut client = MockSimplePrompt::new();
+
+        client
+            .expect_prompt()
+            .returning(|_| Ok("A Title".to_string()));
+
+        let transformer = MetadataTitle::builder().client(client).build().unwrap();
+        let node = IngestionNode::new("Some text");
+
+        let result = transformer.transform_node(node).await.unwrap();
+
+        assert_eq!(result.metadata.get("Title").unwrap(), "A Title");
+    }
+}

--- a/swiftide/src/transformers/mod.rs
+++ b/swiftide/src/transformers/mod.rs
@@ -3,13 +3,19 @@ pub mod chunk_code;
 
 pub mod chunk_markdown;
 pub mod embed;
+pub mod metadata_keywords;
 pub mod metadata_qa_code;
 pub mod metadata_qa_text;
+pub mod metadata_summary;
+pub mod metadata_title;
 
 #[cfg(feature = "tree-sitter")]
 pub use chunk_code::ChunkCode;
 
 pub use chunk_markdown::ChunkMarkdown;
 pub use embed::Embed;
+pub use metadata_keywords::MetadataKeywords;
 pub use metadata_qa_code::MetadataQACode;
 pub use metadata_qa_text::MetadataQAText;
+pub use metadata_summary::MetadataSummary;
+pub use metadata_title::MetadataTitle;


### PR DESCRIPTION
Closes #68 

Need to double tap on the examples before merging.

- **feat(ingestion_node): add constructor with defaults**
- **feat(traits): add automock for simpleprompt**
- **feat(transformers): add transformers for title, summary and keywords**
- **feat(examples): example for markdown with all metadata**
- **feat: add example**
