### PR TITLE
fix(embed): panic in rare cases num embeddings != num nodes

### DIFF
--- a/swiftide/src/ingestion/ingestion_pipeline.rs
+++ b/swiftide/src/ingestion/ingestion_pipeline.rs
@@ -263,13 +263,8 @@ impl IngestionPipeline {
     /// Logs all results processed by the pipeline.
     ///
     /// This method logs all results processed by the pipeline at the `DEBUG` level.
-    pub fn log_all(mut self) -> Self {
-        self.stream = self
-            .stream
-            .inspect(|result| tracing::debug!("Processing result: {:?}", result))
-            .boxed()
-            .into();
-        self
+    pub fn log_all(self) -> Self {
+        self.log_errors().log_nodes()
     }
 
     /// Logs all errors encountered by the pipeline.

--- a/swiftide/src/ingestion/ingestion_stream.rs
+++ b/swiftide/src/ingestion/ingestion_stream.rs
@@ -42,6 +42,15 @@ impl Into<IngestionStream> for Vec<Result<IngestionNode>> {
     }
 }
 
+impl Into<IngestionStream> for Result<Vec<IngestionNode>> {
+    fn into(self) -> IngestionStream {
+        match self {
+            Ok(nodes) => IngestionStream::iter(nodes.into_iter().map(Ok)),
+            Err(err) => IngestionStream::iter(vec![Err(err)]),
+        }
+    }
+}
+
 impl Into<IngestionStream> for Pin<Box<dyn Stream<Item = Result<IngestionNode>> + Send>> {
     fn into(self) -> IngestionStream {
         IngestionStream { inner: self }

--- a/swiftide/src/transformers/embed.rs
+++ b/swiftide/src/transformers/embed.rs
@@ -6,6 +6,7 @@ use crate::{
 };
 use anyhow::Result;
 use async_trait::async_trait;
+use itertools::Itertools as _;
 
 /// A transformer that can generate embeddings for an `IngestionNode`
 ///
@@ -72,14 +73,14 @@ impl BatchableTransformer for Embed {
             .map(|embeddings| {
                 nodes
                     .into_iter()
-                    .zip(embeddings)
+                    // Will panic if the number of embeddings doesn't match the number of nodes
+                    .zip_eq(embeddings)
                     .map(|(mut n, v)| {
                         n.vector = Some(v);
-                        Ok(n)
+                        n
                     })
-                    .collect::<Vec<Result<IngestionNode>>>()
+                    .collect::<Vec<_>>()
             })
-            .unwrap_or_else(|e| vec![Err(e)])
             .into()
     }
 


### PR DESCRIPTION
- **refactor(ingestion_pipeline): log_all combines other log helpers**
- **feat(ingestion_stream): implement into for Result<Vec<IngestionNode>>**
- **fix(embed): panic if number of embeddings and node are equal**
