### PR TITLE
feat(ingestion_pipeline): stream splitting and merging + build from stream

### DIFF
--- a/swiftide/src/ingestion/ingestion_pipeline.rs
+++ b/swiftide/src/ingestion/ingestion_pipeline.rs
@@ -53,6 +53,22 @@ impl IngestionPipeline {
         }
     }
 
+    /// Creates an `IngestionPipeline` from a given stream.
+    ///
+    /// # Arguments
+    ///
+    /// * `stream` - An `IngestionStream` containing the nodes to be processed.
+    ///
+    /// # Returns
+    ///
+    /// An instance of `IngestionPipeline` initialized with the provided stream.
+    pub fn from_stream(stream: impl Into<IngestionStream>) -> Self {
+        Self {
+            stream: stream.into(),
+            ..Default::default()
+        }
+    }
+
     /// Sets the concurrency level for the pipeline.
     ///
     /// # Arguments


### PR DESCRIPTION
Closes #67 

Introduces several related major features:
* Stream splitting and merging; extremely useful. Streams can be split multiple times. The provided helper only merges two streams, but it's perfectly possible to merge as many as desired. Default merge alternates between the streams so that it doesn't break concurrency settings.
* mpsc::tokio::Receiver can now be converted into an IngestionStream
* ... which makes a IngestionPipeline::from_stream really interesting. You can hook up what you already have to a pipeline, connecting streams to streams to streams of streams :tada: 