### PR TITLE
chore: Default features cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,34 +28,34 @@ insta.opt-level = 3
 similar.opt-level = 3
 
 [workspace.dependencies]
-anyhow = { version = "1.0", default-features = false }
-async-trait = { version = "0.1", default-features = false }
-derive_builder = { version = "0.20", default-features = false }
+anyhow = { version = "1.0" }
+async-trait = { version = "0.1" }
+derive_builder = { version = "0.20" }
 futures-util = { version = "0.3", default-features = false }
-tokio = { version = "1.38", default-features = false }
-tokio-stream = { version = "0.1", default-features = false }
-tracing = { version = "0.1", features = ["log"], default-features = false }
-num_cpus = { version = "1.16", default-features = false }
-pin-project-lite = { version = "0.2", default-features = false }
-itertools = { version = "0.13", default-features = false }
-serde = { version = "1.0", features = ["derive"], default-features = false }
-serde_json = { version = "1.0", default-features = false }
-strum = { version = "0.26", default-features = false }
-strum_macros = { version = "0.26", default-features = false }
-lazy_static = { version = "1.5.0", default-features = false }
-chrono = { version = "0.4", default-features = false }
-indoc = { version = "2.0", default-features = false }
-regex = { version = "1.10.6", default-features = false }
+tokio = { version = "1.38", features = ["full"] }
+tokio-stream = { version = "0.1" }
+tracing = { version = "0.1", features = ["log"] }
+num_cpus = { version = "1.16" }
+pin-project-lite = { version = "0.2" }
+itertools = { version = "0.13" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
+strum = { version = "0.26" }
+strum_macros = { version = "0.26" }
+lazy_static = { version = "1.5.0" }
+chrono = { version = "0.4" }
+indoc = { version = "2.0" }
+regex = { version = "1.10.6" }
 
 # Integrations
 spider = { version = "2.2" }
-async-openai = { version = "0.24", default-features = false }
+async-openai = { version = "0.24" }
 qdrant-client = { version = "1.10", default-features = false, features = [
   "serde",
 ] }
 fluvio = { version = "0.23", default-features = false }
-lancedb = { version = "0.9" }
-arrow-array = { version = "52.2" }
+lancedb = { version = "0.9", default-features = false }
+arrow-array = { version = "52.2", default-features = false }
 
 # Testing
 test-log = "0.2.16"


### PR DESCRIPTION
Integrations are messy and pull a lot in. A potential solution is to disable default features, only add what is actually required, and put the responsibility at users if they need anything specific. Feature unification should then take care of the rest.
