### PR TITLE
feat(integrations): Add fluvio as loader support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5299,6 +5299,7 @@ dependencies = [
  "derive_builder",
  "fastembed",
  "fluvio",
+ "flv-util",
  "futures-util",
  "htmd",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,6 +153,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +198,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d416feee97712e43152cd42874de162b8f9b77295b1c85e5d92725cc8310bae"
 dependencies = [
  "async-trait",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.1.0",
+ "futures-lite 2.3.0",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io 2.3.4",
+ "async-lock 3.4.0",
+ "blocking",
+ "futures-lite 2.3.0",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-lite 1.13.0",
+ "log",
+ "parking",
+ "polling 2.8.0",
+ "rustix 0.37.27",
+ "slab",
+ "socket2 0.4.10",
+ "waker-fn",
+]
+
+[[package]]
+name = "async-io"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
+dependencies = [
+ "async-lock 3.4.0",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "parking",
+ "polling 3.7.3",
+ "rustix 0.38.34",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.3.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io 2.3.4",
+ "blocking",
+ "futures-lite 2.3.0",
 ]
 
 [[package]]
@@ -204,6 +325,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+dependencies = [
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-signal",
+ "blocking",
+ "cfg-if",
+ "event-listener 3.1.0",
+ "futures-lite 1.13.0",
+ "rustix 0.38.34",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io 2.3.4",
+ "async-lock 3.4.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.34",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 1.13.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +409,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +423,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.74",
+]
+
+[[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
 ]
 
 [[package]]
@@ -279,7 +479,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.1.0",
  "hex",
  "http 0.2.12",
  "ring",
@@ -316,7 +516,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand",
+ "fastrand 2.1.0",
  "http 0.2.12",
  "http-body 0.4.6",
  "once_cell",
@@ -512,7 +712,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand",
+ "fastrand 2.1.0",
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
@@ -733,6 +933,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-task",
+ "futures-io",
+ "futures-lite 2.3.0",
+ "piper",
+]
+
+[[package]]
 name = "bollard"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +1027,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,6 +1061,15 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -885,6 +1113,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -988,6 +1222,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1241,15 @@ dependencies = [
  "libc",
  "unicode-width",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1051,6 +1303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -1351,6 +1612,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
 name = "ego-tree"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1384,6 +1657,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
  "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.74",
@@ -1433,6 +1726,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener 5.3.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1784,16 @@ dependencies = [
  "swiftide",
  "tokio",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
 ]
 
 [[package]]
@@ -1500,6 +1841,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
@@ -1524,6 +1874,313 @@ checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluvio"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a437bef3baa91c0a29bc3a3641e14c7cd3a9ce3243fadefb30bb72a44acb064f"
+dependencies = [
+ "anyhow",
+ "async-channel 1.9.0",
+ "async-lock 3.4.0",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "derive_builder",
+ "dirs",
+ "event-listener 5.3.1",
+ "fluvio-compression",
+ "fluvio-future",
+ "fluvio-protocol",
+ "fluvio-sc-schema",
+ "fluvio-smartmodule",
+ "fluvio-socket",
+ "fluvio-spu-schema",
+ "fluvio-stream-dispatcher",
+ "fluvio-types",
+ "futures-lite 2.3.0",
+ "futures-util",
+ "once_cell",
+ "pin-project",
+ "semver",
+ "serde",
+ "serde_json",
+ "siphasher 1.0.1",
+ "thiserror",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-compression"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94399c0eb4224a511515fdf134f5ccd05b3c7ea1de566b9ab3cac63e6a4bc8f2"
+dependencies = [
+ "bytes",
+ "flate2",
+ "lz4_flex",
+ "serde",
+ "snap",
+ "thiserror",
+ "zstd",
+]
+
+[[package]]
+name = "fluvio-controlplane-metadata"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e92bd947b7a1877ba8eb36b379b478e92148947b407c375e758fe9be2cee92d2"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "bytesize",
+ "derive_builder",
+ "flate2",
+ "fluvio-future",
+ "fluvio-protocol",
+ "fluvio-stream-model",
+ "fluvio-types",
+ "flv-util",
+ "humantime-serde",
+ "lenient_semver",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "thiserror",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-future"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a28090046453db33a8bace0e1f71350b9878cd7fb576e48592ae8284bc83c7e"
+dependencies = [
+ "anyhow",
+ "async-io 2.3.4",
+ "async-net",
+ "async-std",
+ "async-trait",
+ "cfg-if",
+ "fluvio-wasm-timer",
+ "futures-lite 2.3.0",
+ "futures-util",
+ "openssl",
+ "openssl-sys",
+ "pin-project",
+ "socket2 0.5.7",
+ "thiserror",
+ "tracing",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "fluvio-protocol"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0d018de11a926dded54fa6ebbb0495cb15516f715392bebbcda76977fe12c1"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "content_inspector",
+ "crc32c",
+ "eyre",
+ "fluvio-compression",
+ "fluvio-future",
+ "fluvio-protocol-derive",
+ "fluvio-types",
+ "flv-util",
+ "once_cell",
+ "semver",
+ "thiserror",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-protocol-derive"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a9820c3b6b95ee62deaa0b724f783bfb1a54f2ce00331274f1eec879f14ca0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-sc-schema"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc1314d904319cf2a2e89bfb9f113f2700a5e6c5179753779efcb221f40bc24"
+dependencies = [
+ "anyhow",
+ "fluvio-controlplane-metadata",
+ "fluvio-protocol",
+ "fluvio-socket",
+ "fluvio-stream-model",
+ "fluvio-types",
+ "paste",
+ "static_assertions",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-smartmodule"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82883b06deb0d2feecbd2c9a1edc489477321dce4fc7a0f97842f6df62340a0f"
+dependencies = [
+ "eyre",
+ "fluvio-protocol",
+ "fluvio-smartmodule-derive",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-smartmodule-derive"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c36cb221d72fb3b4bdc9b53d448859a979b5f87660d41f7155994bb2f33d0c70"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "fluvio-socket"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98d2c341d5aaa1d08162a7936e87f5da3110eafcc3bd84a79e850053c554877"
+dependencies = [
+ "anyhow",
+ "async-channel 1.9.0",
+ "async-lock 3.4.0",
+ "async-trait",
+ "built",
+ "bytes",
+ "cfg-if",
+ "event-listener 5.3.1",
+ "fluvio-future",
+ "fluvio-protocol",
+ "futures-util",
+ "nix",
+ "once_cell",
+ "pin-project",
+ "semver",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-spu-schema"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7856cf9d5330aa74ce168284f5a9aeb2782c6961c191b9ffd5424250b847edf3"
+dependencies = [
+ "bytes",
+ "derive_builder",
+ "educe",
+ "flate2",
+ "fluvio-future",
+ "fluvio-protocol",
+ "fluvio-smartmodule",
+ "fluvio-types",
+ "serde",
+ "static_assertions",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-stream-dispatcher"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f7f45291006e26eb43826b130f1f01ba8428312bc88c398c0faef0f960ad11"
+dependencies = [
+ "anyhow",
+ "async-channel 1.9.0",
+ "async-lock 3.4.0",
+ "async-trait",
+ "cfg-if",
+ "event-listener 5.3.1",
+ "fluvio-future",
+ "fluvio-stream-model",
+ "fluvio-types",
+ "futures-util",
+ "once_cell",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-stream-model"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd883354fee545863d0983ef7bd74ad6b2d6aa58e74af3eafc6490939b8a16aa"
+dependencies = [
+ "async-lock 3.4.0",
+ "event-listener 5.3.1",
+ "k8-types",
+ "once_cell",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f04460aa87f1cfeb5f6099977b9f9d145ce302cd9de85c5c13a9877568dc39"
+dependencies = [
+ "event-listener 5.3.1",
+ "serde",
+ "thiserror",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "fluvio-wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b768c170dc045fa587a8f948c91f9bcfb87f774930477c6215addf54317f137f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "flv-util"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de89447c8b4aecfa4c0614d1a7be1c6ab4a0266b59bb2713fd746901f28d124e"
+dependencies = [
+ "log",
+ "tracing",
 ]
 
 [[package]]
@@ -1619,6 +2276,34 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
+name = "futures-lite"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
+dependencies = [
+ "fastrand 2.1.0",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1728,6 +2413,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +2507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,7 +2571,7 @@ dependencies = [
  "ipconfig",
  "lru-cache",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.3",
  "rand",
  "resolv-conf",
  "smallvec",
@@ -1999,6 +2702,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,7 +2734,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -2154,7 +2873,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.4.1",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower",
  "tower-service",
@@ -2252,6 +2971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,6 +3037,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2320,7 +3059,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2",
+ "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -2338,7 +3077,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -2410,10 +3149,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8-types"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1996eb39fe3991c64d32262261d3a37a8a43fcf7bc3a5456ab399f02a50114"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lenient_semver"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
+dependencies = [
+ "lenient_semver_parser",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_parser"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
+dependencies = [
+ "lenient_semver_version_builder",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_version_builder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "libc"
@@ -2439,6 +3226,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
@@ -2458,6 +3251,9 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-cache"
@@ -2466,6 +3262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -2590,7 +3395,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -2680,6 +3485,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,7 +3565,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -2848,6 +3665,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.3.1+3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2855,6 +3681,7 @@ checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2905,13 +3732,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.10",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -3010,6 +3868,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
+]
+
+[[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,7 +3955,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -3096,7 +3964,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
- "siphasher",
+ "siphasher 0.3.11",
 ]
 
 [[package]]
@@ -3132,6 +4000,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.1.0",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,6 +4042,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix 0.38.34",
+ "tracing",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3360,7 +4270,7 @@ checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.7",
  "windows-sys 0.52.0",
 ]
 
@@ -3462,12 +4372,21 @@ dependencies = [
  "rustls-pki-types",
  "ryu",
  "sha1_smol",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-retry",
  "tokio-rustls 0.26.0",
  "tokio-util",
  "url",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3669,6 +4588,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea8ca367a3a01fe35e6943c400addf443c0f57670e6ec51196f71a4b8762dd2"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
@@ -3676,7 +4609,7 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
 ]
 
@@ -3895,6 +4828,15 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -3940,6 +4882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3979,6 +4930,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.74",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4038,6 +5002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4051,6 +5021,22 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "socket2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "socket2"
@@ -4143,7 +5129,7 @@ checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.3",
  "phf_shared 0.10.0",
  "precomputed-hash",
  "serde",
@@ -4312,6 +5298,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "fastembed",
+ "fluvio",
  "futures-util",
  "htmd",
  "indoc",
@@ -4478,8 +5465,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand",
- "rustix",
+ "fastrand 2.1.0",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -4745,10 +5732,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
+ "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -4836,9 +5823,45 @@ checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4865,7 +5888,7 @@ dependencies = [
  "prost",
  "rustls-native-certs 0.7.1",
  "rustls-pemfile 2.1.2",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-rustls 0.26.0",
  "tokio-stream",
@@ -5036,6 +6059,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5047,7 +6080,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20093f826c4866dc7d4808ecd9ed351e3021b94194f25f490f0ea9ea030e1f87"
 dependencies = [
- "fastrand",
+ "fastrand 2.1.0",
  "serde",
  "serde_json",
  "ureq",
@@ -5167,6 +6200,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5240,6 +6279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-bag"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5256,6 +6301,12 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "waker-fn"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -5445,6 +6496,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5566,6 +6626,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5610,14 +6679,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "xattr"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "linux-raw-sys 0.4.14",
+ "rustix 0.38.34",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1778,6 +1778,7 @@ dependencies = [
 name = "examples"
 version = "0.8.0"
 dependencies = [
+ "fluvio",
  "qdrant-client",
  "serde_json",
  "spider",

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Our goal is to create a fast, extendable platform for data indexing and querying
 - Splitting and merging pipelines
 - Jinja-like templating for prompts
 - Store into multiple backends
-- Integrations with OpenAI, Groq, Redis, Qdrant, Ollama, FastEmbed-rs, and Treesitter
+- Integrations with OpenAI, Groq, Redis, Qdrant, Ollama, FastEmbed-rs, Fluvio, and Treesitter
 - Sparse vector support for hybrid search
 - `tracing` supported for logging and tracing, see /examples and the `tracing` crate for more information.
 
@@ -155,7 +155,7 @@ Our goal is to create a fast, extendable platform for data indexing and querying
 | **Feature**                                  | **Details**                                                                                                                                                          |
 | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Supported Large Language Model providers** | OpenAI (and Azure) - All models and embeddings <br> AWS Bedrock - Anthropic and Titan <br> Groq - All models <br> Ollama - All models                                |
-| **Loading data**                             | Files <br> Scraping <br> Other pipelines and streams                                                                                                                 |
+| **Loading data**                             | Files <br> Scraping <br> Fluvio <br> Other pipelines and streams                                                                                                     |
 | **Transformers and metadata generation**     | Generate Question and answerers for both text and code (Hyde) <br> Summaries, titles and queries via an LLM <br> Extract definitions and references with tree-sitter |
 | **Splitting and chunking**                   | Markdown <br> Code (with tree-sitter)                                                                                                                                |
 | **Storage**                                  | Qdrant <br> Redis                                                                                                                                                    |

--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,7 @@ allow = [
   "Unicode-DFS-2016",
   "WTFPL",
   "MPL-2.0",
+  "Unlicense",
 ]
 exceptions = [{ allow = ["OpenSSL"], crate = "ring" }]
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,11 +19,13 @@ swiftide = { path = "../swiftide/", features = [
   "aws-bedrock",
   "groq",
   "ollama",
+  "fluvio",
 ] }
 tracing-subscriber = "0.3"
 serde_json = "1.0"
 spider = "1.98"
 qdrant-client = "1.10.3"
+fluvio = "0.23.1"
 
 [[example]]
 doc-scrape-examples = true
@@ -79,3 +81,7 @@ path = "query_pipeline.rs"
 [[example]]
 name = "hybrid-search"
 path = "hybrid_search.rs"
+
+[[example]]
+name = "fluvio"
+path = "fluvio.rs"

--- a/examples/fluvio.rs
+++ b/examples/fluvio.rs
@@ -1,0 +1,62 @@
+//! # [Swiftide] Loading data from Fluvio
+//!
+//! This example demonstrates how to index the Swiftide codebase itself.
+//! Note that for it to work correctly you need to have OPENAI_API_KEY set, redis and qdrant
+//! running.
+//!
+//! The pipeline will:
+//! - Load all `.rs` files from the current directory
+//! - Skip any nodes previously processed; hashes are based on the path and chunk (not the
+//!   metadata!)
+//! - Run metadata QA on each chunk; generating questions and answers and adding metadata
+//! - Chunk the code into pieces of 10 to 2048 bytes
+//! - Embed the chunks in batches of 10, Metadata is embedded by default
+//! - Store the nodes in Qdrant
+//!
+//! Note that metadata is copied over to smaller chunks when chunking. When making LLM requests
+//! with lots of small chunks, consider the rate limits of the API.
+//!
+//! [Swiftide]: https://github.com/bosun-ai/swiftide
+//! [examples]: https://github.com/bosun-ai/swiftide/blob/master/examples
+
+use swiftide::{
+    indexing::{self, transformers::Embed},
+    integrations::{
+        fastembed::FastEmbed,
+        fluvio::{ConsumerConfigExt, Fluvio},
+        qdrant::Qdrant,
+    },
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
+    static TOPIC_NAME: &str = "hello-rust";
+    static PARTITION_NUM: u32 = 0;
+
+    let loader = Fluvio::builder()
+        .consumer_config_ext(
+            ConsumerConfigExt::builder()
+                .topic(TOPIC_NAME)
+                .partition(PARTITION_NUM)
+                .offset_start(fluvio::Offset::from_end(1))
+                .build()
+                .unwrap(),
+        )
+        .build()
+        .unwrap();
+
+    indexing::Pipeline::from_loader(loader)
+        .then_in_batch(10, Embed::new(FastEmbed::try_default().unwrap()))
+        .then_store_with(
+            Qdrant::builder()
+                .batch_size(50)
+                .vector_size(384)
+                .collection_name("swiftide-examples")
+                .build()?,
+        )
+        .run()
+        .await?;
+    Ok(())
+}

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 regex = { workspace = true }
+futures-util = { workspace = true }
 
 
 # Integrations
@@ -60,6 +61,12 @@ aws-sdk-bedrockruntime = { version = "1.37", features = [
 secrecy = { version = "0.8.0", optional = true }
 reqwest = { version = "0.12.5", optional = true, default-features = false }
 ollama-rs = { version = "0.2.0", optional = true }
+# Unfortunately their rustls version fails to compile
+# fluvio = { version = "0.23", default-features = false, features = [
+#   "compress",
+#   "rustls",
+# ], optional = true }
+fluvio = { version = "0.23", optional = true }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }
@@ -68,7 +75,6 @@ mockall = { workspace = true }
 test-log = { workspace = true }
 testcontainers = { workspace = true }
 test-case = { workspace = true }
-futures-util = { workspace = true }
 indoc = { workspace = true }
 insta = { workspace = true }
 
@@ -105,6 +111,8 @@ aws-bedrock = [
   "dep:aws-credential-types",
   "dep:aws-sdk-bedrockruntime",
 ]
+# Fluvio loader
+fluvio = ["dep:fluvio"]
 
 [lints]
 workspace = true

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -71,6 +71,9 @@ fluvio = { version = "0.23", optional = true }
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }
 
+# Used for hacking fluv to play nice
+flv-util = "0.5.2"
+
 mockall = { workspace = true }
 test-log = { workspace = true }
 testcontainers = { workspace = true }

--- a/swiftide-integrations/src/fluvio/loader.rs
+++ b/swiftide-integrations/src/fluvio/loader.rs
@@ -1,5 +1,6 @@
 use std::string::ToString;
 
+use anyhow::Context as _;
 use futures_util::{StreamExt as _, TryStreamExt as _};
 use swiftide_core::{indexing::IndexingStream, indexing::Node, Loader};
 use tokio::runtime::Handle;
@@ -9,12 +10,19 @@ use super::Fluvio;
 impl Loader for Fluvio {
     #[tracing::instrument]
     fn into_stream(self) -> IndexingStream {
-        let config = self.consumer_config_ext;
+        let fluvio_config = self.fluvio_config;
+        let consumer_config = self.consumer_config_ext;
 
         let stream = tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
-                let client = fluvio::Fluvio::connect().await?;
-                client.consumer_with_config(config).await
+                let client = if let Some(fluvio_config) = &fluvio_config {
+                    fluvio::Fluvio::connect_with_config(fluvio_config).await
+                } else {
+                    fluvio::Fluvio::connect().await
+                }
+                .context(format!("Failed to connect to Fluvio {fluvio_config:?}"))
+                .unwrap();
+                client.consumer_with_config(consumer_config).await
             })
         })
         .expect("Failed to connect to Fluvio");
@@ -30,5 +38,231 @@ impl Loader for Fluvio {
             .map_err(anyhow::Error::from);
 
         swiftide_stream.boxed().into()
+    }
+}
+
+// Test fluvio with testcontainers, manually connect the Loader to the testcontainer and use a
+// fluvio client to send a test message, then assert that the message is received by the Loader
+#[cfg(test)]
+mod tests {
+    use std::{pin::Pin, time::Duration};
+
+    use super::*;
+    use fluvio::{
+        consumer::ConsumerConfigExt,
+        metadata::{customspu::CustomSpuSpec, topic::TopicSpec},
+        RecordKey,
+    };
+    use flv_util::socket_helpers::ServerAddress;
+    use futures_util::TryStreamExt;
+    use indoc::{formatdoc, indoc};
+    use itertools::Itertools;
+    use regex::Regex;
+    use testcontainers::{runners::AsyncRunner, ContainerAsync, GenericImage, ImageExt};
+    use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+
+    struct FluvioCluster {
+        sc: ContainerAsync<GenericImage>,
+        spu: ContainerAsync<GenericImage>,
+
+        // topic_name: String,
+        // partition_num: u32,
+        // partitions: u32,
+        // replicas: u32,
+        port: u16,
+        host_spu_port: u16,
+        host: String,
+    }
+
+    impl FluvioCluster {
+        pub async fn start() -> FluvioCluster {
+            static SC_PORT: u16 = 9003;
+            static SPU_PORT1: u16 = 9010;
+            static SPU_PORT2: u16 = 9011;
+            static NETWORK_NAME: &str = "fluvio";
+
+            let sc = GenericImage::new("infinyon/fluvio", "latest")
+                .with_exposed_port(SC_PORT.into())
+                .with_wait_for(testcontainers::core::WaitFor::message_on_stdout(
+                    "started successfully",
+                ))
+                .with_network(NETWORK_NAME)
+                .with_container_name("sc")
+                .with_cmd("./fluvio-run sc --local /fluvio/metadata".split(' '))
+                .with_env_var("RUST_LOG", "info")
+                .start()
+                .await
+                .expect("Failed to start fluvio");
+
+            let spu = GenericImage::new("infinyon/fluvio", "latest")
+                .with_exposed_port(SPU_PORT1.into())
+                .with_wait_for(testcontainers::core::WaitFor::message_on_stdout(
+                    "started successfully",
+                ))
+                .with_network(NETWORK_NAME)
+                .with_container_name("spu")
+                // .with_exposed_port(SPU_PORT2.into())
+                .with_cmd(format!("./fluvio-run spu -i 5001 -p spu:{SPU_PORT1} -v spu:{SPU_PORT2} --sc-addr sc:9004 --log-base-dir /fluvio/data").split(" "))
+                .with_env_var("RUST_LOG", "info")
+                .start()
+                .await
+                .expect("Failed to start fluvio");
+
+            let host_spu_port_1 = spu.get_host_port_ipv4(SPU_PORT1).await.unwrap();
+            let host = sc.get_host().await.unwrap().to_string();
+
+            // let entrypoint = formatdoc!(r#"
+            //     /bin/sh -c "
+            //         fluvio profile add docker sc:{SC_PORT} docker;
+            //         fluvio cluster spu register --id 5001 -p 0.0.0.0:{host_spu_port_1} --private-server spu:{SPU_PORT2};
+            //         exit 0;
+            //     "
+            //     "#).replace('\n', "");
+            //
+            // dbg!(&entrypoint);
+            //
+            // GenericImage::
+            // let sc_setup = GenericImage::new("infinyon/fluvio", "latest")
+            //     .with_entrypoint(&entrypoint)
+            //     .with_network(NETWORK_NAME)
+            //     // .with_cmd(entrypoint.split(" "))
+            //     .with_env_var("RUST_LOG", "info")
+            //     .start()
+            //     .await
+            //     .expect("Failed to start fluvio");
+            //
+            let sc_host_port = sc.get_host_port_ipv4(SC_PORT).await.unwrap();
+
+            FluvioCluster {
+                sc,
+                spu,
+                port: sc_host_port,
+                host_spu_port: host_spu_port_1,
+                host,
+            }
+        }
+
+        pub fn forward_logs_to_tracing(&self) {
+            Self::log_stdout(self.sc.stdout(true));
+            Self::log_stderr(self.sc.stderr(true));
+
+            Self::log_stdout(self.spu.stdout(true));
+            Self::log_stderr(self.spu.stderr(true));
+        }
+
+        fn log_stdout(reader: Pin<Box<dyn AsyncBufRead + Send>>) {
+            let regex = Self::ansii_regex();
+            tokio::spawn(async move {
+                let mut lines = reader.lines();
+                while let Some(line) = lines.next_line().await.unwrap() {
+                    let line = regex.replace_all(&line, "").to_string();
+                    tracing::info!(line);
+                }
+            });
+        }
+
+        fn log_stderr(reader: Pin<Box<dyn AsyncBufRead + Send>>) {
+            let regex = Self::ansii_regex();
+            tokio::spawn(async move {
+                let mut lines = reader.lines();
+                while let Some(line) = lines.next_line().await.unwrap() {
+                    let line = regex.replace_all(&line, "").to_string();
+                    tracing::error!(line);
+                }
+            });
+        }
+
+        fn ansii_regex() -> Regex {
+            regex::Regex::new(r"\x1b\[([\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e])").unwrap()
+        }
+
+        pub fn endpoint(&self) -> String {
+            // format!("{}:{}", self.host, self.port)
+            format!("127.0.0.1:{}", self.port)
+        }
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_fluvio_loader() {
+        static TOPIC_NAME: &str = "hello-rust";
+        static PARTITION_NUM: u32 = 0;
+        static PARTITIONS: u32 = 1;
+        static REPLICAS: u32 = 1;
+
+        let fluvio_cluster = FluvioCluster::start().await;
+        fluvio_cluster.forward_logs_to_tracing();
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let config = fluvio::FluvioConfig::new(fluvio_cluster.endpoint());
+
+        dbg!(&config);
+        let client = fluvio::Fluvio::connect_with_config(&config).await.unwrap();
+
+        // Create a topic
+        let admin = client.admin().await;
+
+        //         fluvio cluster spu register --id 5001 -p 0.0.0.0:{host_spu_port_1} --private-server spu:{SPU_PORT2};
+        let spu_spec = CustomSpuSpec {
+            id: 5001,
+            public_endpoint: ServerAddress::try_from(format!(
+                "0.0.0.0:{}",
+                fluvio_cluster.host_spu_port
+            ))
+            .unwrap()
+            .into(),
+            private_endpoint: ServerAddress::try_from(format!("spu:{}", 9011))
+                .unwrap()
+                .into(),
+            rack: None,
+            public_endpoint_local: None,
+        };
+
+        admin
+            .create("SPU".to_string(), false, spu_spec)
+            .await
+            .unwrap();
+        // assert!(false);
+        let topic_spec = TopicSpec::new_computed(PARTITIONS, REPLICAS, None);
+        let _result = admin
+            .create(TOPIC_NAME.to_string(), false, topic_spec)
+            .await;
+
+        let producer = client.topic_producer(TOPIC_NAME).await.unwrap();
+        producer
+            .send(RecordKey::NULL, "Hello fluvio")
+            .await
+            .unwrap();
+        producer.flush().await.unwrap();
+
+        // Consume the topic with the loader
+        let loader = Fluvio::builder()
+            .fluvio_config(&config)
+            .consumer_config_ext(
+                ConsumerConfigExt::builder()
+                    .topic(TOPIC_NAME)
+                    .partition(PARTITION_NUM)
+                    .offset_start(fluvio::Offset::from_end(1))
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let node: Node = loader.into_stream().try_next().await.unwrap().unwrap();
+
+        assert_eq!(node.chunk, "Hello fluvio");
+
+        // let runner = AsyncRunner::new();
+        // let fluvio = runner.run(fluvio_image);
+        // let fluvio = fluvio.await.unwrap();
+        // let fluvio_address = format!("{}:{}", fluvio.host(), 9003);
+        // let fluvio = Fluvio::new(fluvio_address, "test-topic".to_owned());
+        // let stream = fluvio.into_stream();
+        // let mut stream = stream.take(1);
+        // let fluvio_client = fluvio::Fluvio::connect().await.unwrap();
+        // let producer = fluvio_client.topic_producer("test-topic").await.unwrap();
+        // producer.send_record("test-message".into()).await.unwrap();
+        // let node = stream.next().await.unwrap().unwrap();
+        // assert_eq!(node.name, "test-message");
     }
 }

--- a/swiftide-integrations/src/fluvio/loader.rs
+++ b/swiftide-integrations/src/fluvio/loader.rs
@@ -182,7 +182,7 @@ mod tests {
         }
     }
 
-    #[test_log::test(tokio::test)]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_fluvio_loader() {
         static TOPIC_NAME: &str = "hello-rust";
         static PARTITION_NUM: u32 = 0;
@@ -251,18 +251,5 @@ mod tests {
         let node: Node = loader.into_stream().try_next().await.unwrap().unwrap();
 
         assert_eq!(node.chunk, "Hello fluvio");
-
-        // let runner = AsyncRunner::new();
-        // let fluvio = runner.run(fluvio_image);
-        // let fluvio = fluvio.await.unwrap();
-        // let fluvio_address = format!("{}:{}", fluvio.host(), 9003);
-        // let fluvio = Fluvio::new(fluvio_address, "test-topic".to_owned());
-        // let stream = fluvio.into_stream();
-        // let mut stream = stream.take(1);
-        // let fluvio_client = fluvio::Fluvio::connect().await.unwrap();
-        // let producer = fluvio_client.topic_producer("test-topic").await.unwrap();
-        // producer.send_record("test-message".into()).await.unwrap();
-        // let node = stream.next().await.unwrap().unwrap();
-        // assert_eq!(node.name, "test-message");
     }
 }

--- a/swiftide-integrations/src/fluvio/loader.rs
+++ b/swiftide-integrations/src/fluvio/loader.rs
@@ -1,0 +1,34 @@
+use std::string::ToString;
+
+use futures_util::{StreamExt as _, TryStreamExt as _};
+use swiftide_core::{indexing::IndexingStream, indexing::Node, Loader};
+use tokio::runtime::Handle;
+
+use super::Fluvio;
+
+impl Loader for Fluvio {
+    #[tracing::instrument]
+    fn into_stream(self) -> IndexingStream {
+        let config = self.consumer_config_ext;
+
+        let stream = tokio::task::block_in_place(|| {
+            Handle::current().block_on(async {
+                let client = fluvio::Fluvio::connect().await?;
+                client.consumer_with_config(config).await
+            })
+        })
+        .expect("Failed to connect to Fluvio");
+
+        let swiftide_stream = stream
+            .map_ok(|f| {
+                let mut node = Node::new(f.get_value().to_string());
+                node.metadata
+                    .insert("fluvio_key", f.get_key().map(ToString::to_string));
+
+                node
+            })
+            .map_err(anyhow::Error::from);
+
+        swiftide_stream.boxed().into()
+    }
+}

--- a/swiftide-integrations/src/fluvio/mod.rs
+++ b/swiftide-integrations/src/fluvio/mod.rs
@@ -1,7 +1,23 @@
 //! Fluvio is a real-time streaming data transformation platform.
 //!
 //! This module provides a Fluvio loader for Swiftide and allows you to ingest
-//! messages from Fluvio topics and use them for RAG
+//! messages from Fluvio topics and use them for RAG.
+//!
+//! Can be configured with [`ConsumerConfigExt`].
+//!
+//! # Example
+//!
+//! ```no_run
+//! # use swiftide_integrations::fluvio::*;
+//! let loader = Fluvio::builder()
+//!     .consumer_config_ext(
+//!         ConsumerConfigExt::builder()
+//!             .topic("Hello Fluvio")
+//!             .partition(0)
+//!             .offset_start(fluvio::Offset::from_end(1))
+//!             .build().unwrap()
+//!     ).build().unwrap();
+//! ```
 
 use derive_builder::Builder;
 
@@ -18,10 +34,12 @@ pub struct Fluvio {
     consumer_config_ext: ConsumerConfigExt,
 
     #[builder(default, setter(custom))]
+    /// Custom connection configuration
     fluvio_config: Option<FluvioConfig>,
 }
 
 impl Fluvio {
+    /// Creates a new Fluvio instance from a consumer extended configuration
     pub fn from_consumer_config(config: impl Into<ConsumerConfigExt>) -> Fluvio {
         Fluvio {
             consumer_config_ext: config.into(),

--- a/swiftide-integrations/src/fluvio/mod.rs
+++ b/swiftide-integrations/src/fluvio/mod.rs
@@ -4,8 +4,10 @@
 //! messages from Fluvio topics and use them for RAG
 
 use derive_builder::Builder;
+
 /// Re-export the fluvio config builder
 pub use fluvio::consumer::{ConsumerConfigExt, ConsumerConfigExtBuilder};
+use fluvio::FluvioConfig;
 
 mod loader;
 
@@ -14,4 +16,28 @@ mod loader;
 pub struct Fluvio {
     /// The Fluvio consumer configuration to use.
     consumer_config_ext: ConsumerConfigExt,
+
+    #[builder(default, setter(custom))]
+    fluvio_config: Option<FluvioConfig>,
+}
+
+impl Fluvio {
+    pub fn from_consumer_config(config: impl Into<ConsumerConfigExt>) -> Fluvio {
+        Fluvio {
+            consumer_config_ext: config.into(),
+            fluvio_config: None,
+        }
+    }
+
+    pub fn builder() -> FluvioBuilder {
+        FluvioBuilder::default()
+    }
+}
+
+impl FluvioBuilder {
+    pub fn fluvio_config(&mut self, config: &FluvioConfig) -> &mut Self {
+        self.fluvio_config = Some(Some(config.to_owned()));
+
+        self
+    }
 }

--- a/swiftide-integrations/src/fluvio/mod.rs
+++ b/swiftide-integrations/src/fluvio/mod.rs
@@ -1,0 +1,17 @@
+//! Fluvio is a real-time streaming data transformation platform.
+//!
+//! This module provides a Fluvio loader for Swiftide and allows you to ingest
+//! messages from Fluvio topics and use them for RAG
+
+use derive_builder::Builder;
+/// Re-export the fluvio config builder
+pub use fluvio::consumer::{ConsumerConfigExt, ConsumerConfigExtBuilder};
+
+mod loader;
+
+#[derive(Debug, Clone, Builder)]
+#[builder(setter(into, strip_option))]
+pub struct Fluvio {
+    /// The Fluvio consumer configuration to use.
+    consumer_config_ext: ConsumerConfigExt,
+}

--- a/swiftide-integrations/src/lib.rs
+++ b/swiftide-integrations/src/lib.rs
@@ -4,6 +4,8 @@
 pub mod aws_bedrock;
 #[cfg(feature = "fastembed")]
 pub mod fastembed;
+#[cfg(feature = "fluvio")]
+pub mod fluvio;
 #[cfg(feature = "groq")]
 pub mod groq;
 #[cfg(feature = "ollama")]

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -22,15 +22,15 @@ swiftide-query = { path = "../swiftide-query", version = "0.8" }
 [features]
 default = []
 all = [
-    "qdrant",
-    "redis",
-    "tree-sitter",
-    "openai",
-    "fastembed",
-    "scraping",
-    "aws-bedrock",
-    "groq",
-    "ollama",
+  "qdrant",
+  "redis",
+  "tree-sitter",
+  "openai",
+  "fastembed",
+  "scraping",
+  "aws-bedrock",
+  "groq",
+  "ollama",
 ]
 # Qdrant for storage
 qdrant = ["swiftide-integrations/qdrant"]
@@ -38,8 +38,8 @@ qdrant = ["swiftide-integrations/qdrant"]
 redis = ["swiftide-integrations/redis"]
 # Tree-sitter for code operations and chunking
 tree-sitter = [
-    "swiftide-integrations/tree-sitter",
-    "swiftide-indexing/tree-sitter",
+  "swiftide-integrations/tree-sitter",
+  "swiftide-indexing/tree-sitter",
 ]
 # OpenAI for embedding and prompting
 openai = ["swiftide-integrations/openai"]
@@ -53,6 +53,7 @@ fastembed = ["swiftide-integrations/fastembed"]
 scraping = ["swiftide-integrations/scraping"]
 # AWS Bedrock for prompting
 aws-bedrock = ["swiftide-integrations/aws-bedrock"]
+fluvio = ["swiftide-integrations/fluvio"]
 
 # Testing, internal only
 test-utils = []
@@ -63,7 +64,7 @@ swiftide-test-utils = { path = "../swiftide-test-utils" }
 
 async-openai = { workspace = true }
 qdrant-client = { workspace = true, default-features = false, features = [
-    "serde",
+  "serde",
 ] }
 
 anyhow = { workspace = true }


### PR DESCRIPTION
Adds Fluvio as a loader support, enabling Swiftide indexing streams to process messages from a Fluvio topic.

Closes #240