### PR TITLE
feat(ingestion_stream): improved stream developer experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,6 +2922,7 @@ dependencies = [
  "itertools 0.13.0",
  "mockall",
  "num_cpus",
+ "pin-project-lite",
  "qdrant-client",
  "redis",
  "serde",

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -28,6 +28,7 @@ tracing = { version = "0.1.40", features = ["log"] }
 strum = "0.26.2"
 strum_macros = "0.26.4"
 num_cpus = "1.16.0"
+pin-project-lite = "0.2"
 
 # Integrations
 async-openai = { version = "0.23.2", optional = true }

--- a/swiftide/src/ingestion/ingestion_stream.rs
+++ b/swiftide/src/ingestion/ingestion_stream.rs
@@ -1,44 +1,68 @@
+#![allow(clippy::from_over_into)]
+#![cfg(not(tarpaulin_include))]
 //! This module defines the `IngestionStream` type, which is used for handling asynchronous streams of `IngestionNode` items in the ingestion pipeline.
-//!
-//! The `IngestionStream` type is a pinned, boxed, dynamically-dispatched stream that yields `Result<IngestionNode>` items. This type is essential for managing
-//! and processing large volumes of data asynchronously, ensuring efficient and scalable ingestion workflows.
 
 use anyhow::Result;
-use futures_util::stream::Stream;
+use futures_util::stream::{self, Stream};
+use pin_project_lite::pin_project;
 use std::pin::Pin;
 
 use super::IngestionNode;
 
-/// A type alias for a pinned, boxed, dynamically-dispatched stream of `IngestionNode` items.
-///
-/// This type is used in the ingestion pipeline to handle asynchronous streams of data. Each item in the stream is a `Result<IngestionNode>`,
-/// allowing for error handling during the ingestion process. The `Send` trait is implemented to ensure that the stream can be safely sent
-/// across threads, enabling concurrent processing.
-///
-/// # Type Definition
-/// - `Pin<Box<dyn Stream<Item = Result<IngestionNode>> + Send>>`
-///
-/// # Components
-/// - `Pin`: Ensures that the memory location of the stream is fixed, which is necessary for certain asynchronous operations.
-/// - `Box<dyn Stream<Item = Result<IngestionNode>>>`: A heap-allocated, dynamically-dispatched stream that yields `Result<IngestionNode>` items.
-/// - `Send`: Ensures that the stream can be sent across thread boundaries, facilitating concurrent processing.
-///
-/// # Usage
-/// The `IngestionStream` type is typically used in the ingestion pipeline to process data asynchronously. It allows for efficient handling
-/// of large volumes of data by leveraging Rust's asynchronous capabilities.
-///
-/// # Error Handling
-/// Each item in the stream is a `Result<IngestionNode>`, which means that errors can be propagated and handled during the ingestion process.
-/// This design allows for robust error handling and ensures that the ingestion pipeline can gracefully handle failures.
-///
-/// # Performance Considerations
-/// The use of `Pin` and `Box` ensures that the stream's memory location is fixed and heap-allocated, respectively. This design choice is
-/// crucial for asynchronous operations that require stable memory addresses. Additionally, the `Send` trait enables concurrent processing,
-/// which can significantly improve performance in multi-threaded environments.
-///
-/// # Edge Cases
-/// - The stream may yield errors (`Err` variants) instead of valid `IngestionNode` items. These errors should be handled appropriately
-///   to ensure the robustness of the ingestion pipeline.
-/// - The stream must be pinned to ensure that its memory location remains fixed, which is necessary for certain asynchronous operations.
+pub use futures_util::{StreamExt, TryStreamExt};
 
-pub type IngestionStream = Pin<Box<dyn Stream<Item = Result<IngestionNode>> + Send>>;
+// We need to inform the compiler that `inner` is pinned as well
+pin_project! {
+    /// An asynchronous stream of `IngestionNode` items.
+    ///
+    /// Wraps an internal stream of `Result<IngestionNode>` items.
+    ///
+    /// Streams, iterators and vectors of `Result<IngestionNode>` can be converted into an `IngestionStream`.
+    pub struct IngestionStream {
+        #[pin]
+        inner: Pin<Box<dyn Stream<Item = Result<IngestionNode>> + Send>>,
+    }
+}
+
+impl Stream for IngestionStream {
+    type Item = Result<IngestionNode>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.project();
+        this.inner.poll_next(cx)
+    }
+}
+
+impl Into<IngestionStream> for Vec<Result<IngestionNode>> {
+    fn into(self) -> IngestionStream {
+        IngestionStream::iter(self)
+    }
+}
+
+impl Into<IngestionStream> for Pin<Box<dyn Stream<Item = Result<IngestionNode>> + Send>> {
+    fn into(self) -> IngestionStream {
+        IngestionStream { inner: self }
+    }
+}
+
+impl IngestionStream {
+    pub fn empty() -> Self {
+        IngestionStream {
+            inner: stream::empty().boxed(),
+        }
+    }
+
+    // NOTE: Can we really guarantee that the iterator will outlive the stream?
+    pub fn iter<I>(iter: I) -> Self
+    where
+        I: IntoIterator<Item = Result<IngestionNode>> + Send + 'static,
+        <I as IntoIterator>::IntoIter: Send,
+    {
+        IngestionStream {
+            inner: stream::iter(iter).boxed(),
+        }
+    }
+}

--- a/swiftide/src/integrations/qdrant/persist.rs
+++ b/swiftide/src/integrations/qdrant/persist.rs
@@ -4,7 +4,6 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use futures_util::{stream, StreamExt};
 
 use crate::{
     ingestion::{IngestionNode, IngestionStream},
@@ -82,7 +81,7 @@ impl Persist for Qdrant {
             .collect::<Result<Vec<_>>>();
 
         if points.is_err() {
-            return stream::iter(vec![Err(points.unwrap_err())]).boxed();
+            return vec![Err(points.unwrap_err())].into();
         }
 
         let points = points.unwrap();
@@ -93,9 +92,9 @@ impl Persist for Qdrant {
             .await;
 
         if result.is_ok() {
-            stream::iter(nodes.into_iter().map(Ok)).boxed()
+            IngestionStream::iter(nodes.into_iter().map(Ok))
         } else {
-            stream::iter(vec![Err(result.unwrap_err())]).boxed()
+            vec![Err(result.unwrap_err())].into()
         }
     }
 }

--- a/swiftide/src/loaders/file_loader.rs
+++ b/swiftide/src/loaders/file_loader.rs
@@ -1,5 +1,4 @@
 use crate::{ingestion::IngestionNode, ingestion::IngestionStream, Loader};
-use futures_util::{stream, StreamExt};
 use std::path::PathBuf;
 
 /// The `FileLoader` struct is responsible for loading files from a specified directory,
@@ -103,7 +102,7 @@ impl Loader for FileLoader {
                 })
             });
 
-        stream::iter(file_paths).boxed()
+        IngestionStream::iter(file_paths)
     }
 }
 

--- a/swiftide/src/transformers/chunk_code.rs
+++ b/swiftide/src/transformers/chunk_code.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_builder::Builder;
-use futures_util::{stream, StreamExt};
 
 use crate::{
     ingestion::{IngestionNode, IngestionStream},
@@ -90,16 +89,15 @@ impl ChunkerTransformer for ChunkCode {
         let split_result = self.chunker.split(&node.chunk);
 
         if let Ok(split) = split_result {
-            return stream::iter(split.into_iter().map(move |chunk| {
+            IngestionStream::iter(split.into_iter().map(move |chunk| {
                 Ok(IngestionNode {
                     chunk,
                     ..node.clone()
                 })
             }))
-            .boxed();
         } else {
             // Send the error downstream
-            return stream::iter(vec![Err(split_result.unwrap_err())]).boxed();
+            IngestionStream::iter(vec![Err(split_result.unwrap_err())])
         }
     }
 

--- a/swiftide/src/transformers/chunk_markdown.rs
+++ b/swiftide/src/transformers/chunk_markdown.rs
@@ -1,7 +1,6 @@
 use crate::{ingestion::IngestionNode, ingestion::IngestionStream, ChunkerTransformer};
 use async_trait::async_trait;
 use derive_builder::Builder;
-use futures_util::{stream, StreamExt};
 use text_splitter::{Characters, MarkdownSplitter};
 
 #[derive(Debug, Builder)]
@@ -42,13 +41,12 @@ impl ChunkerTransformer for ChunkMarkdown {
             .map(|chunk| chunk.to_string())
             .collect::<Vec<String>>();
 
-        stream::iter(chunks.into_iter().map(move |chunk| {
+        IngestionStream::iter(chunks.into_iter().map(move |chunk| {
             Ok(IngestionNode {
                 chunk,
                 ..node.clone()
             })
         }))
-        .boxed()
     }
 
     fn concurrency(&self) -> Option<usize> {


### PR DESCRIPTION
Improves stream ergonomics by providing convenient helpers and `Into` for streams, vectors and iterators that match the internal type.

This means that in many cases, trait implementers can simply call `.into()` instead of manually constructing a stream. In the case it's an iterator, they can now use `IngestionStream::iter(<IntoIterator>)` instead.