### PR TITLE
feat(prompts): add prompts as first class citizens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2301,6 +2301,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "insta"
+version = "1.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ae6042d48e2c9e9215043563a58a80b877bc863228a74cf10c49d4620a6f5"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "serde",
+ "similar",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3995,6 +4008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4204,6 +4223,7 @@ dependencies = [
  "htmd",
  "ignore",
  "indoc",
+ "insta",
  "itertools 0.13.0",
  "lazy_static",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,6 +1726,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.5.0",
+ "ignore",
+ "walkdir",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2925,6 +2936,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.67",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,7 +3212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.67",
@@ -4160,6 +4216,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "temp-dir",
+ "tera",
  "test-case",
  "test-log",
  "testcontainers",
@@ -4269,6 +4326,22 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "tera"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee"
+dependencies = [
+ "globwalk",
+ "lazy_static",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "serde_json",
+ "unic-segment",
 ]
 
 [[package]]
@@ -4821,6 +4894,62 @@ dependencies = [
  "serde",
  "serde_json",
  "ureq",
+]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
+dependencies = [
+ "unic-ucd-segment",
+]
+
+[[package]]
+name = "unic-ucd-segment"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4205,6 +4205,7 @@ dependencies = [
  "ignore",
  "indoc",
  "itertools 0.13.0",
+ "lazy_static",
  "mockall",
  "num_cpus",
  "pin-project-lite",
@@ -4230,6 +4231,7 @@ dependencies = [
  "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "uuid",
  "wiremock",
 ]
 
@@ -5070,9 +5072,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.9.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["swiftide", "examples", "benchmarks"]
 resolver = "2"
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -97,6 +97,7 @@ mockall = "0.12.1"
 temp-dir = "0.1.13"
 wiremock = "0.6.0"
 test-case = "3.3.1"
+insta = { version = "1.39.0", features = ["yaml"] }
 
 [lints.rust]
 unsafe_code = "forbid"
@@ -113,3 +114,7 @@ multiple_crate_versions = "allow"
 
 [package.metadata.docs.rs]
 all-features = true
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -30,6 +30,8 @@ strum_macros = "0.26.4"
 num_cpus = "1.16.0"
 pin-project-lite = "0.2"
 tera = { version = "1", default-features = false }
+lazy_static = { version = "1.5.0" }
+uuid = { version = "1.10", features = ["v4"] }
 
 # Integrations
 async-openai = { version = "0.23.2", optional = true }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -29,6 +29,7 @@ strum = "0.26.2"
 strum_macros = "0.26.4"
 num_cpus = "1.16.0"
 pin-project-lite = "0.2"
+tera = { version = "1", default-features = false }
 
 # Integrations
 async-openai = { version = "0.23.2", optional = true }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -114,7 +114,3 @@ multiple_crate_versions = "allow"
 
 [package.metadata.docs.rs]
 all-features = true
-
-[profile.dev.package]
-insta.opt-level = 3
-similar.opt-level = 3

--- a/swiftide/src/indexing/node.rs
+++ b/swiftide/src/indexing/node.rs
@@ -64,8 +64,7 @@ impl Debug for Node {
                 &self
                     .vectors
                     .iter()
-                    .map(HashMap::iter)
-                    .flatten()
+                    .flat_map(HashMap::iter)
                     .map(|(embed_type, vec)| format!("'{embed_type}': {}", vec.len()))
                     .join(","),
             )
@@ -99,7 +98,7 @@ impl Node {
 
         if self.embed_mode == EmbedMode::PerField || self.embed_mode == EmbedMode::Both {
             embeddables.push((EmbeddedField::Chunk, self.chunk.clone()));
-            for (name, value) in self.metadata.iter() {
+            for (name, value) in &self.metadata {
                 embeddables.push((EmbeddedField::Metadata(name.clone()), value.clone()));
             }
         }
@@ -107,7 +106,7 @@ impl Node {
         embeddables
     }
 
-    /// Converts the node into an [self::EmbeddedField::Combined] type of embeddable.
+    /// Converts the node into an [`self::EmbeddedField::Combined`] type of embeddable.
     ///
     /// This embeddable format consists of the metadata formatted as key-value pairs, each on a new line,
     /// followed by the data chunk.
@@ -153,7 +152,7 @@ impl Hash for Node {
 
 /// Embed mode of the pipeline.
 ///
-/// See also [super::pipeline::Pipeline::with_embed_mode].
+/// See also [`super::pipeline::Pipeline::with_embed_mode`].
 #[derive(Copy, Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub enum EmbedMode {
     #[default]

--- a/swiftide/src/indexing/pipeline.rs
+++ b/swiftide/src/indexing/pipeline.rs
@@ -95,6 +95,7 @@ impl Pipeline {
     /// # Returns
     ///
     /// An instance of `Pipeline` with the updated embed mode.
+    #[must_use]
     pub fn with_embed_mode(mut self, embed_mode: EmbedMode) -> Self {
         self.stream = self
             .stream

--- a/swiftide/src/indexing/pipeline.rs
+++ b/swiftide/src/indexing/pipeline.rs
@@ -86,7 +86,7 @@ impl Pipeline {
 
     /// Sets the embed mode for the pipeline.
     ///
-    /// See also [super::node::EmbedMode].
+    /// See also [`super::node::EmbedMode`].
     ///
     /// # Arguments
     ///

--- a/swiftide/src/integrations/aws_bedrock/simple_prompt.rs
+++ b/swiftide/src/integrations/aws_bedrock/simple_prompt.rs
@@ -8,7 +8,7 @@ use super::AwsBedrock;
 #[async_trait]
 impl SimplePrompt for AwsBedrock {
     #[tracing::instrument(skip_all, err)]
-    async fn prompt(&self, prompt: &Prompt) -> Result<String> {
+    async fn prompt(&self, prompt: Prompt) -> Result<String> {
         let blob = self
             .model_family
             .build_request_to_bytes(prompt.render().await?, &self.model_config)
@@ -53,7 +53,7 @@ mod test {
             .build()
             .unwrap();
 
-        let response = bedrock.prompt(&"Hello".into()).await.unwrap();
+        let response = bedrock.prompt("Hello".into()).await.unwrap();
 
         assert_eq!(response, "Hello, world!");
     }
@@ -84,7 +84,7 @@ mod test {
             .test_client(bedrock_mock)
             .build()
             .unwrap();
-        let response = bedrock.prompt(&"Hello".into()).await.unwrap();
+        let response = bedrock.prompt("Hello".into()).await.unwrap();
         assert_eq!(response, "Hello, world!");
     }
 }

--- a/swiftide/src/integrations/openai/simple_prompt.rs
+++ b/swiftide/src/integrations/openai/simple_prompt.rs
@@ -1,7 +1,7 @@
 //! This module provides an implementation of the `SimplePrompt` trait for the `OpenAI` struct.
 //! It defines an asynchronous function to interact with the `OpenAI` API, allowing prompt processing
 //! and generating responses as part of the Swiftide system.
-use crate::SimplePrompt;
+use crate::{prompt::Prompt, SimplePrompt};
 use async_openai::types::{ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs};
 use async_trait::async_trait;
 
@@ -25,7 +25,7 @@ impl SimplePrompt for OpenAI {
     /// - Returns an error if the request to the OpenAI API fails.
     /// - Returns an error if the response does not contain the expected content.
     #[tracing::instrument(skip_all, err)]
-    async fn prompt(&self, prompt: &str) -> Result<String> {
+    async fn prompt(&self, prompt: &Prompt) -> Result<String> {
         // Retrieve the model from the default options, returning an error if not set.
         let model = self
             .default_options
@@ -37,7 +37,7 @@ impl SimplePrompt for OpenAI {
         let request = CreateChatCompletionRequestArgs::default()
             .model(model)
             .messages(vec![ChatCompletionRequestUserMessageArgs::default()
-                .content(prompt)
+                .content(prompt.render().await?)
                 .build()?
                 .into()])
             .build()?;

--- a/swiftide/src/integrations/openai/simple_prompt.rs
+++ b/swiftide/src/integrations/openai/simple_prompt.rs
@@ -25,7 +25,7 @@ impl SimplePrompt for OpenAI {
     /// - Returns an error if the request to the OpenAI API fails.
     /// - Returns an error if the response does not contain the expected content.
     #[tracing::instrument(skip_all, err)]
-    async fn prompt(&self, prompt: &Prompt) -> Result<String> {
+    async fn prompt(&self, prompt: Prompt) -> Result<String> {
         // Retrieve the model from the default options, returning an error if not set.
         let model = self
             .default_options

--- a/swiftide/src/integrations/qdrant/indexing_node.rs
+++ b/swiftide/src/integrations/qdrant/indexing_node.rs
@@ -92,7 +92,7 @@ mod tests {
             metadata: BTreeMap::from([("m1".into(), "mv1".into())]),
             embed_mode: crate::ingestion::EmbedMode::SingleWithMetadata
         },
-        PointStruct { id: Some(PointId::from(6516159902038153111)), payload: HashMap::from([
+        PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
             ("path".into(), Value::from("/path")),
             ("m1".into(), Value::from("mv1"))]), 
@@ -109,7 +109,7 @@ mod tests {
             metadata: BTreeMap::from([("m1".into(), "mv1".into())]),
             embed_mode: crate::ingestion::EmbedMode::PerField
         },
-        PointStruct { id: Some(PointId::from(6516159902038153111)), payload: HashMap::from([
+        PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
             ("path".into(), Value::from("/path")),
             ("m1".into(), Value::from("mv1"))]), 
@@ -134,7 +134,7 @@ mod tests {
             metadata: BTreeMap::from([("m1".into(), "mv1".into())]),
             embed_mode: crate::ingestion::EmbedMode::SingleWithMetadata
         },
-        PointStruct { id: Some(PointId::from(6516159902038153111)), payload: HashMap::from([
+        PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
             ("path".into(), Value::from("/path")),
             ("m1".into(), Value::from("mv1"))]), 

--- a/swiftide/src/integrations/qdrant/mod.rs
+++ b/swiftide/src/integrations/qdrant/mod.rs
@@ -154,11 +154,11 @@ impl QdrantBuilder {
         Ok(Arc::new(client))
     }
 
-    /// Adds new [VectorConfig]
+    /// Adds new [`VectorConfig`]
     ///
-    /// When not configured Pipeline by default configures vector only for [EmbeddedField::Combined]
-    /// Default config is enough when [crate::indexing::Pipeline::with_embed_mode] is not set
-    /// or when the value is set to [crate::indexing::EmbedMode::SingleWithMetadata].
+    /// When not configured Pipeline by default configures vector only for [`EmbeddedField::Combined`]
+    /// Default config is enough when [`crate::indexing::Pipeline::with_embed_mode`] is not set
+    /// or when the value is set to [`crate::indexing::EmbedMode::SingleWithMetadata`].
     pub fn with_vector(mut self, vector: impl Into<VectorConfig>) -> QdrantBuilder {
         if self.vectors.is_none() {
             self = self.vectors(Default::default());
@@ -193,7 +193,7 @@ impl std::fmt::Debug for Qdrant {
 
 /// Vector config
 ///
-/// See also [QdrantBuilder::with_vector]
+/// See also [`QdrantBuilder::with_vector`]
 #[derive(Clone, Builder, Default)]
 pub struct VectorConfig {
     /// A type of the embeddable of the stored vector.
@@ -201,12 +201,12 @@ pub struct VectorConfig {
     pub(super) embedded_field: EmbeddedField,
     /// A size of the vector to be stored in the collection.
     ///
-    /// Overrides default set in [QdrantBuilder::vector_size]
+    /// Overrides default set in [`QdrantBuilder::vector_size`]
     #[builder(setter(into, strip_option), default)]
     vector_size: Option<u64>,
     /// A distance of the vector to be stored in the collection.
     ///
-    /// Overrides default set in [QdrantBuilder::vector_distance]
+    /// Overrides default set in [`QdrantBuilder::vector_distance`]
     #[builder(setter(into, strip_option), default)]
     distance: Option<qdrant::Distance>,
 }

--- a/swiftide/src/integrations/qdrant/mod.rs
+++ b/swiftide/src/integrations/qdrant/mod.rs
@@ -159,9 +159,10 @@ impl QdrantBuilder {
     /// When not configured Pipeline by default configures vector only for [`EmbeddedField::Combined`]
     /// Default config is enough when [`crate::indexing::Pipeline::with_embed_mode`] is not set
     /// or when the value is set to [`crate::indexing::EmbedMode::SingleWithMetadata`].
+    #[must_use]
     pub fn with_vector(mut self, vector: impl Into<VectorConfig>) -> QdrantBuilder {
         if self.vectors.is_none() {
-            self = self.vectors(Default::default());
+            self = self.vectors(HashMap::default());
         }
         let vector = vector.into();
         if let Some(vectors) = self.vectors.as_mut() {
@@ -176,7 +177,7 @@ impl QdrantBuilder {
     }
 
     fn default_vectors() -> HashMap<EmbeddedField, VectorConfig> {
-        HashMap::from([(Default::default(), Default::default())])
+        HashMap::from([(EmbeddedField::default(), VectorConfig::default())])
     }
 }
 

--- a/swiftide/src/lib.rs
+++ b/swiftide/src/lib.rs
@@ -17,6 +17,7 @@ pub mod indexing;
 pub mod integrations;
 pub mod loaders;
 pub mod persist;
+pub mod prompt;
 pub mod traits;
 pub mod transformers;
 pub mod type_aliases;

--- a/swiftide/src/prompt.rs
+++ b/swiftide/src/prompt.rs
@@ -1,1 +1,119 @@
-pub struct Prompt {}
+use anyhow::{Context as _, Result};
+use lazy_static::lazy_static;
+use tera::Tera;
+use tokio::sync::RwLock;
+use uuid::Uuid;
+
+use crate::ingestion::Node;
+
+lazy_static! {
+    pub static ref TEMPLATES: RwLock<Tera> = {
+        match Tera::new("examples/basic/templates/**/*") {
+            Ok(t) => RwLock::new(t),
+            Err(e) => {
+                tracing::error!("Parsing error(s): {e}");
+                ::std::process::exit(1);
+            }
+        }
+    };
+}
+
+#[derive(Clone, Debug)]
+pub struct Prompt {
+    template: PromptTemplate,
+    context: Option<tera::Context>,
+}
+
+#[derive(Clone, Debug)]
+pub enum PromptTemplate {
+    CompiledTemplate(String),
+    OneOff(String),
+    String(String),
+    Static(&'static str),
+}
+
+impl<'tmpl> PromptTemplate {
+    pub async fn try_from_str(template: impl AsRef<str>) -> Result<PromptTemplate> {
+        let id = Uuid::new_v4().to_string();
+        let mut lock = TEMPLATES.write().await;
+        lock.add_raw_template(&id, template.as_ref())
+            .context("Failed to add raw template")?;
+
+        Ok(PromptTemplate::CompiledTemplate(id))
+    }
+
+    pub async fn render(&self, context: &Option<tera::Context>) -> Result<String> {
+        let lock = TEMPLATES.read().await;
+        let template = match self {
+            PromptTemplate::CompiledTemplate(id) => {
+                let context = match &context {
+                    Some(context) => context,
+                    None => &tera::Context::default(),
+                };
+                lock.render(id, context)
+                    .context("Failed to render template")?
+            }
+            PromptTemplate::OneOff(template) => {
+                let context = match &context {
+                    Some(context) => context,
+                    None => &tera::Context::default(),
+                };
+                Tera::one_off(template, context, false)
+                    .context("Failed to render one-off template")?
+            }
+            PromptTemplate::String(template) => template.clone(),
+            PromptTemplate::Static(template) => template.to_string(),
+        };
+        Ok(template)
+    }
+
+    pub fn to_prompt(&self) -> Prompt {
+        Prompt {
+            template: self.clone(),
+            context: Some(tera::Context::default()),
+        }
+    }
+}
+
+impl Prompt {
+    pub fn with_node(mut self, node: &Node) -> Self {
+        let context = self.context.get_or_insert_with(tera::Context::default);
+        context.insert("node", &node);
+        self
+    }
+
+    pub fn with_context(mut self, new_context: impl Into<tera::Context>) -> Self {
+        let context = self.context.get_or_insert_with(tera::Context::default);
+        context.extend(new_context.into());
+
+        self
+    }
+
+    pub fn with_context_value(mut self, key: &str, value: impl Into<tera::Value>) -> Self {
+        let context = self.context.get_or_insert_with(tera::Context::default);
+        context.insert(key, &value.into());
+        self
+    }
+
+    pub async fn render(&self) -> Result<String> {
+        self.template.render(&self.context).await
+    }
+}
+
+impl From<&'static str> for Prompt {
+    fn from(prompt: &'static str) -> Self {
+        Prompt {
+            template: PromptTemplate::Static(prompt),
+            context: None,
+        }
+    }
+}
+
+impl From<String> for Prompt {
+    fn from(prompt: String) -> Self {
+        Prompt {
+            template: PromptTemplate::String(prompt),
+            context: None,
+        }
+    }
+}

--- a/swiftide/src/prompt.rs
+++ b/swiftide/src/prompt.rs
@@ -1,0 +1,1 @@
+pub struct Prompt {}

--- a/swiftide/src/prompt.rs
+++ b/swiftide/src/prompt.rs
@@ -3,13 +3,13 @@
 //! Prompts are first class citizens in Swiftide and use [tera] under the hood. tera
 //! uses jinja style templates which allows for a lot of flexibility.
 //!
-//! Conceptually, a [Prompt] is something you send to i.e. [Simpleprompt]. A prompt can have
+//! Conceptually, a [Prompt] is something you send to i.e. [`crate::traits::Simpleprompt`]. A prompt can have
 //! added context for substitution and other templating features.
 //!
 //! Transformers in Swiftide come with default prompts, and they can be customized or replaced as
 //! needed.
 //!
-//! `PromptTemplates` can be added with `PromptTemplate::try_compiled_from_str`. Prompts can also be
+//! `PromptTemplates` can be added with [`PromptTemplate::try_compiled_from_str`]. Prompts can also be
 //! created on the fly from anything that implements [Into<String>]. Compiled prompts are stored in
 //! an internal repository.
 //!

--- a/swiftide/src/prompt.rs
+++ b/swiftide/src/prompt.rs
@@ -43,10 +43,11 @@ lazy_static! {
 /// ```
 /// #[tokio::main]
 /// # async fn main() {
+/// # use swiftide::prompt::PromptTemplate;
 /// let template = PromptTemplate::try_compiled_from_str("hello {{world}}").await.unwrap();
 /// let prompt = template.to_prompt().with_context_value("world", "swiftide");
 ///
-/// assert_eq!(prompt.render().unwrap(), "hello swiftide");
+/// assert_eq!(prompt.render().await.unwrap(), "hello swiftide");
 /// # }
 /// ```
 

--- a/swiftide/src/traits.rs
+++ b/swiftide/src/traits.rs
@@ -5,7 +5,11 @@
 //! trait and it should work out of the box.
 use std::fmt::Debug;
 
-use crate::{indexing::IndexingStream, indexing::Node, Embeddings};
+use crate::{
+    indexing::{IndexingStream, Node},
+    prompt::Prompt,
+    Embeddings,
+};
 use anyhow::Result;
 use async_trait::async_trait;
 
@@ -107,7 +111,7 @@ pub trait EmbeddingModel: Send + Sync {
 /// Given a string prompt, queries an LLM
 pub trait SimplePrompt: Debug + Send + Sync {
     // Takes a simple prompt, prompts the llm and returns the response
-    async fn prompt(&self, prompt: &str) -> Result<String>;
+    async fn prompt(&self, prompt: &Prompt) -> Result<String>;
 }
 
 #[cfg_attr(test, automock)]

--- a/swiftide/src/traits.rs
+++ b/swiftide/src/traits.rs
@@ -111,7 +111,7 @@ pub trait EmbeddingModel: Send + Sync {
 /// Given a string prompt, queries an LLM
 pub trait SimplePrompt: Debug + Send + Sync {
     // Takes a simple prompt, prompts the llm and returns the response
-    async fn prompt(&self, prompt: &Prompt) -> Result<String>;
+    async fn prompt(&self, prompt: Prompt) -> Result<String>;
 }
 
 #[cfg_attr(test, automock)]

--- a/swiftide/src/transformers/embed.rs
+++ b/swiftide/src/transformers/embed.rs
@@ -75,7 +75,7 @@ impl BatchableTransformer for Embed {
             .fold(Vec::new(), |mut embeddables_data, node| {
                 let embeddables = node.as_embeddables();
                 let mut embeddables_keys = Vec::with_capacity(embeddables.len());
-                for (embeddable_key, embeddable_data) in embeddables.into_iter() {
+                for (embeddable_key, embeddable_data) in embeddables {
                     embeddables_keys.push(embeddable_key);
                     embeddables_data.push(embeddable_data);
                 }
@@ -235,7 +235,7 @@ mod tests {
                 metadata: data
                     .metadata
                     .iter()
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
                     .collect(),
                 embed_mode: data.embed_mode,
                 ..Default::default()
@@ -255,15 +255,13 @@ mod tests {
         let expected_embeddables_batch = test_data
             .clone()
             .iter()
-            .map(|d| &d.expected_embedables)
-            .flatten()
+            .flat_map(|d| &d.expected_embedables)
             .map(ToString::to_string)
             .collect::<Vec<String>>();
         let expected_vectors_batch: Vec<Vec<f32>> = test_data
             .clone()
             .iter()
-            .map(|d| d.expected_vectors.iter().map(|(_, v)| v).cloned())
-            .flatten()
+            .flat_map(|d| d.expected_vectors.iter().map(|(_, v)| v).cloned())
             .collect();
 
         let mut model_mock = MockEmbeddingModel::new();

--- a/swiftide/src/transformers/embed.rs
+++ b/swiftide/src/transformers/embed.rs
@@ -227,7 +227,7 @@ mod tests {
     ]; "Multiple nodes EmbedMode::Both with multiple metadata.")]
     #[test_case(vec![]; "No ingestion nodes")]
     #[tokio::test]
-    async fn batch_transform<'a>(test_data: Vec<TestData<'a>>) {
+    async fn batch_transform(test_data: Vec<TestData<'_>>) {
         let test_nodes: Vec<Node> = test_data
             .iter()
             .map(|data| Node {

--- a/swiftide/src/transformers/metadata_keywords.rs
+++ b/swiftide/src/transformers/metadata_keywords.rs
@@ -5,7 +5,6 @@ use crate::{indexing::Node, prompt::PromptTemplate, SimplePrompt, Transformer};
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_builder::Builder;
-use indoc::indoc;
 
 pub const NAME: &str = "Keywords";
 

--- a/swiftide/src/transformers/metadata_keywords.rs
+++ b/swiftide/src/transformers/metadata_keywords.rs
@@ -117,7 +117,7 @@ mod test {
         let template = default_prompt();
 
         let prompt = template.to_prompt().with_node(&Node::new("test"));
-        insta::assert_snapshot!(prompt.render().await.unwrap())
+        insta::assert_snapshot!(prompt.render().await.unwrap());
     }
 
     #[tokio::test]

--- a/swiftide/src/transformers/metadata_keywords.rs
+++ b/swiftide/src/transformers/metadata_keywords.rs
@@ -61,10 +61,6 @@ impl MetadataKeywords {
 }
 
 /// Generates the default prompt template for extracting keywords.
-///
-/// # Returns
-///
-/// A string containing the default prompt template.
 fn default_prompt() -> PromptTemplate {
     PromptTemplate::from_compiled_template_name(
         "src/transformers/prompts/metadata_keywords.prompt.md",

--- a/swiftide/src/transformers/metadata_keywords.rs
+++ b/swiftide/src/transformers/metadata_keywords.rs
@@ -113,6 +113,14 @@ mod test {
     use super::*;
 
     #[tokio::test]
+    async fn test_template() {
+        let template = default_prompt();
+
+        let prompt = template.to_prompt().with_node(&Node::new("test"));
+        insta::assert_snapshot!(prompt.render().await.unwrap())
+    }
+
+    #[tokio::test]
     async fn test_metadata_keywords() {
         let mut client = MockSimplePrompt::new();
 

--- a/swiftide/src/transformers/metadata_qa_code.rs
+++ b/swiftide/src/transformers/metadata_qa_code.rs
@@ -118,6 +118,17 @@ mod test {
     use super::*;
 
     #[tokio::test]
+    async fn test_template() {
+        let template = default_prompt();
+
+        let prompt = template
+            .to_prompt()
+            .with_node(&Node::new("test"))
+            .with_context_value("questions", 5);
+        insta::assert_snapshot!(prompt.render().await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_metadata_qacode() {
         let mut client = MockSimplePrompt::new();
 

--- a/swiftide/src/transformers/metadata_qa_code.rs
+++ b/swiftide/src/transformers/metadata_qa_code.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use crate::{indexing::Node, prompt::PromptTemplate, SimplePrompt, Transformer};
 use anyhow::Result;
 use async_trait::async_trait;
-use indoc::indoc;
 
 pub const NAME: &str = "Questions and Answers (code)";
 

--- a/swiftide/src/transformers/metadata_qa_code.rs
+++ b/swiftide/src/transformers/metadata_qa_code.rs
@@ -61,10 +61,6 @@ impl MetadataQACode {
 /// Returns the default prompt template for generating questions and answers.
 ///
 /// This template includes placeholders for the number of questions and the code chunk.
-///
-/// # Returns
-///
-/// A string representing the default prompt template.
 fn default_prompt() -> PromptTemplate {
     PromptTemplate::from_compiled_template_name(
         "src/transformers/prompts/metadata_qa_code.prompt.md",

--- a/swiftide/src/transformers/metadata_qa_text.rs
+++ b/swiftide/src/transformers/metadata_qa_text.rs
@@ -5,7 +5,6 @@ use crate::{indexing::Node, prompt::PromptTemplate, SimplePrompt, Transformer};
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_builder::Builder;
-use indoc::indoc;
 
 pub const NAME: &str = "Questions and Answers (text)";
 

--- a/swiftide/src/transformers/metadata_qa_text.rs
+++ b/swiftide/src/transformers/metadata_qa_text.rs
@@ -121,6 +121,17 @@ mod test {
     use super::*;
 
     #[tokio::test]
+    async fn test_template() {
+        let template = default_prompt();
+
+        let prompt = template
+            .to_prompt()
+            .with_node(&Node::new("test"))
+            .with_context_value("questions", 5);
+        insta::assert_snapshot!(prompt.render().await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_metadata_qacode() {
         let mut client = MockSimplePrompt::new();
 

--- a/swiftide/src/transformers/metadata_qa_text.rs
+++ b/swiftide/src/transformers/metadata_qa_text.rs
@@ -69,39 +69,9 @@ impl MetadataQAText {
 ///
 /// A string containing the default prompt template.
 fn default_prompt() -> PromptTemplate {
-    indoc! {r"
-
-            # Task
-            Your task is to generate questions and answers for the given text. 
-
-            Given that somebody else might ask questions about the text, consider things like:
-            * What does this text do?
-            * What other internal parts does the text use?
-            * Does this text have any dependencies?
-            * What are some potential use cases for this text?
-            * ... and so on
-
-            # Constraints 
-            * Generate at most {questions} questions and answers.
-            * Only respond in the example format
-            * Only respond with questions and answers that can be derived from the text.
-
-            # Example
-            Respond in the following example format and do not include anything else:
-
-            ```
-            Q1: What is the capital of France?
-            A1: Paris.
-            ```
-
-            # text
-            ```
-            {text}
-            ```
-
-        "}
-    .try_into()
-    .expect("Failed to build default prompt")
+    PromptTemplate::from_compiled_template_name(
+        "src/transformers/prompts/metadata_qa_text.prompt.md",
+    )
 }
 
 impl MetadataQATextBuilder {
@@ -137,7 +107,7 @@ impl Transformer for MetadataQAText {
             .with_node(&node)
             .with_context_value("questions", self.num_questions);
 
-        let response = self.client.prompt(&prompt).await?;
+        let response = self.client.prompt(prompt).await?;
 
         node.metadata.insert(NAME.into(), response);
 

--- a/swiftide/src/transformers/metadata_qa_text.rs
+++ b/swiftide/src/transformers/metadata_qa_text.rs
@@ -64,10 +64,6 @@ impl MetadataQAText {
 }
 
 /// Generates the default prompt template for generating questions and answers.
-///
-/// # Returns
-///
-/// A string containing the default prompt template.
 fn default_prompt() -> PromptTemplate {
     PromptTemplate::from_compiled_template_name(
         "src/transformers/prompts/metadata_qa_text.prompt.md",

--- a/swiftide/src/transformers/metadata_summary.rs
+++ b/swiftide/src/transformers/metadata_summary.rs
@@ -1,7 +1,7 @@
 //! Generate a summary and adds it as metadata
 use std::sync::Arc;
 
-use crate::{indexing::Node, SimplePrompt, Transformer};
+use crate::{indexing::Node, prompt::PromptTemplate, SimplePrompt, Transformer};
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_builder::Builder;
@@ -23,7 +23,7 @@ pub struct MetadataSummary {
     #[builder(setter(custom))]
     client: Arc<dyn SimplePrompt>,
     #[builder(default = "default_prompt()")]
-    prompt: String,
+    prompt_template: PromptTemplate,
     #[builder(default)]
     concurrency: Option<usize>,
 }
@@ -48,7 +48,7 @@ impl MetadataSummary {
     pub fn new(client: impl SimplePrompt + 'static) -> Self {
         Self {
             client: Arc::new(client),
-            prompt: default_prompt(),
+            prompt_template: default_prompt(),
             concurrency: None,
         }
     }
@@ -65,7 +65,7 @@ impl MetadataSummary {
 /// # Returns
 ///
 /// A string containing the default prompt template.
-fn default_prompt() -> String {
+fn default_prompt() -> PromptTemplate {
     indoc! {r"
 
             # Task
@@ -85,11 +85,12 @@ fn default_prompt() -> String {
 
             # Text
             ```
-            {text}
+            {{node.chunk}}
             ```
 
         "}
-    .to_string()
+    .try_into()
+    .expect("Failed to build default prompt")
 }
 
 impl MetadataSummaryBuilder {
@@ -119,7 +120,7 @@ impl Transformer for MetadataSummary {
     /// a summary from the provided prompt.
     #[tracing::instrument(skip_all, name = "transformers.metadata_summary")]
     async fn transform_node(&self, mut node: Node) -> Result<Node> {
-        let prompt = self.prompt.replace("{text}", &node.chunk);
+        let prompt = self.prompt_template.to_prompt().with_node(&node);
 
         let response = self.client.prompt(&prompt).await?;
 

--- a/swiftide/src/transformers/metadata_summary.rs
+++ b/swiftide/src/transformers/metadata_summary.rs
@@ -62,7 +62,7 @@ impl MetadataSummary {
 /// Generates the default prompt template for extracting a summary.
 fn default_prompt() -> PromptTemplate {
     PromptTemplate::from_compiled_template_name(
-        "src/transformers/prompts/metadata_qa_summary.prompt.md",
+        "src/transformers/prompts/metadata_summary.prompt.md",
     )
 }
 

--- a/swiftide/src/transformers/metadata_summary.rs
+++ b/swiftide/src/transformers/metadata_summary.rs
@@ -114,6 +114,14 @@ mod test {
     use super::*;
 
     #[tokio::test]
+    async fn test_template() {
+        let template = default_prompt();
+
+        let prompt = template.to_prompt().with_node(&Node::new("test"));
+        insta::assert_snapshot!(prompt.render().await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_metadata_summary() {
         let mut client = MockSimplePrompt::new();
 

--- a/swiftide/src/transformers/metadata_summary.rs
+++ b/swiftide/src/transformers/metadata_summary.rs
@@ -5,7 +5,6 @@ use crate::{indexing::Node, prompt::PromptTemplate, SimplePrompt, Transformer};
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_builder::Builder;
-use indoc::indoc;
 
 pub const NAME: &str = "Summary";
 

--- a/swiftide/src/transformers/metadata_summary.rs
+++ b/swiftide/src/transformers/metadata_summary.rs
@@ -66,31 +66,9 @@ impl MetadataSummary {
 ///
 /// A string containing the default prompt template.
 fn default_prompt() -> PromptTemplate {
-    indoc! {r"
-
-            # Task
-            Your task is to generate a descriptive, concise summary for the given text
-
-            # Constraints 
-            * Only respond in the example format
-            * Respond with a summary that is accurate and descriptive without fluff
-            * Only include information that is included in the text
-
-            # Example
-            Respond in the following example format and do not include anything else:
-
-            ```
-            <summary>
-            ```
-
-            # Text
-            ```
-            {{node.chunk}}
-            ```
-
-        "}
-    .try_into()
-    .expect("Failed to build default prompt")
+    PromptTemplate::from_compiled_template_name(
+        "src/transformers/prompts/metadata_qa_summary.prompt.md",
+    )
 }
 
 impl MetadataSummaryBuilder {
@@ -122,7 +100,7 @@ impl Transformer for MetadataSummary {
     async fn transform_node(&self, mut node: Node) -> Result<Node> {
         let prompt = self.prompt_template.to_prompt().with_node(&node);
 
-        let response = self.client.prompt(&prompt).await?;
+        let response = self.client.prompt(prompt).await?;
 
         node.metadata.insert(NAME.into(), response);
 

--- a/swiftide/src/transformers/metadata_summary.rs
+++ b/swiftide/src/transformers/metadata_summary.rs
@@ -61,10 +61,6 @@ impl MetadataSummary {
 }
 
 /// Generates the default prompt template for extracting a summary.
-///
-/// # Returns
-///
-/// A string containing the default prompt template.
 fn default_prompt() -> PromptTemplate {
     PromptTemplate::from_compiled_template_name(
         "src/transformers/prompts/metadata_qa_summary.prompt.md",

--- a/swiftide/src/transformers/metadata_title.rs
+++ b/swiftide/src/transformers/metadata_title.rs
@@ -112,6 +112,14 @@ mod test {
     use super::*;
 
     #[tokio::test]
+    async fn test_template() {
+        let template = default_prompt();
+
+        let prompt = template.to_prompt().with_node(&Node::new("test"));
+        insta::assert_snapshot!(prompt.render().await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_metadata_title() {
         let mut client = MockSimplePrompt::new();
 

--- a/swiftide/src/transformers/metadata_title.rs
+++ b/swiftide/src/transformers/metadata_title.rs
@@ -61,10 +61,6 @@ impl MetadataTitle {
 }
 
 /// Generates the default prompt template for generating questions and answers.
-///
-/// # Returns
-///
-/// A string containing the default prompt template.
 fn default_prompt() -> PromptTemplate {
     PromptTemplate::from_compiled_template_name("src/transformers/prompts/metadata_tile.prompt.md")
 }

--- a/swiftide/src/transformers/metadata_title.rs
+++ b/swiftide/src/transformers/metadata_title.rs
@@ -66,30 +66,7 @@ impl MetadataTitle {
 ///
 /// A string containing the default prompt template.
 fn default_prompt() -> PromptTemplate {
-    indoc! {r"
-
-            # Task
-            Your task is to generate a descriptive, concise title for the given text
-
-            # Constraints 
-            * Only respond in the example format
-            * Respond with a title that is accurate and descriptive without fluff
-
-            # Example
-            Respond in the following example format and do not include anything else:
-
-            ```
-            <title>
-            ```
-
-            # Text
-            ```
-            {{node.chunk}}
-            ```
-
-        "}
-    .try_into()
-    .expect("Failed to build default prompt")
+    PromptTemplate::from_compiled_template_name("src/transformers/prompts/metadata_tile.prompt.md")
 }
 
 impl MetadataTitleBuilder {
@@ -121,7 +98,7 @@ impl Transformer for MetadataTitle {
     async fn transform_node(&self, mut node: Node) -> Result<Node> {
         let prompt = self.prompt_template.to_prompt().with_node(&node);
 
-        let response = self.client.prompt(&prompt).await?;
+        let response = self.client.prompt(prompt).await?;
 
         node.metadata.insert(NAME.into(), response);
 

--- a/swiftide/src/transformers/metadata_title.rs
+++ b/swiftide/src/transformers/metadata_title.rs
@@ -5,7 +5,6 @@ use crate::{indexing::Node, prompt::PromptTemplate, SimplePrompt, Transformer};
 use anyhow::Result;
 use async_trait::async_trait;
 use derive_builder::Builder;
-use indoc::indoc;
 
 pub const NAME: &str = "Title";
 

--- a/swiftide/src/transformers/metadata_title.rs
+++ b/swiftide/src/transformers/metadata_title.rs
@@ -61,7 +61,7 @@ impl MetadataTitle {
 
 /// Generates the default prompt template for generating questions and answers.
 fn default_prompt() -> PromptTemplate {
-    PromptTemplate::from_compiled_template_name("src/transformers/prompts/metadata_tile.prompt.md")
+    PromptTemplate::from_compiled_template_name("src/transformers/prompts/metadata_title.prompt.md")
 }
 
 impl MetadataTitleBuilder {

--- a/swiftide/src/transformers/prompts/metadata_keywords.prompt.md
+++ b/swiftide/src/transformers/prompts/metadata_keywords.prompt.md
@@ -1,0 +1,24 @@
+# Task
+
+Your task is to generate a descriptive, concise keywords for the given text
+
+# Constraints
+
+- Only respond in the example format
+- Respond with a keywords that are representative of the text
+- Only include keywords that are literally included in the text
+- Respond with a comma-separated list of keywords
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+<keyword>,<other-keyword>
+```
+
+# Text
+
+```
+{{ node.chunk }}
+```

--- a/swiftide/src/transformers/prompts/metadata_qa_code.prompt.md
+++ b/swiftide/src/transformers/prompts/metadata_qa_code.prompt.md
@@ -1,0 +1,34 @@
+# Task
+
+Your task is to generate questions and answers for the given code.
+
+Given that somebody else might ask questions about the code, consider things like:
+
+- What does this code do?
+- What other internal parts does the code use?
+- Does this code have any dependencies?
+- What are some potential use cases for this code?
+- ... and so on
+
+# Constraints
+
+- Generate only {{questions}} questions and answers.
+- Only respond in the example format
+- Only respond with questions and answers that can be derived from the code.
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+Q1: What does this code do?
+A1: It transforms strings into integers.
+Q2: What other internal parts does the code use?
+A2: A hasher to hash the strings.
+```
+
+# Code
+
+```
+{{ node.chunk }}
+```

--- a/swiftide/src/transformers/prompts/metadata_qa_text.prompt.md
+++ b/swiftide/src/transformers/prompts/metadata_qa_text.prompt.md
@@ -1,0 +1,32 @@
+# Task
+
+Your task is to generate questions and answers for the given text.
+
+Given that somebody else might ask questions about the text, consider things like:
+
+- What does this text do?
+- What other internal parts does the text use?
+- Does this text have any dependencies?
+- What are some potential use cases for this text?
+- ... and so on
+
+# Constraints
+
+- Generate at most {{questions}} questions and answers.
+- Only respond in the example format
+- Only respond with questions and answers that can be derived from the text.
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+Q1: What is the capital of France?
+A1: Paris.
+```
+
+# text
+
+```
+{{node.chunk}}
+```

--- a/swiftide/src/transformers/prompts/metadata_summary.prompt.md
+++ b/swiftide/src/transformers/prompts/metadata_summary.prompt.md
@@ -1,0 +1,23 @@
+# Task
+
+Your task is to generate a descriptive, concise summary for the given text
+
+# Constraints
+
+- Only respond in the example format
+- Respond with a summary that is accurate and descriptive without fluff
+- Only include information that is included in the text
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+<summary>
+```
+
+# Text
+
+```
+{{node.chunk}}
+```

--- a/swiftide/src/transformers/prompts/metadata_title.prompt.md
+++ b/swiftide/src/transformers/prompts/metadata_title.prompt.md
@@ -1,0 +1,22 @@
+# Task
+
+Your task is to generate a descriptive, concise title for the given text
+
+# Constraints
+
+- Only respond in the example format
+- Respond with a title that is accurate and descriptive without fluff
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+<title>
+```
+
+# Text
+
+```
+{{node.chunk}}
+```

--- a/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_keywords__test__template.snap
+++ b/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_keywords__test__template.snap
@@ -1,0 +1,28 @@
+---
+source: swiftide/src/transformers/metadata_keywords.rs
+expression: prompt.render().await.unwrap()
+---
+# Task
+
+Your task is to generate a descriptive, concise keywords for the given text
+
+# Constraints
+
+- Only respond in the example format
+- Respond with a keywords that are representative of the text
+- Only include keywords that are literally included in the text
+- Respond with a comma-separated list of keywords
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+<keyword>,<other-keyword>
+```
+
+# Text
+
+```
+test
+```

--- a/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_qa_code__test__template.snap
+++ b/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_qa_code__test__template.snap
@@ -1,0 +1,38 @@
+---
+source: swiftide/src/transformers/metadata_qa_code.rs
+expression: prompt.render().await.unwrap()
+---
+# Task
+
+Your task is to generate questions and answers for the given code.
+
+Given that somebody else might ask questions about the code, consider things like:
+
+- What does this code do?
+- What other internal parts does the code use?
+- Does this code have any dependencies?
+- What are some potential use cases for this code?
+- ... and so on
+
+# Constraints
+
+- Generate only 5 questions and answers.
+- Only respond in the example format
+- Only respond with questions and answers that can be derived from the code.
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+Q1: What does this code do?
+A1: It transforms strings into integers.
+Q2: What other internal parts does the code use?
+A2: A hasher to hash the strings.
+```
+
+# Code
+
+```
+test
+```

--- a/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_qa_text__test__template.snap
+++ b/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_qa_text__test__template.snap
@@ -1,0 +1,36 @@
+---
+source: swiftide/src/transformers/metadata_qa_text.rs
+expression: prompt.render().await.unwrap()
+---
+# Task
+
+Your task is to generate questions and answers for the given text.
+
+Given that somebody else might ask questions about the text, consider things like:
+
+- What does this text do?
+- What other internal parts does the text use?
+- Does this text have any dependencies?
+- What are some potential use cases for this text?
+- ... and so on
+
+# Constraints
+
+- Generate at most 5 questions and answers.
+- Only respond in the example format
+- Only respond with questions and answers that can be derived from the text.
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+Q1: What is the capital of France?
+A1: Paris.
+```
+
+# text
+
+```
+test
+```

--- a/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_summary__test__template.snap
+++ b/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_summary__test__template.snap
@@ -1,0 +1,27 @@
+---
+source: swiftide/src/transformers/metadata_summary.rs
+expression: prompt.render().await.unwrap()
+---
+# Task
+
+Your task is to generate a descriptive, concise summary for the given text
+
+# Constraints
+
+- Only respond in the example format
+- Respond with a summary that is accurate and descriptive without fluff
+- Only include information that is included in the text
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+<summary>
+```
+
+# Text
+
+```
+test
+```

--- a/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_title__test__template.snap
+++ b/swiftide/src/transformers/snapshots/swiftide__transformers__metadata_title__test__template.snap
@@ -1,0 +1,26 @@
+---
+source: swiftide/src/transformers/metadata_title.rs
+expression: prompt.render().await.unwrap()
+---
+# Task
+
+Your task is to generate a descriptive, concise title for the given text
+
+# Constraints
+
+- Only respond in the example format
+- Respond with a title that is accurate and descriptive without fluff
+
+# Example
+
+Respond in the following example format and do not include anything else:
+
+```
+<title>
+```
+
+# Text
+
+```
+test
+```

--- a/swiftide/tests/indexing_pipeline.rs
+++ b/swiftide/tests/indexing_pipeline.rs
@@ -227,7 +227,7 @@ async fn test_named_vectors() {
     );
 }
 
-/// Setup OpenAI client with the mock server
+/// Setup `OpenAI` client with the mock server
 fn openai_client(mock_server_uri: &str, embed_model: &str, prompt_model: &str) -> OpenAI {
     let config = async_openai::config::OpenAIConfig::new().with_api_base(mock_server_uri);
     let async_openai = async_openai::Client::with_config(config);
@@ -245,7 +245,7 @@ fn openai_client(mock_server_uri: &str, embed_model: &str, prompt_model: &str) -
 }
 
 /// Setup Qdrant container.
-/// Returns container server and server_url.
+/// Returns container server and `server_url`.
 async fn start_qdrant() -> (ContainerAsync<GenericImage>, String) {
     let qdrant = testcontainers::GenericImage::new("qdrant/qdrant", "v1.9.2")
         .with_exposed_port(6334.into())
@@ -266,7 +266,7 @@ async fn start_qdrant() -> (ContainerAsync<GenericImage>, String) {
 }
 
 /// Setup Redis container for caching in the test.
-/// Returns container server and server_url.
+/// Returns container server and `server_url`.
 async fn start_redis() -> (ContainerAsync<GenericImage>, String) {
     let redis = testcontainers::GenericImage::new("redis", "7.2.4")
         .with_exposed_port(6379.into())
@@ -288,7 +288,6 @@ async fn start_redis() -> (ContainerAsync<GenericImage>, String) {
 /// `embeddings_count` controls number of returned embedding vectors.
 async fn mock_embeddings(mock_server: &MockServer, embeddings_count: u8) {
     let data = (0..embeddings_count)
-        .into_iter()
         .map(|i| {
             json!( {
               "object": "embedding",
@@ -337,6 +336,6 @@ async fn mock_chat_completions(mock_server: &MockServer) {
               "total_tokens": 21
             }
         })))
-        .mount(&mock_server)
+        .mount(mock_server)
         .await;
 }


### PR DESCRIPTION
Adds Prompts as first class citizens. This is a breaking change as SimplePrompt with just a a `&str` is no longer allowed.

This introduces `Prompt` and `PromptTemplate`. A template uses jinja style templating build on tera. Templates can be converted into prompts, and have context added. A prompt is then send to something that prompts, i.e. openai or bedrock.

Additional prompts can be added either compiled or as one-offs. Additionally, it's perfectly fine to prompt with just a string as well, just provide an `.into()`.

For future development, some LLMs really benefit from system prompts, which this would enable. For the query pipeline we can also take a much more structured approach with composed templates and conditionals.