### PR TITLE
fix(transformers)!: markdown chunker not skipping small chunks

### DIFF
--- a/benchmarks/local_pipeline.rs
+++ b/benchmarks/local_pipeline.rs
@@ -10,7 +10,7 @@ use swiftide::{
 
 async fn run_pipeline() -> Result<()> {
     IngestionPipeline::from_loader(FileLoader::new("README.md").with_extensions(&["md"]))
-        .then_chunk(ChunkMarkdown::with_chunk_range(20..256))
+        .then_chunk(ChunkMarkdown::from_chunk_range(20..256))
         .then_in_batch(10, Embed::new(FastEmbed::builder().batch_size(10).build()?))
         .then_store_with(MemoryStorage::default())
         .run()

--- a/examples/aws_bedrock.rs
+++ b/examples/aws_bedrock.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     ingestion::IngestionPipeline::from_loader(FileLoader::new("./README.md"))
         .log_nodes()
-        .then_chunk(transformers::ChunkMarkdown::with_chunk_range(100..512))
+        .then_chunk(transformers::ChunkMarkdown::from_chunk_range(100..512))
         .then(transformers::MetadataSummary::new(aws_bedrock.clone()))
         .then_store_with(memory_storage.clone())
         .log_all()

--- a/examples/ingest_markdown_lots_of_metadata.rs
+++ b/examples/ingest_markdown_lots_of_metadata.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         FileLoader::new("README.md").with_extensions(&["md"]),
     )
     .with_concurrency(1)
-    .then_chunk(ChunkMarkdown::with_chunk_range(20..2048))
+    .then_chunk(ChunkMarkdown::from_chunk_range(20..2048))
     .then(MetadataQAText::new(openai_client.clone()))
     .then(MetadataSummary::new(openai_client.clone()))
     .then(MetadataTitle::new(openai_client.clone()))

--- a/examples/scraping_ingest_to_markdown.rs
+++ b/examples/scraping_ingest_to_markdown.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .to_owned(),
     ))
     .then(HtmlToMarkdownTransformer::default())
-    .then_chunk(ChunkMarkdown::with_chunk_range(20..2048))
+    .then_chunk(ChunkMarkdown::from_chunk_range(20..2048))
     .log_all()
     .then_store_with(MemoryStorage::default())
     .run()

--- a/swiftide/src/integrations/openai/mod.rs
+++ b/swiftide/src/integrations/openai/mod.rs
@@ -103,3 +103,40 @@ impl OpenAIBuilder {
         self
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// test default embed model
+    #[test]
+    fn test_default_embed_and_prompt_model() {
+        let openai = OpenAI::builder()
+            .default_embed_model("gpt-3")
+            .default_prompt_model("gpt-4")
+            .build()
+            .unwrap();
+        assert_eq!(
+            openai.default_options.embed_model,
+            Some("gpt-3".to_string())
+        );
+        assert_eq!(
+            openai.default_options.prompt_model,
+            Some("gpt-4".to_string())
+        );
+
+        let openai = OpenAI::builder()
+            .default_prompt_model("gpt-4")
+            .default_embed_model("gpt-3")
+            .build()
+            .unwrap();
+        assert_eq!(
+            openai.default_options.prompt_model,
+            Some("gpt-4".to_string())
+        );
+        assert_eq!(
+            openai.default_options.embed_model,
+            Some("gpt-3".to_string())
+        );
+    }
+}

--- a/swiftide/src/transformers/chunk_markdown.rs
+++ b/swiftide/src/transformers/chunk_markdown.rs
@@ -4,30 +4,61 @@ use derive_builder::Builder;
 use text_splitter::{Characters, MarkdownSplitter};
 
 #[derive(Debug, Builder)]
-#[builder(pattern = "owned", setter(into, strip_option))]
+#[builder(pattern = "owned", setter(strip_option))]
+/// A transformer that chunks markdown content into smaller pieces.
+///
+/// The transformer will split the markdown content into smaller pieces based on the specified
+/// `max_characters` or `range` of characters.
+///
+/// For further customization, you can use the builder to create a custom splitter.
+///
+/// Technically that might work with every splitter `text_splitter` provides.
 pub struct ChunkMarkdown {
     chunker: MarkdownSplitter<Characters>,
     #[builder(default)]
+    /// The number of concurrent chunks to process.
     concurrency: Option<usize>,
+    /// The splitter is not perfect in skipping min size nodes.
+    ///
+    /// If you provide a custom chunker, you might want to set the range as well.
+    #[builder(default)]
+    range: Option<std::ops::Range<usize>>,
 }
 
 impl ChunkMarkdown {
-    pub fn with_max_characters(max_characters: usize) -> Self {
+    /// Create a new transformer with a maximum number of characters per chunk.
+    pub fn from_max_characters(max_characters: usize) -> Self {
         Self {
             chunker: MarkdownSplitter::new(max_characters),
             concurrency: None,
+            range: None,
         }
     }
 
-    pub fn with_chunk_range(range: std::ops::Range<usize>) -> Self {
+    /// Create a new transformer with a range of characters per chunk.
+    ///
+    /// Chunks smaller than the range will be ignored.
+    pub fn from_chunk_range(range: std::ops::Range<usize>) -> Self {
         Self {
-            chunker: MarkdownSplitter::new(range),
+            chunker: MarkdownSplitter::new(range.clone()),
             concurrency: None,
+            range: Some(range),
         }
     }
 
+    /// Build a custom markdown chunker.
     pub fn builder() -> ChunkMarkdownBuilder {
         ChunkMarkdownBuilder::default()
+    }
+
+    /// Set the number of concurrent chunks to process.
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = Some(concurrency);
+        self
+    }
+
+    fn min_size(&self) -> usize {
+        self.range.as_ref().map(|r| r.start).unwrap_or(0)
     }
 }
 
@@ -38,7 +69,14 @@ impl ChunkerTransformer for ChunkMarkdown {
         let chunks = self
             .chunker
             .chunks(&node.chunk)
-            .map(|chunk| chunk.to_string())
+            .filter_map(|chunk| {
+                let trim = chunk.trim();
+                if trim.is_empty() || trim.len() < self.min_size() {
+                    None
+                } else {
+                    Some(chunk.to_string())
+                }
+            })
             .collect::<Vec<String>>();
 
         IngestionStream::iter(chunks.into_iter().map(move |chunk| {
@@ -51,5 +89,89 @@ impl ChunkerTransformer for ChunkMarkdown {
 
     fn concurrency(&self) -> Option<usize> {
         self.concurrency
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use futures_util::stream::TryStreamExt;
+
+    const MARKDOWN: &str = r#"
+        # Hello, world!
+
+        This is a test markdown document.
+
+        ## Section 1
+
+        This is a paragraph.
+
+        ## Section 2
+
+        This is another paragraph.
+        "#;
+
+    #[tokio::test]
+    async fn test_transforming_with_max_characters_and_trimming() {
+        let chunker = ChunkMarkdown::from_max_characters(40);
+
+        let node = IngestionNode {
+            chunk: MARKDOWN.to_string(),
+            ..IngestionNode::default()
+        };
+
+        let nodes: Vec<IngestionNode> = chunker
+            .transform_node(node)
+            .await
+            .try_collect()
+            .await
+            .unwrap();
+
+        for line in MARKDOWN.lines().filter(|line| !line.trim().is_empty()) {
+            assert!(nodes.iter().any(|node| node.chunk == line.trim()));
+        }
+
+        assert_eq!(nodes.len(), 6);
+    }
+
+    #[tokio::test]
+    async fn test_always_within_range() {
+        let ranges = vec![(10..15), (20..25), (30..35), (40..45), (50..55)];
+        for range in ranges {
+            let chunker = ChunkMarkdown::from_chunk_range(range.clone());
+            let node = IngestionNode {
+                chunk: MARKDOWN.to_string(),
+                ..IngestionNode::default()
+            };
+            let nodes: Vec<IngestionNode> = chunker
+                .transform_node(node)
+                .await
+                .try_collect()
+                .await
+                .unwrap();
+            // Assert all nodes chunk length within the range
+            assert!(
+                nodes.iter().all(|node| {
+                    let len = node.chunk.len();
+                    range.contains(&len)
+                }),
+                "{:?}, {:?}",
+                range,
+                nodes.iter().filter(|node| {
+                    let len = node.chunk.len();
+                    !range.contains(&len)
+                })
+            );
+        }
+    }
+
+    #[test]
+    fn test_builder() {
+        ChunkMarkdown::builder()
+            .chunker(MarkdownSplitter::new(40))
+            .concurrency(10)
+            .range(10..20)
+            .build()
+            .unwrap();
     }
 }


### PR DESCRIPTION
For reasons unknown the markdown chunker was not skipping chunks smaller than the given min. 

Improved test coverage while I was at it.
