### PR TITLE
feat(query): hybrid search for qdrant in query pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ A query stream starts with a search strategy. In the query pipeline a `Query` go
 That sounds like a lot but, tl&dr; the query pipeline is _fully and strongly typed_.
 
 - **Pending** The query has not been executed, and can be further transformed with transformers
-- **Retrieved** Documents have been retrieved, and can be futher transformed to provide context for an answer
+- **Retrieved** Documents have been retrieved, and can be further transformed to provide context for an answer
 - **Answered** The query is done
 
 Additionally, query pipelines can also be evaluated. I.e. by [Ragas](https://ragas.io).

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Our goal is to create a fast, extendable platform for Retrieval Augmented Genera
 | **Transformers and metadata generation**     | Generate Question and answerers for both text and code (Hyde) <br> Summaries, titles and queries via an LLM <br> Extract definitions and references with tree-sitter |
 | **Splitting and chunking**                   | Markdown <br> Code (with tree-sitter)                                                                                                                                |
 | **Storage**                                  | Qdrant <br> Redis <br> LanceDB                                                                                                                                       |
+| **Query pipeline**                           | Similarity and hybrid search, query and response transformations, and evaluation                                                                                     |
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -217,9 +218,16 @@ Other integrations might have their own requirements.
 
 ## Usage and concepts
 
-Before building your stream, you need to enable and configure any integrations required. See /examples.
+Before building your streams, you need to enable and configure any integrations required. See /examples.
 
-A stream starts with a Loader that emits Nodes. For instance, with the Fileloader each file is a Node.
+_We have a lot of examples, please refer to /examples and the [Documentation](https://docs.rs/swiftide/latest/swiftide/)_
+
+> [!NOTE]
+> No integrations are enabled by default as some are code heavy. We recommend you to cherry-pick the integrations you need. By convention flags have the same name as the integration they represent.
+
+### Indexing
+
+An indexing stream starts with a Loader that emits Nodes. For instance, with the Fileloader each file is a Node.
 
 You can then slice and dice, augment, and filter nodes. Each different kind of step in the pipeline requires different traits. This enables extension.
 
@@ -234,13 +242,22 @@ Nodes have a path, chunk and metadata. Currently metadata is copied over when ch
 
 Additionally, several generic transformers are implemented. They take implementers of `SimplePrompt` and `EmbedModel` to do their things.
 
-> [!NOTE]
-> No integrations are enabled by default as some are code heavy. We recommend you to cherry-pick the integrations you need. By convention flags have the same name as the integration they represent.
-
 > [!WARNING]
 > Due to the performance, chunking before adding metadata gives rate limit errors on OpenAI very fast, especially with faster models like 3.5-turbo. Be aware.
 
-_For more examples, please refer to /examples and the [Documentation](https://docs.rs/swiftide/latest/swiftide/)_
+### Querying
+
+A query stream starts with a search strategy. In the query pipeline a `Query` goes through several stages. Transformers and retrievers work together to get the right context into a prompt, before generating an answer. Transformers and Retrievers operate on different stages of the Query via a generic statemachine. Additionally, the search strategy is generic over the pipeline and Retrievers need to implement specifically for each strategy.
+
+That sounds like a lot but, tl&dr; the query pipeline is _fully and strongly typed_.
+
+- **Pending** The query has not been executed, and can be further transformed with transformers
+- **Retrieved** Documents have been retrieved, and can be futher transformed to provide context for an answer
+- **Answered** The query is done
+
+Additionally, query pipelines can also be evaluated. I.e. by [Ragas](https://ragas.io).
+
+Similar to the indexing pipeline each step is governed by simple Traits and closures implement these traits as well.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/examples/hybrid_search.rs
+++ b/examples/hybrid_search.rs
@@ -5,15 +5,15 @@
 //! [Swiftide]: https://github.com/bosun-ai/swiftide
 //! [examples]: https://github.com/bosun-ai/swiftide/blob/master/examples
 
-use qdrant_client::qdrant::{Fusion, PrefetchQueryBuilder, Query, QueryPointsBuilder, VectorInput};
 use swiftide::{
     indexing::{
         self,
         loaders::FileLoader,
-        transformers::{self, ChunkCode},
-        EmbeddedField, EmbeddingModel as _, SparseEmbeddingModel as _,
+        transformers::{self, ChunkCode, MetadataQACode},
+        EmbeddedField,
     },
-    integrations::{fastembed::FastEmbed, qdrant::Qdrant},
+    integrations::{fastembed::FastEmbed, groq, openai, qdrant::Qdrant},
+    query::{self, answers, query_transformers, search_strategies::HybridSearch},
 };
 
 #[tokio::main]
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
     // Ensure all batching is consistent
-    let batch_size = 256;
+    let batch_size = 64;
 
     let fastembed_sparse = FastEmbed::try_default_sparse()
         .unwrap()
@@ -32,77 +32,203 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_batch_size(batch_size)
         .to_owned();
 
+    // Set up openai with the mini model, which is great for indexing
+    let openai = openai::OpenAI::builder()
+        .default_prompt_model("gpt-4o-mini")
+        .build()
+        .unwrap();
+
+    // Set up qdrant and use the combined fields (metadata + chunks) for both sparse and dense
+    // vectors
+    let qdrant = Qdrant::builder()
+        .batch_size(batch_size)
+        .vector_size(384)
+        .with_vector(EmbeddedField::Combined)
+        .with_sparse_vector(EmbeddedField::Combined)
+        .collection_name("swiftide-hybrid-example")
+        .build()?;
+
     indexing::Pipeline::from_loader(FileLoader::new("swiftide-core/").with_extensions(&["rs"]))
+        // Chunk fairly large as the context window is big
         .then_chunk(ChunkCode::try_for_language_and_chunk_size(
             "rust",
             10..2048,
         )?)
+        // Generate metadata on the code chunks to increase our chances of finding the right code
+        .then(MetadataQACode::from_client(openai.clone()).build().unwrap())
         .then_in_batch(
             batch_size,
             transformers::SparseEmbed::new(fastembed_sparse.clone()),
         )
         .then_in_batch(batch_size, transformers::Embed::new(fastembed.clone()))
-        .then_store_with(
-            Qdrant::builder()
-                .batch_size(batch_size)
-                .vector_size(384)
-                .with_vector(EmbeddedField::Combined)
-                .with_sparse_vector(EmbeddedField::Combined)
-                .collection_name("swiftide-hybrid")
-                .build()?,
-        )
+        .then_store_with(qdrant.clone())
         .run()
         .await?;
 
-    let query = "Where is the indexing pipeline defined?";
-
-    let sparse = fastembed_sparse
-        .sparse_embed(vec![query.to_string()])
-        .await?
-        .first()
-        .unwrap()
-        .to_owned();
-
-    let dense = fastembed
-        .embed(vec![query.to_string()])
-        .await?
-        .first()
-        .unwrap()
-        .to_owned();
-
-    let qdrant = qdrant_client::Qdrant::from_url("http://localhost:6334")
+    // Use sophisticated model for our query
+    let openai = openai::OpenAI::builder()
+        .default_prompt_model("gpt-4o")
         .build()
         .unwrap();
 
-    let search_response = qdrant
-        .query(
-            QueryPointsBuilder::new("swiftide-hybrid")
-                .with_payload(true)
-                .add_prefetch(
-                    PrefetchQueryBuilder::default()
-                        .query(Query::new_nearest(VectorInput::new_sparse(
-                            sparse.indices,
-                            sparse.values,
-                        )))
-                        .using("Combined_sparse")
-                        .limit(20u64),
-                )
-                .add_prefetch(
-                    PrefetchQueryBuilder::default()
-                        .query(Query::new_nearest(dense))
-                        .using("Combined")
-                        .limit(20u64),
-                )
-                .query(Query::new_fusion(Fusion::Rrf)),
-        )
+    let query_pipeline = query::Pipeline::from_search_strategy(
+        // Return a large amount of documents because we have a large context window
+        // By default it uses the Combined fields, no need to configure
+        HybridSearch::default()
+            .with_top_n(20)
+            .with_top_k(20)
+            .to_owned(),
+    )
+    // Generate subquestions on the initial query to increase our query coverage
+    .then_transform_query(query_transformers::GenerateSubquestions::from_client(
+        openai.clone(),
+    ))
+    // Generate the same embeddings we used for indexing
+    .then_transform_query(query_transformers::Embed::from_client(fastembed.clone()))
+    .then_transform_query(query_transformers::SparseEmbed::from_client(
+        fastembed_sparse.clone(),
+    ))
+    .then_retrieve(qdrant.clone())
+    // Answer with Simple, which either takes the documents as is (in this case), or any transformations applied
+    // after querying
+    .then_answer(answers::Simple::from_client(openai.clone()));
+
+    let answer = query_pipeline
+        .query("What are the different pipelines in Swiftide and how do they work? Provide an elaborate answer with examples.")
         .await
         .unwrap();
 
-    for result in search_response.result {
-        println!("---");
-        println!("{:?}", result);
-        println!("---");
-    }
+    println!("{}", answer.answer());
+
+    // ## Different Pipelines in Swiftide and How They Work
+    //
+    // Swiftide offers multiple pipelines, notably the indexing pipeline and the query pipeline. The functionality of these pipelines is enhanced using traits and components like transformers, stream handlers, and more. Below we elaborate on the key components and how they become part of the larger pipeline system:
+    //
+    // ### Indexing Pipeline
+    //
+    // 1. **Transformers**:
+    //     - **Transformer Trait**: Transforms single nodes into single nodes. Mainly used for transforming data in a singular manner.
+    //     - **BatchableTransformer Trait**: Transforms a batch of nodes into a stream of nodes, useful for bulk processing.
+    //
+    //     ```rust
+    //     #[async_trait]
+    //     pub trait Transformer: Send + Sync {
+    //         async fn transform_node(&self, node: Node) -> Result<Node>;
+    //         fn concurrency(&self) -> Option<usize> { None }
+    //     }
+    //
+    //     #[async_trait]
+    //     impl<F> Transformer for F where F: Fn(Node) -> Result<Node> + Send + Sync {
+    //         async fn transform_node(&self, node: Node) -> Result<Node> {
+    //             self(node)
+    //         }
+    //     }
+    //
+    //     #[async_trait]
+    //     pub trait BatchableTransformer: Send + Sync {
+    //         async fn batch_transform(&self, nodes: Vec<Node>) -> IndexingStream;
+    //         fn concurrency(&self) -> Option<usize> { None }
+    //     }
+    //
+    //     #[async_trait]
+    //     impl<F> BatchableTransformer for F where F: Fn(Vec<Node>) -> IndexingStream + Send + Sync {
+    //         async fn batch_transform(&self, nodes: Vec<Node>) -> IndexingStream {
+    //             self(nodes)
+    //         }
+    //     }
+    //     ```
+    //
+    // 2. **Loaders**:
+    //     - Defines methods for converting a loader into an `IndexingStream`.
+    //
+    //     ```rust
+    //     pub trait Loader {
+    //         fn into_stream(self) -> IndexingStream;
+    //     }
+    //     ```
+    //
+    // 3. **Chunker Transformers**:
+    //     - Splits one node into multiple nodes. It's useful for breaking down large nodes into smaller, manageable chunks.
+    //
+    //     ```rust
+    //     #[async_trait]
+    //     pub trait ChunkerTransformer: Send + Sync + Debug {
+    //         async fn transform_node(&self, node: Node) -> IndexingStream;
+    //         fn concurrency(&self) -> Option<usize> { None }
+    //     }
+    //     ```
+    //
+    // 4. **IndexingStream**:
+    //     - An asynchronous stream of nodes, used internally by the indexing pipeline to handle streams of `Node` items.
+    //
+    //     ```rust
+    //     pub struct IndexingStream {
+    //         #[pin]
+    //         pub(crate) inner: Pin<Box<dyn Stream<Item = Result<Node>> + Send>>,
+    //     }
+    //     ```
+    //
+    // ### Query Pipeline
+    //
+    // 1. **QueryStream**:
+    //     - Handles query streams, ensuring data flows correctly through various query states.
+    //
+    //     ```rust
+    //     pub struct QueryStream<'stream, Q: 'stream> {
+    //         #[pin]
+    //         pub(crate) inner: Pin<Box<dyn Stream<Item = Result<Query<Q>>> + Send + 'stream>>,
+    //         #[pin]
+    //         pub sender: Option<Sender<Result<Query<Q>>>>,
+    //     }
+    //     ```
+    //
+    // 2. **Query Handling**:
+    //     - Various state transitions and handling for queries in the pipeline.
+    //
+    //     ```rust
+    //     pub struct Query<State> {
+    //         original: String,
+    //         current: String,
+    //         state: State,
+    //         transformation_history: Vec<TransformationEvent>,
+    //         pub embedding: Option<Embedding>,
+    //         pub sparse_embedding: Option<SparseEmbedding>,
+    //     }
+    //     ```
+    //
+    // ### Extending the Pipeline with Traits
+    //
+    // Swiftide allows developers to extend the pipeline by implementing custom transformers, loaders, and other components by implementing the respective traits. This design ensures flexibility and modularity, allowing seamless integration of custom functionality.
+    //
+    // For example, to create a custom transformer:
+    // ```rust
+    // use crate::node::Node;
+    // use anyhow::Result;
+    //
+    // struct MyCustomTransformer;
+    //
+    // #[async_trait]
+    // impl Transformer for MyCustomTransformer {
+    //     async fn transform_node(&self, node: Node) -> Result<Node> {
+    //         // Custom transformation logic here...
+    //         Ok(node)
+    //     }
+    // }
+    // ```
+    //
+    // ### Usage of Prompts in Transformers
+    //
+    // Swiftide utilizes the [`PromptTemplate`] for templating prompts, making it easy to define and manage prompts within transformers.
+    //
+    // ```rust
+    // let template = PromptTemplate::try_compiled_from_str("hello {{world}}").await.unwrap();
+    // let prompt = template.to_prompt().with_context_value("world", "swiftide");
+    // assert_eq!(prompt.render().await.unwrap(), "hello swiftide");
+    // ```
+    //
+    // ### Conclusion
+    //
+    // The Indexing and Query Pipelines in Swiftide are made extensible and modular via traits such as `Transformer`, `BatchableTransformer`, `Loader`, and more. Custom implementations can seamlessly integrate into the pipeline, providing flexibility in how data is processed, transformed, and indexed. The use of prompts further enhances the capability to manage dynamic and templated data within these pipelines.
 
     Ok(())
 }

--- a/examples/hybrid_search.rs
+++ b/examples/hybrid_search.rs
@@ -12,7 +12,7 @@ use swiftide::{
         transformers::{self, ChunkCode, MetadataQACode},
         EmbeddedField,
     },
-    integrations::{fastembed::FastEmbed, groq, openai, qdrant::Qdrant},
+    integrations::{fastembed::FastEmbed, openai, qdrant::Qdrant},
     query::{self, answers, query_transformers, search_strategies::HybridSearch},
 };
 

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -7,7 +7,7 @@
 //! `states::Answered`: The query has been answered
 use derive_builder::Builder;
 
-use crate::Embedding;
+use crate::{Embedding, SparseEmbedding};
 
 type Document = String;
 
@@ -31,6 +31,9 @@ pub struct Query<State> {
     // TODO: How would this work when doing a rollup query?
     #[builder(default)]
     pub embedding: Option<Embedding>,
+
+    #[builder(default)]
+    pub sparse_embedding: Option<SparseEmbedding>,
 }
 
 impl<T: std::fmt::Debug> std::fmt::Debug for Query<T> {
@@ -67,6 +70,7 @@ impl<T: Clone> Query<T> {
             current: self.current,
             transformation_history: self.transformation_history,
             embedding: self.embedding,
+            sparse_embedding: self.sparse_embedding,
         }
     }
 

--- a/swiftide-core/src/search_strategies.rs
+++ b/swiftide-core/src/search_strategies.rs
@@ -1,4 +1,3 @@
-
 use derive_builder::Builder;
 
 const DEFAULT_TOP_K: u64 = 10;

--- a/swiftide-core/src/search_strategies.rs
+++ b/swiftide-core/src/search_strategies.rs
@@ -1,4 +1,3 @@
-use std::thread::Builder;
 
 use derive_builder::Builder;
 

--- a/swiftide-core/src/search_strategies.rs
+++ b/swiftide-core/src/search_strategies.rs
@@ -2,6 +2,9 @@ use std::thread::Builder;
 
 use derive_builder::Builder;
 
+const DEFAULT_TOP_K: u64 = 10;
+const DEFAULT_TOP_N: u64 = 10;
+
 /// Search strategies provide a generic way for Retrievers to implement their
 /// search in various ways.
 ///
@@ -17,7 +20,9 @@ pub struct SimilaritySingleEmbedding {
 }
 
 /// A hybrid search strategy that combines a similarity search with a
-/// keyword search.
+/// keyword search / sparse search.
+///
+/// Defaults to a a maximum of 10 documents and `EmbeddedField::Combined` for the field(s).
 #[derive(Debug, Clone, Builder)]
 #[builder(setter(into))]
 pub struct HybridSearch {
@@ -41,8 +46,8 @@ pub struct HybridSearch {
 impl Default for HybridSearch {
     fn default() -> Self {
         Self {
-            top_k: 10,
-            top_n: 10,
+            top_k: DEFAULT_TOP_K,
+            top_n: DEFAULT_TOP_N,
             dense_vector_field: EmbeddedField::Combined,
             sparse_vector_field: EmbeddedField::Combined,
         }
@@ -50,20 +55,28 @@ impl Default for HybridSearch {
 }
 
 impl HybridSearch {
+    /// Sets the maximum amount of total documents retrieved
     pub fn with_top_k(&mut self, top_k: u64) -> &mut Self {
         self.top_k = top_k;
         self
     }
+    /// Returns the maximum amount of total documents to be retrieved
     pub fn top_k(&self) -> u64 {
         self.top_k
     }
+    /// Sets the maximum amount of documents to be retrieved
+    /// per individual query
     pub fn with_top_n(&mut self, top_n: u64) -> &mut Self {
         self.top_n = top_n;
         self
     }
+    /// Returns the maximum amount of documents per query
     pub fn top_n(&self) -> u64 {
         self.top_n
     }
+    /// Sets the vector field for the dense vector
+    ///
+    /// Defaults to `EmbeddedField::Combined`
     pub fn with_dense_vector_field(
         &mut self,
         dense_vector_field: impl Into<EmbeddedField>,
@@ -71,9 +84,14 @@ impl HybridSearch {
         self.dense_vector_field = dense_vector_field.into();
         self
     }
+
+    /// Returns the field for the dense vector
     pub fn dense_vector_field(&self) -> &EmbeddedField {
         &self.dense_vector_field
     }
+    /// Sets the vector field for the sparse vector (if applicable)
+    ///
+    /// Defaults to `EmbeddedField::Combined`
     pub fn with_sparse_vector_field(
         &mut self,
         sparse_vector_field: impl Into<EmbeddedField>,
@@ -81,6 +99,8 @@ impl HybridSearch {
         self.sparse_vector_field = sparse_vector_field.into();
         self
     }
+
+    /// Returns the field for the dense vector
     pub fn sparse_vector_field(&self) -> &EmbeddedField {
         &self.sparse_vector_field
     }
@@ -88,16 +108,21 @@ impl HybridSearch {
 
 impl Default for SimilaritySingleEmbedding {
     fn default() -> Self {
-        Self { top_k: 10 }
+        Self {
+            top_k: DEFAULT_TOP_K,
+        }
     }
 }
 
 impl SimilaritySingleEmbedding {
+    /// Set the maximum amount of documents to be returned
     pub fn with_top_k(&mut self, top_k: u64) -> &mut Self {
         self.top_k = top_k;
 
         self
     }
+
+    /// Returns the maximum of documents to be returned
     pub fn top_k(&self) -> u64 {
         self.top_k
     }

--- a/swiftide-core/src/search_strategies.rs
+++ b/swiftide-core/src/search_strategies.rs
@@ -1,14 +1,89 @@
+use std::thread::Builder;
+
+use derive_builder::Builder;
+
 /// Search strategies provide a generic way for Retrievers to implement their
 /// search in various ways.
 ///
 /// The strategy is also yielded to the Retriever and can contain addition configuration
-use crate::querying;
+use crate::{indexing::EmbeddedField, querying};
 
 /// A very simple search where it takes the embedding on the current query
 /// and returns `top_k` documents.
 #[derive(Debug, Clone, Copy)]
 pub struct SimilaritySingleEmbedding {
+    /// Maximum number of documents to return
     top_k: u64,
+}
+
+/// A hybrid search strategy that combines a similarity search with a
+/// keyword search.
+#[derive(Debug, Clone, Builder)]
+#[builder(setter(into))]
+pub struct HybridSearch {
+    /// Maximum number of documents to return
+    #[builder(default)]
+    top_k: u64,
+    /// Maximum number of documents to return per query
+    #[builder(default)]
+    top_n: u64,
+
+    /// The field to use for the dense vector
+    #[builder(default)]
+    dense_vector_field: EmbeddedField,
+
+    /// The field to use for the sparse vector
+    /// TODO: I.e. lancedb does not use sparse embeddings for hybrid search
+    #[builder(default)]
+    sparse_vector_field: EmbeddedField,
+}
+
+impl Default for HybridSearch {
+    fn default() -> Self {
+        Self {
+            top_k: 10,
+            top_n: 10,
+            dense_vector_field: EmbeddedField::Combined,
+            sparse_vector_field: EmbeddedField::Combined,
+        }
+    }
+}
+
+impl HybridSearch {
+    pub fn with_top_k(&mut self, top_k: u64) -> &mut Self {
+        self.top_k = top_k;
+        self
+    }
+    pub fn top_k(&self) -> u64 {
+        self.top_k
+    }
+    pub fn with_top_n(&mut self, top_n: u64) -> &mut Self {
+        self.top_n = top_n;
+        self
+    }
+    pub fn top_n(&self) -> u64 {
+        self.top_n
+    }
+    pub fn with_dense_vector_field(
+        &mut self,
+        dense_vector_field: impl Into<EmbeddedField>,
+    ) -> &mut Self {
+        self.dense_vector_field = dense_vector_field.into();
+        self
+    }
+    pub fn dense_vector_field(&self) -> &EmbeddedField {
+        &self.dense_vector_field
+    }
+    pub fn with_sparse_vector_field(
+        &mut self,
+        sparse_vector_field: impl Into<EmbeddedField>,
+    ) -> &mut Self {
+        self.sparse_vector_field = sparse_vector_field.into();
+        self
+    }
+    pub fn sparse_vector_field(&self) -> &EmbeddedField {
+        &self.sparse_vector_field
+    }
 }
 
 impl Default for SimilaritySingleEmbedding {
@@ -29,3 +104,4 @@ impl SimilaritySingleEmbedding {
 }
 
 impl querying::SearchStrategy for SimilaritySingleEmbedding {}
+impl querying::SearchStrategy for HybridSearch {}

--- a/swiftide-integrations/src/qdrant/retrieve.rs
+++ b/swiftide-integrations/src/qdrant/retrieve.rs
@@ -67,6 +67,7 @@ impl Retrieve<HybridSearch> for Qdrant {
             anyhow::bail!("No sparse embedding for query")
         };
 
+        // NOTE: Potential improvement to consume the vectors instead of cloning
         let result = self
             .client
             .query(
@@ -75,15 +76,15 @@ impl Retrieve<HybridSearch> for Qdrant {
                     .add_prefetch(
                         PrefetchQueryBuilder::default()
                             .query(qdrant::Query::new_nearest(qdrant::VectorInput::new_sparse(
-                                sparse.indices,
-                                sparse.values,
+                                sparse.indices.clone(),
+                                sparse.values.clone(),
                             )))
-                            .using(search_strategy.sparse_vector_field().field_name())
+                            .using(search_strategy.sparse_vector_field().sparse_field_name())
                             .limit(search_strategy.top_n()),
                     )
                     .add_prefetch(
                         PrefetchQueryBuilder::default()
-                            .query(qdrant::Query::new_nearest(*dense))
+                            .query(qdrant::Query::new_nearest(dense.clone()))
                             .using(search_strategy.dense_vector_field().field_name())
                             .limit(search_strategy.top_n()),
                     )

--- a/swiftide-integrations/src/qdrant/retrieve.rs
+++ b/swiftide-integrations/src/qdrant/retrieve.rs
@@ -1,7 +1,10 @@
-use qdrant_client::qdrant::SearchPointsBuilder;
+use qdrant_client::qdrant::{self, PrefetchQueryBuilder, QueryPointsBuilder, SearchPointsBuilder};
 use swiftide_core::{
     prelude::{Result, *},
-    querying::{search_strategies::SimilaritySingleEmbedding, states, Query},
+    querying::{
+        search_strategies::{HybridSearch, SimilaritySingleEmbedding},
+        states, Query,
+    },
     Retrieve,
 };
 
@@ -31,6 +34,63 @@ impl Retrieve<SimilaritySingleEmbedding> for Qdrant {
             .search_points(points)
             .await
             .context("Failed to retrieve from qdrant")?
+            .result;
+
+        let documents = result
+            .into_iter()
+            .map(|scored_point| {
+                Ok(scored_point
+                    .payload
+                    .get("content")
+                    .context("Expected document in qdrant payload")?
+                    .to_string())
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(query.retrieved_documents(documents))
+    }
+}
+
+#[async_trait]
+impl Retrieve<HybridSearch> for Qdrant {
+    #[tracing::instrument]
+    async fn retrieve(
+        &self,
+        search_strategy: &HybridSearch,
+        query: Query<states::Pending>,
+    ) -> Result<Query<states::Retrieved>> {
+        let Some(dense) = &query.embedding else {
+            anyhow::bail!("No embedding for query")
+        };
+
+        let Some(sparse) = &query.sparse_embedding else {
+            anyhow::bail!("No sparse embedding for query")
+        };
+
+        let result = self
+            .client
+            .query(
+                qdrant::QueryPointsBuilder::new(&self.collection_name)
+                    .with_payload(true)
+                    .add_prefetch(
+                        PrefetchQueryBuilder::default()
+                            .query(qdrant::Query::new_nearest(qdrant::VectorInput::new_sparse(
+                                sparse.indices,
+                                sparse.values,
+                            )))
+                            .using(search_strategy.sparse_vector_field().field_name())
+                            .limit(search_strategy.top_n()),
+                    )
+                    .add_prefetch(
+                        PrefetchQueryBuilder::default()
+                            .query(qdrant::Query::new_nearest(*dense))
+                            .using(search_strategy.dense_vector_field().field_name())
+                            .limit(search_strategy.top_n()),
+                    )
+                    .query(qdrant::Query::new_fusion(qdrant::Fusion::Rrf))
+                    .limit(search_strategy.top_k()),
+            )
+            .await?
             .result;
 
         let documents = result

--- a/swiftide-integrations/src/qdrant/retrieve.rs
+++ b/swiftide-integrations/src/qdrant/retrieve.rs
@@ -1,4 +1,4 @@
-use qdrant_client::qdrant::{self, PrefetchQueryBuilder, QueryPointsBuilder, SearchPointsBuilder};
+use qdrant_client::qdrant::{self, PrefetchQueryBuilder, SearchPointsBuilder};
 use swiftide_core::{
     prelude::{Result, *},
     querying::{

--- a/swiftide-query/src/query_transformers/mod.rs
+++ b/swiftide-query/src/query_transformers/mod.rs
@@ -3,4 +3,6 @@ mod generate_subquestions;
 pub use generate_subquestions::GenerateSubquestions;
 
 mod embed;
+mod sparse_embed;
 pub use embed::Embed;
+pub use sparse_embed::SparseEmbed;

--- a/swiftide-query/src/query_transformers/sparse_embed.rs
+++ b/swiftide-query/src/query_transformers/sparse_embed.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use swiftide_core::{
-    indexing::EmbeddingModel,
     prelude::*,
     querying::{states, Query, TransformQuery},
     SparseEmbeddingModel,

--- a/swiftide-query/src/query_transformers/sparse_embed.rs
+++ b/swiftide-query/src/query_transformers/sparse_embed.rs
@@ -1,0 +1,44 @@
+use std::sync::Arc;
+
+use swiftide_core::{
+    indexing::EmbeddingModel,
+    prelude::*,
+    querying::{states, Query, TransformQuery},
+    SparseEmbeddingModel,
+};
+
+/// Embed a query with a sparse embedding.
+#[derive(Debug, Clone)]
+pub struct SparseEmbed {
+    embed_model: Arc<dyn SparseEmbeddingModel>,
+}
+
+impl SparseEmbed {
+    pub fn from_client(client: impl SparseEmbeddingModel + 'static) -> SparseEmbed {
+        SparseEmbed {
+            embed_model: Arc::new(client),
+        }
+    }
+}
+
+#[async_trait]
+impl TransformQuery for SparseEmbed {
+    #[tracing::instrument]
+    async fn transform_query(
+        &self,
+        mut query: Query<states::Pending>,
+    ) -> Result<Query<states::Pending>> {
+        let Some(embedding) = self
+            .embed_model
+            .sparse_embed(vec![query.current().to_string()])
+            .await?
+            .pop()
+        else {
+            anyhow::bail!("Failed to embed query")
+        };
+
+        query.sparse_embedding = Some(embedding);
+
+        Ok(query)
+    }
+}

--- a/swiftide/tests/query_pipeline.rs
+++ b/swiftide/tests/query_pipeline.rs
@@ -2,7 +2,6 @@ use swiftide::indexing::{self, *};
 use swiftide::query::search_strategies::HybridSearch;
 use swiftide::{integrations, query};
 use swiftide_integrations::fastembed::FastEmbed;
-use swiftide_integrations::qdrant::Qdrant;
 use swiftide_query::{answers, query_transformers, response_transformers};
 use swiftide_test_utils::*;
 use temp_dir::TempDir;

--- a/swiftide/tests/query_pipeline.rs
+++ b/swiftide/tests/query_pipeline.rs
@@ -1,5 +1,8 @@
 use swiftide::indexing::{self, *};
+use swiftide::query::search_strategies::HybridSearch;
 use swiftide::{integrations, query};
+use swiftide_integrations::fastembed::FastEmbed;
+use swiftide_integrations::qdrant::Qdrant;
 use swiftide_query::{answers, query_transformers, response_transformers};
 use swiftide_test_utils::*;
 use temp_dir::TempDir;
@@ -51,6 +54,81 @@ async fn test_query_pipeline() {
         .then_transform_response(response_transformers::Summary::from_client(
             openai_client.clone(),
         ))
+        .then_answer(answers::Simple::from_client(openai_client.clone()));
+
+    let result = query_pipeline.query("What is swiftide?").await.unwrap();
+
+    assert!(result.embedding.is_some());
+    assert!(!result.answer().is_empty());
+}
+
+#[test_log::test(tokio::test)]
+async fn test_hybrid_search_qdrant() {
+    // Setup temporary directory and file for testing
+    let tempdir = TempDir::new().unwrap();
+    let codefile = tempdir.child("main.rs");
+    std::fs::write(&codefile, "fn main() { println!(\"Hello, World!\"); }").unwrap();
+
+    // Setup mock servers to simulate API responses
+    let mock_server = MockServer::start().await;
+
+    mock_chat_completions(&mock_server).await;
+
+    let openai_client = openai_client(&mock_server.uri(), "text-embedding-3-small", "gpt-4o");
+
+    let (_qdrant, qdrant_url) = start_qdrant().await;
+
+    let batch_size = 10;
+
+    let qdrant_client = integrations::qdrant::Qdrant::try_from_url(&qdrant_url)
+        .unwrap()
+        .vector_size(384)
+        .batch_size(batch_size)
+        .with_vector(EmbeddedField::Combined)
+        .with_sparse_vector(EmbeddedField::Combined)
+        .collection_name("swiftide-hybrid")
+        .build()
+        .unwrap();
+
+    let fastembed_sparse = FastEmbed::try_default_sparse()
+        .unwrap()
+        .with_batch_size(batch_size)
+        .to_owned();
+    let fastembed = FastEmbed::try_default()
+        .unwrap()
+        .with_batch_size(batch_size)
+        .to_owned();
+
+    println!("Qdrant URL: {qdrant_url}");
+
+    indexing::Pipeline::from_loader(
+        loaders::FileLoader::new(tempdir.path()).with_extensions(&["rs"]),
+    )
+    .then_chunk(transformers::ChunkCode::try_for_language("rust").unwrap())
+    .then_in_batch(batch_size, transformers::Embed::new(fastembed.clone()))
+    .then_in_batch(
+        batch_size,
+        transformers::SparseEmbed::new(fastembed_sparse.clone()),
+    )
+    .then_store_with(qdrant_client.clone())
+    .run()
+    .await
+    .unwrap();
+
+    let collection = qdrant_client
+        .client()
+        .collection_info("swiftide-hybrid")
+        .await
+        .unwrap();
+
+    dbg!(collection);
+
+    let query_pipeline = query::Pipeline::from_search_strategy(HybridSearch::default())
+        .then_transform_query(query_transformers::Embed::from_client(fastembed.clone()))
+        .then_transform_query(query_transformers::SparseEmbed::from_client(
+            fastembed_sparse.clone(),
+        ))
+        .then_retrieve(qdrant_client.clone())
         .then_answer(answers::Simple::from_client(openai_client.clone()));
 
     let result = query_pipeline.query("What is swiftide?").await.unwrap();


### PR DESCRIPTION
Implement hybrid search for qdrant with their new Fusion search. Example in /examples includes an indexing and query pipeline, included the example answer as well.