### PR TITLE
feat(indexing): Sparse vector support with Splade and Qdrant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
 name = "examples"
 version = "0.7.1"
 dependencies = [
+ "qdrant-client",
  "serde_json",
  "spider",
  "swiftide",
@@ -3290,8 +3291,10 @@ checksum = "8b3660716b1555923d189c2a8e4bf849e9c2cf86a346d868eb2616cf83844a2a"
 dependencies = [
  "anyhow",
  "derive_builder",
+ "futures-util",
  "prost",
  "prost-types",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror",

--- a/README.md
+++ b/README.md
@@ -135,14 +135,15 @@ Our goal is to create a fast, extendable platform for data indexing and querying
 
 ## Features
 
-- Fast streaming indexing pipeline with async, parallel processing
+- Fast, modular streaming indexing pipeline with async, parallel processing
 - Experimental query pipeline
-- Integrations with OpenAI, Groq, Redis, Qdrant, Ollama, FastEmbed, and Treesitter
 - A variety of loaders, transformers, semantic chunkers, embedders, and more
 - Bring your own transformers by extending straightforward traits or use a closure
 - Splitting and merging pipelines
 - Jinja-like templating for prompts
 - Store into multiple backends
+- Integrations with OpenAI, Groq, Redis, Qdrant, Ollama, FastEmbed-rs, and Treesitter
+- Sparse vector support for hybrid search
 - `tracing` supported for logging and tracing, see /examples and the `tracing` crate for more information.
 
 ### In detail
@@ -223,6 +224,7 @@ See the [open issues](https://github.com/bosun-ai/swiftide/issues) for a full li
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- CONTRIBUTING -->
+
 ## Community
 
 If you want to get more involved with Swiftide, have questions or want to chat, you can find us on [discord](https://discord.gg/3jjXYen9UY).

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,15 +14,16 @@ homepage.workspace = true
 [dependencies]
 tokio = { version = "1.0", features = ["full"] }
 swiftide = { path = "../swiftide/", features = [
-    "all",
-    "scraping",
-    "aws-bedrock",
-    "groq",
-    "ollama",
+  "all",
+  "scraping",
+  "aws-bedrock",
+  "groq",
+  "ollama",
 ] }
 tracing-subscriber = "0.3"
 serde_json = "1.0"
 spider = "1.98"
+qdrant-client = "1.10.3"
 
 [[example]]
 doc-scrape-examples = true
@@ -74,3 +75,7 @@ path = "index_ollama.rs"
 [[example]]
 name = "query-pipeline"
 path = "query_pipeline.rs"
+
+[[example]]
+name = "hybrid-search"
+path = "hybrid_search.rs"

--- a/examples/hybrid_search.rs
+++ b/examples/hybrid_search.rs
@@ -1,0 +1,108 @@
+//! # [Swiftide] Hybrid search with qudrant
+//!
+//! This example demonstrates how to do hybrid search with Qdrant with Sparse vectors.
+//!
+//! [Swiftide]: https://github.com/bosun-ai/swiftide
+//! [examples]: https://github.com/bosun-ai/swiftide/blob/master/examples
+
+use qdrant_client::qdrant::{Fusion, PrefetchQueryBuilder, Query, QueryPointsBuilder, VectorInput};
+use swiftide::{
+    indexing::{
+        self,
+        loaders::FileLoader,
+        transformers::{self, ChunkCode},
+        EmbeddedField, EmbeddingModel as _, SparseEmbeddingModel as _,
+    },
+    integrations::{fastembed::FastEmbed, qdrant::Qdrant},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    // Ensure all batching is consistent
+    let batch_size = 256;
+
+    let fastembed_sparse = FastEmbed::try_default_sparse()
+        .unwrap()
+        .with_batch_size(batch_size)
+        .to_owned();
+    let fastembed = FastEmbed::try_default()
+        .unwrap()
+        .with_batch_size(batch_size)
+        .to_owned();
+
+    indexing::Pipeline::from_loader(FileLoader::new("swiftide-core/").with_extensions(&["rs"]))
+        .then_chunk(ChunkCode::try_for_language_and_chunk_size(
+            "rust",
+            10..2048,
+        )?)
+        .then_in_batch(
+            batch_size,
+            transformers::SparseEmbed::new(fastembed_sparse.clone()),
+        )
+        .then_in_batch(batch_size, transformers::Embed::new(fastembed.clone()))
+        .then_store_with(
+            Qdrant::builder()
+                .batch_size(batch_size)
+                .vector_size(384)
+                .with_vector(EmbeddedField::Combined)
+                .with_sparse_vector(EmbeddedField::Combined)
+                .collection_name("swiftide-hybrid")
+                .build()?,
+        )
+        .run()
+        .await?;
+
+    let query = "Where is the indexing pipeline defined?";
+
+    let sparse = fastembed_sparse
+        .sparse_embed(vec![query.to_string()])
+        .await?
+        .first()
+        .unwrap()
+        .to_owned();
+
+    let dense = fastembed
+        .embed(vec![query.to_string()])
+        .await?
+        .first()
+        .unwrap()
+        .to_owned();
+
+    let qdrant = qdrant_client::Qdrant::from_url("http://localhost:6334")
+        .build()
+        .unwrap();
+
+    let search_response = qdrant
+        .query(
+            QueryPointsBuilder::new("swiftide-hybrid")
+                .with_payload(true)
+                .add_prefetch(
+                    PrefetchQueryBuilder::default()
+                        .query(Query::new_nearest(VectorInput::new_sparse(
+                            sparse.indices,
+                            sparse.values,
+                        )))
+                        .using("Combined_sparse")
+                        .limit(20u64),
+                )
+                .add_prefetch(
+                    PrefetchQueryBuilder::default()
+                        .query(Query::new_nearest(dense))
+                        .using("Combined")
+                        .limit(20u64),
+                )
+                .query(Query::new_fusion(Fusion::Rrf)),
+        )
+        .await
+        .unwrap();
+
+    for result in search_response.result {
+        println!("---");
+        println!("{:?}", result);
+        println!("---");
+    }
+
+    Ok(())
+}

--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -3,9 +3,9 @@
 //! All steps defined in the indexing pipeline and the generic transformers can also take a
 //! trait. To bring your own transformers, models and loaders, all you need to do is implement the
 //! trait and it should work out of the box.
-use crate::indexing_stream::IndexingStream;
 use crate::node::Node;
 use crate::Embeddings;
+use crate::{indexing_stream::IndexingStream, SparseEmbeddings};
 use std::fmt::Debug;
 
 use crate::prompt::Prompt;
@@ -99,6 +99,14 @@ pub trait NodeCache: Send + Sync + Debug {
 /// Assumes the strings will be moved.
 pub trait EmbeddingModel: Send + Sync + Debug {
     async fn embed(&self, input: Vec<String>) -> Result<Embeddings>;
+}
+
+#[cfg_attr(feature = "test-utils", automock)]
+#[async_trait]
+/// Embeds a list of strings and returns its embeddings.
+/// Assumes the strings will be moved.
+pub trait SparseEmbeddingModel: Send + Sync + Debug {
+    async fn embed(&self, input: Vec<String>) -> Result<SparseEmbeddings>;
 }
 
 #[cfg_attr(feature = "test-utils", automock)]

--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -106,7 +106,7 @@ pub trait EmbeddingModel: Send + Sync + Debug {
 /// Embeds a list of strings and returns its embeddings.
 /// Assumes the strings will be moved.
 pub trait SparseEmbeddingModel: Send + Sync + Debug {
-    async fn embed(&self, input: Vec<String>) -> Result<SparseEmbeddings>;
+    async fn sparse_embed(&self, input: Vec<String>) -> Result<SparseEmbeddings>;
 }
 
 #[cfg_attr(feature = "test-utils", automock)]

--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -5,7 +5,9 @@
 //! trait and it should work out of the box.
 use crate::node::Node;
 use crate::Embeddings;
-use crate::{indexing_defaults::IndexingDefaults, indexing_stream::IndexingStream, SparseEmbeddings};
+use crate::{
+    indexing_defaults::IndexingDefaults, indexing_stream::IndexingStream, SparseEmbeddings,
+};
 use std::fmt::Debug;
 
 use crate::prompt::Prompt;

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -27,7 +27,7 @@ use std::{
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::metadata::Metadata;
+use crate::{metadata::Metadata, Embedding, SparseEmbedding};
 
 /// Represents a unit of data in the indexing process.
 ///
@@ -43,7 +43,9 @@ pub struct Node {
     /// Data chunk contained in the node.
     pub chunk: String,
     /// Optional vector representation of embedded data.
-    pub vectors: Option<HashMap<EmbeddedField, Vec<f32>>>,
+    pub vectors: Option<HashMap<EmbeddedField, Embedding>>,
+    /// Optional sparse vector representation of embedded data.
+    pub sparse_vectors: Option<HashMap<EmbeddedField, SparseEmbedding>>,
     /// Metadata associated with the node.
     pub metadata: Metadata,
     /// Mode of embedding data Chunk and Metadata
@@ -67,6 +69,15 @@ impl Debug for Node {
             .field("metadata", &self.metadata)
             .field(
                 "vectors",
+                &self
+                    .vectors
+                    .iter()
+                    .flat_map(HashMap::iter)
+                    .map(|(embed_type, vec)| format!("'{embed_type}': {}", vec.len()))
+                    .join(","),
+            )
+            .field(
+                "sparse_vectors",
                 &self
                     .vectors
                     .iter()

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -79,10 +79,16 @@ impl Debug for Node {
             .field(
                 "sparse_vectors",
                 &self
-                    .vectors
+                    .sparse_vectors
                     .iter()
                     .flat_map(HashMap::iter)
-                    .map(|(embed_type, vec)| format!("'{embed_type}': {}", vec.len()))
+                    .map(|(embed_type, vec)| {
+                        format!(
+                            "'{embed_type}': indices({}), values({})",
+                            vec.indices.len(),
+                            vec.values.len()
+                        )
+                    })
                     .join(","),
             )
             .field("embed_mode", &self.embed_mode)
@@ -194,7 +200,9 @@ pub enum EmbedMode {
 }
 
 /// Type of Embeddable stored in model.
-#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, strum_macros::Display)]
+#[derive(
+    Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, strum_macros::Display, Debug,
+)]
 pub enum EmbeddedField {
     #[default]
     /// Embeddable created from Chunk of data combined with Metadata.
@@ -205,4 +213,11 @@ pub enum EmbeddedField {
     /// String stores Metadata name.
     #[strum(to_string = "Metadata: {0}")]
     Metadata(String),
+}
+
+#[allow(clippy::from_over_into)]
+impl Into<String> for EmbeddedField {
+    fn into(self) -> String {
+        self.to_string()
+    }
 }

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -5,7 +5,7 @@ pub type Embeddings = Vec<Embedding>;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct SparseEmbedding {
-    pub indices: Vec<usize>,
+    pub indices: Vec<u32>,
     pub values: Vec<f32>,
 }
 pub type SparseEmbeddings = Vec<SparseEmbedding>;

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -1,6 +1,9 @@
+use serde::{Deserialize, Serialize};
+
 pub type Embedding = Vec<f32>;
 pub type Embeddings = Vec<Embedding>;
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct SparseEmbedding {
     pub indices: Vec<usize>,
     pub values: Vec<f32>,

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -2,7 +2,7 @@ pub type Embedding = Vec<f32>;
 pub type Embeddings = Vec<Embedding>;
 
 pub struct SparseEmbedding {
-    pub indices: Vec<u32>,
+    pub indices: Vec<usize>,
     pub values: Vec<f32>,
 }
 pub type SparseEmbeddings = Vec<SparseEmbedding>;

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -3,9 +3,18 @@ use serde::{Deserialize, Serialize};
 pub type Embedding = Vec<f32>;
 pub type Embeddings = Vec<Embedding>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct SparseEmbedding {
     pub indices: Vec<usize>,
     pub values: Vec<f32>,
 }
 pub type SparseEmbeddings = Vec<SparseEmbedding>;
+
+impl std::fmt::Debug for SparseEmbedding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SparseEmbedding")
+            .field("indices", &self.indices.len())
+            .field("values", &self.values.len())
+            .finish()
+    }
+}

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -1,2 +1,8 @@
 pub type Embedding = Vec<f32>;
 pub type Embeddings = Vec<Embedding>;
+
+pub struct SparseEmbedding {
+    pub indices: Vec<u32>,
+    pub values: Vec<f32>,
+}
+pub type SparseEmbeddings = Vec<SparseEmbedding>;

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -170,7 +170,11 @@ impl Pipeline {
                 let transformer = transformer.clone();
                 let span = tracing::trace_span!("then", node = ?node );
 
-                async move { transformer.transform_node(node).await }.instrument(span)
+                async move {
+                    tracing::debug!(?node, "Transforming node");
+                    transformer.transform_node(node).await
+                }
+                .instrument(span)
             })
             .try_buffer_unordered(concurrency)
             .boxed()
@@ -206,7 +210,11 @@ impl Pipeline {
                 let transformer = Arc::clone(&transformer);
                 let span = tracing::trace_span!("then_in_batch",  nodes = ?nodes );
 
-                async move { Ok(transformer.batch_transform(nodes).await) }.instrument(span)
+                async move {
+                    tracing::debug!(num_nodes = nodes.len(), "Batch transforming nodes");
+                    Ok(transformer.batch_transform(nodes).await)
+                }
+                .instrument(span)
             })
             .try_buffer_unordered(concurrency) // First get the streams from each future
             .try_flatten_unordered(concurrency) // Then flatten all the streams back into one
@@ -234,7 +242,11 @@ impl Pipeline {
                 let chunker = Arc::clone(&chunker);
                 let span = tracing::trace_span!("then_chunk", chunker = ?chunker, node = ?node );
 
-                async move { Ok(chunker.transform_node(node).await) }.instrument(span)
+                async move {
+                    tracing::debug!(?node, "Chunking node");
+                    Ok(chunker.transform_node(node).await)
+                }
+                .instrument(span)
             })
             .try_buffer_unordered(concurrency)
             .try_flatten_unordered(concurrency)
@@ -271,7 +283,9 @@ impl Pipeline {
                     let storage = Arc::clone(&storage);
                     let span = tracing::trace_span!("then_store_with_batched", storage = ?storage, nodes = ?nodes );
 
-                    async move { Ok(storage.batch_store(nodes).await) }.instrument(span)
+                    async move {
+                        tracing::debug!(num_nodes = nodes.len(), "Batch storing nodes");
+                        Ok(storage.batch_store(nodes).await) }.instrument(span)
                 })
                 .try_buffer_unordered(self.concurrency)
                 .try_flatten_unordered(self.concurrency)
@@ -284,7 +298,12 @@ impl Pipeline {
                     let span =
                         tracing::trace_span!("then_store_with", storage = ?storage, node = ?node );
 
-                    async move { storage.store(node).await }.instrument(span)
+                    async move {
+                        tracing::debug!(?node, "Storing node");
+
+                        storage.store(node).await
+                    }
+                    .instrument(span)
                 })
                 .try_buffer_unordered(self.concurrency)
                 .boxed()

--- a/swiftide-indexing/src/transformers/mod.rs
+++ b/swiftide-indexing/src/transformers/mod.rs
@@ -29,6 +29,7 @@ pub mod metadata_qa_code;
 pub mod metadata_qa_text;
 pub mod metadata_summary;
 pub mod metadata_title;
+pub mod sparse_embed;
 
 #[cfg(feature = "tree-sitter")]
 pub use outline_code_tree_sitter::OutlineCodeTreeSitter;
@@ -41,3 +42,5 @@ pub use metadata_qa_code::MetadataQACode;
 pub use metadata_qa_text::MetadataQAText;
 pub use metadata_summary::MetadataSummary;
 pub use metadata_title::MetadataTitle;
+pub use sparse_embed::SparseEmbed;
+

--- a/swiftide-indexing/src/transformers/mod.rs
+++ b/swiftide-indexing/src/transformers/mod.rs
@@ -43,4 +43,3 @@ pub use metadata_qa_text::MetadataQAText;
 pub use metadata_summary::MetadataSummary;
 pub use metadata_title::MetadataTitle;
 pub use sparse_embed::SparseEmbed;
-

--- a/swiftide-indexing/src/transformers/sparse_embed.rs
+++ b/swiftide-indexing/src/transformers/sparse_embed.rs
@@ -5,7 +5,7 @@ use anyhow::bail;
 use async_trait::async_trait;
 use swiftide_core::{
     indexing::{IndexingStream, Node},
-    BatchableTransformer, SparseEmbeddingModel,
+    BatchableTransformer, SparseEmbeddingModel, WithBatchIndexingDefaults, WithIndexingDefaults,
 };
 
 /// A transformer that can generate embeddings for an `Node`
@@ -47,6 +47,9 @@ impl SparseEmbed {
         self
     }
 }
+
+impl WithBatchIndexingDefaults for Embed {}
+impl WithIndexingDefaults for Embed {}
 
 #[async_trait]
 impl BatchableTransformer for SparseEmbed {

--- a/swiftide-indexing/src/transformers/sparse_embed.rs
+++ b/swiftide-indexing/src/transformers/sparse_embed.rs
@@ -48,8 +48,8 @@ impl SparseEmbed {
     }
 }
 
-impl WithBatchIndexingDefaults for Embed {}
-impl WithIndexingDefaults for Embed {}
+impl WithBatchIndexingDefaults for SparseEmbed {}
+impl WithIndexingDefaults for SparseEmbed {}
 
 #[async_trait]
 impl BatchableTransformer for SparseEmbed {

--- a/swiftide-integrations/src/fastembed/embedding_model.rs
+++ b/swiftide-integrations/src/fastembed/embedding_model.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swiftide_core::{EmbeddingModel, Embeddings};
+
+use super::{EmbeddingModelType, FastEmbed};
+#[async_trait]
+impl EmbeddingModel for FastEmbed {
+    #[tracing::instrument(skip_all)]
+    async fn embed(&self, input: Vec<String>) -> Result<Embeddings> {
+        if let EmbeddingModelType::Dense(embedding_model) = &*self.embedding_model {
+            embedding_model.embed(input, self.batch_size)
+        } else {
+            Err(anyhow::anyhow!("Expected dense model, got sparse"))
+        }
+    }
+}

--- a/swiftide-integrations/src/fastembed/mod.rs
+++ b/swiftide-integrations/src/fastembed/mod.rs
@@ -34,13 +34,18 @@ impl From<SparseTextEmbedding> for EmbeddingModelType {
 /// Supports a variety of fast text embedding models. The default is the `Flag Embedding` model
 /// with a dimension size of 384.
 ///
+/// A default can also be used for sparse embeddings, which by default uses Splade. Sparse
+/// embeddings are useful for more exact search in combination with dense vectors.
+///
+/// `Into` is implemented for all available models from fastembed-rs.
+///
 /// See the [FastEmbed documentation](https://docs.rs/fastembed) for more information on usage.
 ///
 /// `FastEmbed` can be customized by setting the embedding model via the builder. The batch size can
 /// also be set and is recommended. Batch size should match the batch size in the indexing
 /// pipeline.
 ///
-/// Node that the embedding vector dimensions need to match the dimensions of the vector database collection
+/// Note that the embedding vector dimensions need to match the dimensions of the vector database collection
 ///
 /// Requires the `fastembed` feature to be enabled.
 #[derive(Builder, Clone)]
@@ -77,6 +82,11 @@ impl FastEmbed {
         Self::builder().build()
     }
 
+    /// Tries to build a default `FastEmbed` for sparse embeddings using Splade
+    ///
+    /// # Errors
+    ///
+    /// Errors if the build fails
     pub fn try_default_sparse() -> Result<Self> {
         Self::builder()
             .embedding_model(SparseTextEmbedding::try_new(

--- a/swiftide-integrations/src/fastembed/mod.rs
+++ b/swiftide-integrations/src/fastembed/mod.rs
@@ -95,6 +95,11 @@ impl FastEmbed {
             .build()
     }
 
+    pub fn with_batch_size(&mut self, batch_size: usize) -> &mut Self {
+        self.batch_size = Some(batch_size);
+        self
+    }
+
     pub fn builder() -> FastEmbedBuilder {
         FastEmbedBuilder::default()
     }

--- a/swiftide-integrations/src/fastembed/mod.rs
+++ b/swiftide-integrations/src/fastembed/mod.rs
@@ -117,8 +117,10 @@ mod tests {
             .sparse_embed(vec!["hello".to_string()])
             .await
             .unwrap();
-        assert_eq!(embeddings.len(), 1);
-        assert_eq!(embeddings[0].values.len(), 1);
+
+        // Model can vary in size, assert it's small and not the full dictionary (30k+)
+        assert!(embeddings[0].values.len() > 1);
+        assert!(embeddings[0].values.len() < 100);
         assert_eq!(embeddings[0].indices.len(), embeddings[0].values.len());
     }
 }

--- a/swiftide-integrations/src/fastembed/sparse_embedding_model.rs
+++ b/swiftide-integrations/src/fastembed/sparse_embedding_model.rs
@@ -14,7 +14,7 @@ impl SparseEmbeddingModel for FastEmbed {
                     embeddings
                         .into_iter()
                         .map(|embedding| SparseEmbedding {
-                            indices: embedding.indices,
+                            indices: embedding.indices.iter().map(|v| *v as u32).collect(),
                             values: embedding.values,
                         })
                         .collect()

--- a/swiftide-integrations/src/fastembed/sparse_embedding_model.rs
+++ b/swiftide-integrations/src/fastembed/sparse_embedding_model.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use swiftide_core::{SparseEmbedding, SparseEmbeddingModel, SparseEmbeddings};
+
+use super::{EmbeddingModelType, FastEmbed};
+#[async_trait]
+impl SparseEmbeddingModel for FastEmbed {
+    #[tracing::instrument(skip_all)]
+    async fn sparse_embed(&self, input: Vec<String>) -> Result<SparseEmbeddings> {
+        if let EmbeddingModelType::Sparse(embedding_model) = &*self.embedding_model {
+            embedding_model
+                .embed(input, self.batch_size)
+                .map(|embeddings| {
+                    embeddings
+                        .into_iter()
+                        .map(|embedding| SparseEmbedding {
+                            indices: embedding.indices,
+                            values: embedding.values,
+                        })
+                        .collect()
+                })
+        } else {
+            Err(anyhow::anyhow!("Expected dense model, got sparse"))
+        }
+    }
+}

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -83,12 +83,19 @@ fn try_create_vectors(
     }
     let mut qdrant_vectors = qdrant::NamedVectors::default();
 
-    for vector in vectors {
-        qdrant_vectors = qdrant_vectors.add_vector(vector.0.to_string(), vector.1.clone());
+    for (field, vector) in vectors {
+        if !vector_fields.contains(&field) {
+            continue;
+        }
+        qdrant_vectors = qdrant_vectors.add_vector(field.to_string(), vector);
     }
 
     if let Some(sparse_vectors) = sparse_vectors {
         for (field, sparse_vector) in sparse_vectors {
+            if !vector_fields.contains(&field) {
+                continue;
+            }
+
             qdrant_vectors = qdrant_vectors.add_vector(
                 format!("{field}_sparse"),
                 qdrant::Vector::new_sparse(

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -108,7 +108,8 @@ mod tests {
             original_size: 4,
             offset: 0,
             metadata: Metadata::from([("m1", "mv1")]),
-            embed_mode: swiftide_core::indexing::EmbedMode::SingleWithMetadata
+            embed_mode: swiftide_core::indexing::EmbedMode::SingleWithMetadata,
+            ..Default::default()
         },
         HashSet::from([EmbeddedField::Combined]),
         PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
@@ -128,7 +129,8 @@ mod tests {
             metadata: Metadata::from([("m1", "mv1")]),
             embed_mode: swiftide_core::indexing::EmbedMode::PerField,
             original_size: 4,
-            offset: 0
+            offset: 0,
+            ..Default::default()
         },
         HashSet::from([EmbeddedField::Chunk, EmbeddedField::Metadata("m1".into())]),
         PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
@@ -158,6 +160,7 @@ mod tests {
             embed_mode: swiftide_core::indexing::EmbedMode::Both,
             original_size: 4,
             offset: 0,
+            ..Default::default()
         },
         HashSet::from([EmbeddedField::Combined]),
         PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -102,7 +102,7 @@ fn try_create_vectors(
                     sparse_vector
                         .indices
                         .into_iter()
-                        .map(|i| i as u32)
+                        .map(|i| i)
                         .collect::<Vec<_>>(),
                     sparse_vector.values,
                 ),

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -99,11 +99,7 @@ fn try_create_vectors(
             qdrant_vectors = qdrant_vectors.add_vector(
                 format!("{field}_sparse"),
                 qdrant::Vector::new_sparse(
-                    sparse_vector
-                        .indices
-                        .into_iter()
-                        .map(|i| i)
-                        .collect::<Vec<_>>(),
+                    sparse_vector.indices.into_iter().collect::<Vec<_>>(),
                     sparse_vector.values,
                 ),
             );
@@ -199,12 +195,13 @@ mod tests {
         };
         "Storing only `Combined` vector. Skipping other vectors."
     )]
+    #[allow(clippy::needless_pass_by_value)]
     fn try_into_point_struct_test(
         node: Node,
         vector_fields: HashSet<EmbeddedField>,
         mut expected_point: PointStruct,
     ) {
-        let node = NodeWithVectors::new(&node, vector_fields.iter().collect(), Default::default());
+        let node = NodeWithVectors::new(&node, vector_fields.iter().collect());
         let point: PointStruct = node.try_into().expect("Can create PointStruct");
 
         // patch last_update_at field to avoid test failure because of time difference

--- a/swiftide-integrations/src/qdrant/mod.rs
+++ b/swiftide-integrations/src/qdrant/mod.rs
@@ -292,21 +292,15 @@ pub type Distance = qdrant::Distance;
 
 /// Utility struct combining `Node` with `EmbeddedField`s of configured _Qdrant_ vectors.
 struct NodeWithVectors<'a> {
-    vector_fields: HashSet<&'a EmbeddedField>,
-    sparse_vector_fields: HashSet<&'a EmbeddedField>,
     node: &'a Node,
+    vector_fields: HashSet<&'a EmbeddedField>,
 }
 
 impl<'a> NodeWithVectors<'a> {
-    pub fn new(
-        node: &'a Node,
-        vector_fields: HashSet<&'a EmbeddedField>,
-        sparse_vector_fields: HashSet<&'a EmbeddedField>,
-    ) -> Self {
+    pub fn new(node: &'a Node, vector_fields: HashSet<&'a EmbeddedField>) -> Self {
         Self {
-            vector_fields,
-            sparse_vector_fields,
             node,
+            vector_fields,
         }
     }
 }

--- a/swiftide-integrations/src/qdrant/mod.rs
+++ b/swiftide-integrations/src/qdrant/mod.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context as _, Result};
 use derive_builder::Builder;
-use qdrant_client::qdrant;
+use qdrant_client::qdrant::{
+    self, sparse_vectors_config, SparseVectorParamsBuilder, SparseVectorsConfigBuilder,
+};
 
 use swiftide_core::indexing::{EmbeddedField, Node};
 
@@ -54,6 +56,8 @@ pub struct Qdrant {
     batch_size: Option<usize>,
     #[builder(private, default = "Self::default_vectors()")]
     vectors: HashMap<EmbeddedField, VectorConfig>,
+    #[builder(private, default)]
+    sparse_vectors: HashMap<EmbeddedField, SparseVectorConfig>,
 }
 
 impl Qdrant {
@@ -98,17 +102,32 @@ impl Qdrant {
     ///
     /// Errors if client fails build
     pub async fn create_index_if_not_exists(&self) -> Result<()> {
-        tracing::info!("Checking if collection {} exists", self.collection_name);
+        tracing::info!("Checking if collection {} exists", &self.collection_name);
 
         if self.client.collection_exists(&self.collection_name).await? {
-            tracing::warn!("Collection {} exists", self.collection_name);
+            tracing::warn!("Collection {} exists", &self.collection_name);
             return Ok(());
         }
 
-        tracing::warn!("Creating collection {}", self.collection_name);
         let vectors_config = self.create_vectors_config()?;
-        let request = qdrant::CreateCollectionBuilder::new(self.collection_name.clone())
-            .vectors_config(vectors_config);
+
+        let request = if let Some(sparse_vectors_config) = self.create_sparse_vectors_config() {
+            tracing::warn!(
+                "Creating collection {} with sparse config",
+                &self.collection_name
+            );
+
+            tracing::debug!(?vectors_config);
+            tracing::debug!(?sparse_vectors_config);
+            qdrant::CreateCollectionBuilder::new(self.collection_name.clone())
+                .vectors_config(vectors_config)
+                .sparse_vectors_config(sparse_vectors_config)
+        } else {
+            tracing::warn!("Creating collection {}", &self.collection_name);
+
+            qdrant::CreateCollectionBuilder::new(self.collection_name.clone())
+                .vectors_config(vectors_config)
+        };
 
         self.client.create_collection(request).await?;
         Ok(())
@@ -117,7 +136,7 @@ impl Qdrant {
     fn create_vectors_config(&self) -> Result<qdrant_client::qdrant::vectors_config::Config> {
         if self.vectors.is_empty() {
             bail!("No configured vectors");
-        } else if self.vectors.len() == 1 {
+        } else if self.vectors.len() == 1 && self.sparse_vectors.is_empty() {
             let config = self
                 .vectors
                 .values()
@@ -127,9 +146,10 @@ impl Qdrant {
             return Ok(qdrant::vectors_config::Config::Params(vector_params));
         }
         let mut map = HashMap::<String, qdrant::VectorParams>::default();
-        for (emebddable_type, config) in &self.vectors {
-            let vector_name = emebddable_type.to_string();
+        for (embedded_field, config) in &self.vectors {
+            let vector_name = embedded_field.to_string();
             let vector_params = self.create_vector_params(config);
+
             map.insert(vector_name, vector_params);
         }
 
@@ -138,9 +158,24 @@ impl Qdrant {
         ))
     }
 
+    fn create_sparse_vectors_config(&self) -> Option<qdrant::SparseVectorConfig> {
+        if self.sparse_vectors.is_empty() {
+            return None;
+        }
+        let mut sparse_vectors_config = SparseVectorsConfigBuilder::default();
+        for embedded_field in self.sparse_vectors.keys() {
+            let vector_name = format!("{embedded_field}_sparse");
+            let vector_params = SparseVectorParamsBuilder::default();
+            sparse_vectors_config.add_named_vector_params(vector_name, vector_params);
+        }
+
+        Some(sparse_vectors_config.into())
+    }
+
     fn create_vector_params(&self, config: &VectorConfig) -> qdrant::VectorParams {
         let size = config.vector_size.unwrap_or(self.vector_size);
         let distance = config.distance.unwrap_or(self.vector_distance);
+
         qdrant::VectorParamsBuilder::new(size, distance).build()
     }
 }
@@ -158,7 +193,7 @@ impl QdrantBuilder {
         Ok(Arc::new(client))
     }
 
-    /// Adds new [`VectorConfig`]
+    /// Configures a dense vector on the collection
     ///
     /// When not configured Pipeline by default configures vector only for [`EmbeddedField::Combined`]
     /// Default config is enough when [`swiftide::indexing::Pipeline::with_embed_mode`] is not set
@@ -170,6 +205,24 @@ impl QdrantBuilder {
         }
         let vector = vector.into();
         if let Some(vectors) = self.vectors.as_mut() {
+            if let Some(overridden_vector) = vectors.insert(vector.embedded_field.clone(), vector) {
+                tracing::warn!(
+                    "Overriding named vector config: {}",
+                    overridden_vector.embedded_field
+                );
+            }
+        }
+        self
+    }
+
+    /// Configures a sparse vector on the collection
+    #[must_use]
+    pub fn with_sparse_vector(mut self, vector: impl Into<SparseVectorConfig>) -> QdrantBuilder {
+        if self.sparse_vectors.is_none() {
+            self = self.sparse_vectors(HashMap::default());
+        }
+        let vector = vector.into();
+        if let Some(vectors) = self.sparse_vectors.as_mut() {
             if let Some(overridden_vector) = vectors.insert(vector.embedded_field.clone(), vector) {
                 tracing::warn!(
                     "Overriding named vector config: {}",
@@ -231,19 +284,39 @@ impl From<EmbeddedField> for VectorConfig {
     }
 }
 
+/// Sparse Vector config
+#[derive(Clone, Builder, Default)]
+pub struct SparseVectorConfig {
+    embedded_field: EmbeddedField,
+}
+
+impl From<EmbeddedField> for SparseVectorConfig {
+    fn from(value: EmbeddedField) -> Self {
+        Self {
+            embedded_field: value,
+        }
+    }
+}
+
 pub type Distance = qdrant::Distance;
 
 /// Utility struct combining `Node` with `EmbeddedField`s of configured _Qdrant_ vectors.
-struct NodeWithVectors {
-    vector_fields: HashSet<EmbeddedField>,
-    node: Node,
+struct NodeWithVectors<'a> {
+    vector_fields: HashSet<&'a EmbeddedField>,
+    sparse_vector_fields: HashSet<&'a EmbeddedField>,
+    node: &'a Node,
 }
 
-impl NodeWithVectors {
-    pub fn new(node: Node, vector_fields: HashSet<EmbeddedField>) -> Self {
+impl<'a> NodeWithVectors<'a> {
+    pub fn new(
+        node: &'a Node,
+        vector_fields: HashSet<&'a EmbeddedField>,
+        sparse_vector_fields: HashSet<&'a EmbeddedField>,
+    ) -> Self {
         Self {
             vector_fields,
             node,
+            sparse_vector_fields,
         }
     }
 }

--- a/swiftide-integrations/src/qdrant/mod.rs
+++ b/swiftide-integrations/src/qdrant/mod.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use anyhow::{bail, Context as _, Result};
 use derive_builder::Builder;
 use qdrant_client::qdrant::{
-    self, sparse_vectors_config, SparseVectorParamsBuilder, SparseVectorsConfigBuilder,
+    self, SparseVectorParamsBuilder, SparseVectorsConfigBuilder,
 };
 
 use swiftide_core::indexing::{EmbeddedField, Node};
@@ -305,10 +305,6 @@ impl<'a> NodeWithVectors<'a> {
         vector_fields: HashSet<&'a EmbeddedField>,
         sparse_vector_fields: HashSet<&'a EmbeddedField>,
     ) -> Self {
-        Self {
-            vector_fields,
-            node,
-            sparse_vector_fields,
-        }
+        Self { vector_fields, sparse_vector_fields, node }
     }
 }

--- a/swiftide-integrations/src/qdrant/mod.rs
+++ b/swiftide-integrations/src/qdrant/mod.rs
@@ -13,9 +13,7 @@ use std::sync::Arc;
 
 use anyhow::{bail, Context as _, Result};
 use derive_builder::Builder;
-use qdrant_client::qdrant::{
-    self, SparseVectorParamsBuilder, SparseVectorsConfigBuilder,
-};
+use qdrant_client::qdrant::{self, SparseVectorParamsBuilder, SparseVectorsConfigBuilder};
 
 use swiftide_core::indexing::{EmbeddedField, Node};
 
@@ -305,6 +303,10 @@ impl<'a> NodeWithVectors<'a> {
         vector_fields: HashSet<&'a EmbeddedField>,
         sparse_vector_fields: HashSet<&'a EmbeddedField>,
     ) -> Self {
-        Self { vector_fields, sparse_vector_fields, node }
+        Self {
+            vector_fields,
+            sparse_vector_fields,
+            node,
+        }
     }
 }

--- a/swiftide-integrations/src/qdrant/persist.rs
+++ b/swiftide-integrations/src/qdrant/persist.rs
@@ -40,6 +40,8 @@ impl Persist for Qdrant {
 
     /// Stores a single indexing node in the Qdrant storage.
     ///
+    /// WARN: If running debug builds, the store is blocking and will impact performance
+    ///
     /// # Parameters
     ///
     /// - `node`: The `Node` to be stored.
@@ -60,10 +62,10 @@ impl Persist for Qdrant {
         tracing::debug!(?point, "Storing node");
 
         self.client
-            .upsert_points(UpsertPointsBuilder::new(
-                self.collection_name.to_string(),
-                vec![point],
-            ))
+            .upsert_points(
+                UpsertPointsBuilder::new(self.collection_name.to_string(), vec![point])
+                    .wait(cfg!(debug_assertions)),
+            )
             .await?;
         Ok(node)
     }

--- a/swiftide-integrations/src/qdrant/persist.rs
+++ b/swiftide-integrations/src/qdrant/persist.rs
@@ -88,7 +88,7 @@ impl Persist for Qdrant {
         let points = nodes
             .iter()
             .map(|node| {
-                NodeWithVectors::new(&node, self.vector_fields(), self.sparse_vector_fields())
+                NodeWithVectors::new(node, self.vector_fields(), self.sparse_vector_fields())
             })
             .map(NodeWithVectors::try_into)
             .collect::<Result<Vec<_>>>();

--- a/swiftide-integrations/src/qdrant/persist.rs
+++ b/swiftide-integrations/src/qdrant/persist.rs
@@ -55,8 +55,7 @@ impl Persist for Qdrant {
     /// This function will return an error if the node conversion or storage operation fails.
     #[tracing::instrument(skip_all, err, name = "storage.qdrant.store")]
     async fn store(&self, node: Node) -> Result<Node> {
-        let node_with_vectors =
-            NodeWithVectors::new(&node, self.vector_fields(), self.sparse_vector_fields());
+        let node_with_vectors = NodeWithVectors::new(&node, self.vector_fields());
         let point = node_with_vectors.try_into()?;
 
         tracing::debug!(?point, "Storing node");
@@ -87,9 +86,7 @@ impl Persist for Qdrant {
     async fn batch_store(&self, nodes: Vec<Node>) -> IndexingStream {
         let points = nodes
             .iter()
-            .map(|node| {
-                NodeWithVectors::new(node, self.vector_fields(), self.sparse_vector_fields())
-            })
+            .map(|node| NodeWithVectors::new(node, self.vector_fields()))
             .map(NodeWithVectors::try_into)
             .collect::<Result<Vec<_>>>();
 
@@ -118,9 +115,5 @@ impl Persist for Qdrant {
 impl Qdrant {
     fn vector_fields(&self) -> HashSet<&EmbeddedField> {
         self.vectors.keys().collect::<HashSet<_>>()
-    }
-
-    fn sparse_vector_fields(&self) -> HashSet<&EmbeddedField> {
-        self.sparse_vectors.keys().collect::<HashSet<_>>()
     }
 }

--- a/swiftide-integrations/src/qdrant/persist.rs
+++ b/swiftide-integrations/src/qdrant/persist.rs
@@ -53,10 +53,11 @@ impl Persist for Qdrant {
     /// This function will return an error if the node conversion or storage operation fails.
     #[tracing::instrument(skip_all, err, name = "storage.qdrant.store")]
     async fn store(&self, node: Node) -> Result<Node> {
-        let node_with_vectors = NodeWithVectors::new(node.clone(), self.vector_fields());
+        let node_with_vectors =
+            NodeWithVectors::new(&node, self.vector_fields(), self.sparse_vector_fields());
         let point = node_with_vectors.try_into()?;
 
-        tracing::debug!(?node, ?point, "Storing node");
+        tracing::debug!(?point, "Storing node");
 
         self.client
             .upsert_points(UpsertPointsBuilder::new(
@@ -84,15 +85,15 @@ impl Persist for Qdrant {
     async fn batch_store(&self, nodes: Vec<Node>) -> IndexingStream {
         let points = nodes
             .iter()
-            .map(|node| NodeWithVectors::new(node.clone(), self.vector_fields()))
+            .map(|node| {
+                NodeWithVectors::new(&node, self.vector_fields(), self.sparse_vector_fields())
+            })
             .map(NodeWithVectors::try_into)
             .collect::<Result<Vec<_>>>();
 
-        if points.is_err() {
+        let Ok(points) = points else {
             return vec![Err(points.unwrap_err())].into();
-        }
-
-        let points = points.unwrap();
+        };
 
         tracing::debug!("Storing batch of {} nodes", points.len());
 
@@ -113,7 +114,11 @@ impl Persist for Qdrant {
 }
 
 impl Qdrant {
-    fn vector_fields(&self) -> HashSet<EmbeddedField> {
-        self.vectors.keys().cloned().collect()
+    fn vector_fields(&self) -> HashSet<&EmbeddedField> {
+        self.vectors.keys().collect::<HashSet<_>>()
+    }
+
+    fn sparse_vector_fields(&self) -> HashSet<&EmbeddedField> {
+        self.sparse_vectors.keys().collect::<HashSet<_>>()
     }
 }

--- a/swiftide-test-utils/src/test_utils.rs
+++ b/swiftide-test-utils/src/test_utils.rs
@@ -33,7 +33,7 @@ pub fn openai_client(
 /// Setup Qdrant container.
 /// Returns container server and `server_url`.
 pub async fn start_qdrant() -> (ContainerAsync<GenericImage>, String) {
-    let qdrant = testcontainers::GenericImage::new("qdrant/qdrant", "v1.9.2")
+    let qdrant = testcontainers::GenericImage::new("qdrant/qdrant", "v1.10.1")
         .with_exposed_port(6334.into())
         .with_exposed_port(6333.into())
         .with_wait_for(testcontainers::core::WaitFor::http(

--- a/swiftide/tests/indexing_pipeline.rs
+++ b/swiftide/tests/indexing_pipeline.rs
@@ -3,7 +3,7 @@
 //! from a temporary file, simulates API responses, and stores data accurately in the Qdrant vector database.
 
 use qdrant_client::qdrant::vectors::VectorsOptions;
-use qdrant_client::qdrant::{SearchPointsBuilder, Value};
+use qdrant_client::qdrant::{ScrollPointsBuilder, SearchPointsBuilder, Value};
 use swiftide::indexing::*;
 use swiftide::integrations;
 use swiftide_test_utils::*;
@@ -95,6 +95,18 @@ async fn test_indexing_pipeline() {
     let qdrant_client = qdrant_client::Qdrant::from_url(&qdrant_url)
         .build()
         .unwrap();
+
+    let stored_node = qdrant_client
+        .scroll(
+            ScrollPointsBuilder::new("swiftide-test")
+                .limit(1)
+                .with_payload(true)
+                .with_vectors(true),
+        )
+        .await
+        .unwrap();
+
+    dbg!(stored_node);
 
     let search_request =
         SearchPointsBuilder::new("swiftide-test", vec![0_f32; 1536], 10).with_payload(true);

--- a/swiftide/tests/indexing_pipeline.rs
+++ b/swiftide/tests/indexing_pipeline.rs
@@ -109,13 +109,13 @@ async fn test_indexing_pipeline() {
     dbg!(
         std::str::from_utf8(&qdrant_container.stdout_to_vec().await.unwrap())
             .unwrap()
-            .split("\n")
+            .split('\n')
             .collect::<Vec<_>>()
     );
     dbg!(
         std::str::from_utf8(&qdrant_container.stderr_to_vec().await.unwrap())
             .unwrap()
-            .split("\n")
+            .split('\n')
             .collect::<Vec<_>>()
     );
     dbg!(stored_node);

--- a/swiftide/tests/indexing_pipeline.rs
+++ b/swiftide/tests/indexing_pipeline.rs
@@ -52,7 +52,7 @@ async fn test_indexing_pipeline() {
         Pipeline::from_loader(loaders::FileLoader::new(tempdir.path()).with_extensions(&["rs"]))
             .then_chunk(transformers::ChunkCode::try_for_language("rust").unwrap())
             .then(transformers::MetadataQACode::new(openai_client.clone()))
-            // .filter_cached(integrations::redis::Redis::try_from_url(&redis_url, "prefix").unwrap())
+            .filter_cached(integrations::redis::Redis::try_from_url(&redis_url, "prefix").unwrap())
             .then_in_batch(1, transformers::Embed::new(openai_client.clone()))
             .log_nodes()
             .then_store_with(

--- a/swiftide/tests/sparse_embeddings.rs
+++ b/swiftide/tests/sparse_embeddings.rs
@@ -90,12 +90,12 @@ async fn test_sparse_indexing_pipeline() {
         .unwrap();
 
     dbg!(stored_node);
-    // dbg!(
-    //     std::str::from_utf8(&qdrant_container.stdout_to_vec().await.unwrap())
-    //         .unwrap()
-    //         .split("\n")
-    //         .collect::<Vec<_>>()
-    // );
+    dbg!(
+        std::str::from_utf8(&qdrant_container.stdout_to_vec().await.unwrap())
+            .unwrap()
+            .split("\n")
+            .collect::<Vec<_>>()
+    );
 
     /// Search using the dense vector
     let dense = node

--- a/swiftide/tests/sparse_embeddings.rs
+++ b/swiftide/tests/sparse_embeddings.rs
@@ -3,8 +3,8 @@
 //! from a temporary file, simulates API responses, and stores data accurately in the Qdrant vector database.
 
 use qdrant_client::qdrant::{
-    Fusion, PrefetchQueryBuilder, Query, QueryPointsBuilder,
-    ScrollPointsBuilder, SearchPointsBuilder, VectorInput,
+    Fusion, PrefetchQueryBuilder, Query, QueryPointsBuilder, ScrollPointsBuilder,
+    SearchPointsBuilder, VectorInput,
 };
 use swiftide::indexing::*;
 use swiftide::integrations;
@@ -135,7 +135,7 @@ async fn test_sparse_indexing_pipeline() {
         .unwrap();
 
     let search_request = SearchPointsBuilder::new("swiftide-test", sparse.values.as_slice(), 10)
-        .sparse_indices(sparse.indices.iter().map(|i| { *i }).collect::<Vec<_>>())
+        .sparse_indices(sparse.indices.iter().map(|i| *i).collect::<Vec<_>>())
         .vector_name(format!("{}_sparse", EmbeddedField::Combined))
         .with_payload(true);
 
@@ -162,7 +162,7 @@ async fn test_sparse_indexing_pipeline() {
                 .add_prefetch(
                     PrefetchQueryBuilder::default()
                         .query(Query::new_nearest(VectorInput::new_sparse(
-                            sparse.indices.iter().map(|i| { *i }).collect::<Vec<_>>(),
+                            sparse.indices.iter().map(|i| *i).collect::<Vec<_>>(),
                             sparse.values,
                         )))
                         .using("Combined_sparse")

--- a/swiftide/tests/sparse_embeddings.rs
+++ b/swiftide/tests/sparse_embeddings.rs
@@ -2,10 +2,9 @@
 //! The tests validate the functionality of the pipeline, ensuring it processes data correctly
 //! from a temporary file, simulates API responses, and stores data accurately in the Qdrant vector database.
 
-use qdrant_client::qdrant::vectors::VectorsOptions;
 use qdrant_client::qdrant::{
-    Condition, Filter, Fusion, PrefetchQueryBuilder, Query, QueryPointsBuilder,
-    ScrollPointsBuilder, SearchPointsBuilder, Value, VectorInput,
+    Fusion, PrefetchQueryBuilder, Query, QueryPointsBuilder,
+    ScrollPointsBuilder, SearchPointsBuilder, VectorInput,
 };
 use swiftide::indexing::*;
 use swiftide::integrations;
@@ -93,7 +92,7 @@ async fn test_sparse_indexing_pipeline() {
     dbg!(
         std::str::from_utf8(&qdrant_container.stdout_to_vec().await.unwrap())
             .unwrap()
-            .split("\n")
+            .split('\n')
             .collect::<Vec<_>>()
     );
 
@@ -136,7 +135,7 @@ async fn test_sparse_indexing_pipeline() {
         .unwrap();
 
     let search_request = SearchPointsBuilder::new("swiftide-test", sparse.values.as_slice(), 10)
-        .sparse_indices(sparse.indices.iter().map(|i| *i as u32).collect::<Vec<_>>())
+        .sparse_indices(sparse.indices.iter().map(|i| { *i }).collect::<Vec<_>>())
         .vector_name(format!("{}_sparse", EmbeddedField::Combined))
         .with_payload(true);
 
@@ -163,7 +162,7 @@ async fn test_sparse_indexing_pipeline() {
                 .add_prefetch(
                     PrefetchQueryBuilder::default()
                         .query(Query::new_nearest(VectorInput::new_sparse(
-                            sparse.indices.iter().map(|i| *i as u32).collect::<Vec<_>>(),
+                            sparse.indices.iter().map(|i| { *i }).collect::<Vec<_>>(),
                             sparse.values,
                         )))
                         .using("Combined_sparse")

--- a/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
+++ b/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
@@ -96,7 +96,7 @@ async fn test_sparse_indexing_pipeline() {
             .collect::<Vec<_>>()
     );
 
-    /// Search using the dense vector
+    // Search using the dense vector
     let dense = node
         .vectors
         .unwrap()
@@ -124,7 +124,7 @@ async fn test_sparse_indexing_pipeline() {
         "fn main() { println!(\"Hello, World!\"); }"
     );
 
-    /// Search using the sparse vector
+    // Search using the sparse vector
     let sparse = node
         .sparse_vectors
         .unwrap()
@@ -134,8 +134,9 @@ async fn test_sparse_indexing_pipeline() {
         .cloned()
         .unwrap();
 
+    // Search sparse
     let search_request = SearchPointsBuilder::new("swiftide-test", sparse.values.as_slice(), 10)
-        .sparse_indices(sparse.indices.iter().map(|i| *i).collect::<Vec<_>>())
+        .sparse_indices(sparse.indices.clone())
         .vector_name(format!("{}_sparse", EmbeddedField::Combined))
         .with_payload(true);
 
@@ -154,7 +155,7 @@ async fn test_sparse_indexing_pipeline() {
         "fn main() { println!(\"Hello, World!\"); }"
     );
 
-    /// Search hybrid
+    // Search hybrid
     let search_response = qdrant_client
         .query(
             QueryPointsBuilder::new("swiftide-test")
@@ -162,7 +163,7 @@ async fn test_sparse_indexing_pipeline() {
                 .add_prefetch(
                     PrefetchQueryBuilder::default()
                         .query(Query::new_nearest(VectorInput::new_sparse(
-                            sparse.indices.iter().map(|i| *i).collect::<Vec<_>>(),
+                            sparse.indices,
                             sparse.values,
                         )))
                         .using("Combined_sparse")


### PR DESCRIPTION
Adds Sparse vector support to the indexing pipeline, enabling hybrid search for vector databases. The design should work for any form of Sparse embedding, and works with existing embedding modes and multiple named vectors. Additionally, added `try_default_sparse` to FastEmbed, using Splade, so it's fully usuable.

Hybrid search in the query pipeline coming soon.
