### PR TITLE
fix!: Rust 1.81 support

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = { workspace = true }
 criterion = { version = "0.5.1", features = [
   "html_reports",
   "async_tokio",
-], default_features = false }
+], default-features = false }
 anyhow = { workspace = true }
 futures-util = { workspace = true }
 

--- a/swiftide-core/src/query_traits.rs
+++ b/swiftide-core/src/query_traits.rs
@@ -36,7 +36,7 @@ pub trait SearchStrategy: Clone + Send + Sync + Default {}
 
 /// Can retrieve documents given a SearchStrategy
 #[async_trait]
-pub trait Retrieve<S: SearchStrategy + ?Sized>: Send + Sync + ToOwned {
+pub trait Retrieve<S: SearchStrategy>: Send + Sync + ToOwned {
     async fn retrieve(
         &self,
         search_strategy: &S,
@@ -47,7 +47,7 @@ pub trait Retrieve<S: SearchStrategy + ?Sized>: Send + Sync + ToOwned {
 #[async_trait]
 impl<S, F> Retrieve<S> for F
 where
-    S: SearchStrategy + ?Sized,
+    S: SearchStrategy,
     F: Fn(&S, Query<states::Pending>) -> Result<Query<states::Retrieved>> + Send + Sync + ToOwned,
 {
     async fn retrieve(

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -121,6 +121,8 @@ mod tests {
 
     use crate::qdrant::indexing_node::NodeWithVectors;
 
+    static EXPECTED_VECTOR_ID: u64 = 17_298_870_094_173_045_322;
+
     #[test_case(
         Node { id: Some(1), path: "/path".into(), chunk: "data".into(),
             vectors: Some(HashMap::from([(EmbeddedField::Chunk, vec![1.0])])),
@@ -131,7 +133,7 @@ mod tests {
             ..Default::default()
         },
         HashSet::from([EmbeddedField::Combined]),
-        PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
+        PointStruct { id: Some(PointId::from(EXPECTED_VECTOR_ID)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
             ("path".into(), Value::from("/path")),
             ("m1".into(), Value::from("mv1"))]),
@@ -152,7 +154,7 @@ mod tests {
             ..Default::default()
         },
         HashSet::from([EmbeddedField::Chunk, EmbeddedField::Metadata("m1".into())]),
-        PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
+        PointStruct { id: Some(PointId::from(EXPECTED_VECTOR_ID)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
             ("path".into(), Value::from("/path")),
             ("m1".into(), Value::from("mv1"))]),
@@ -182,7 +184,7 @@ mod tests {
             ..Default::default()
         },
         HashSet::from([EmbeddedField::Combined]),
-        PointStruct { id: Some(PointId::from(6_516_159_902_038_153_111)), payload: HashMap::from([
+        PointStruct { id: Some(PointId::from(EXPECTED_VECTOR_ID)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
             ("path".into(), Value::from("/path")),
             ("m1".into(), Value::from("mv1")),

--- a/swiftide-integrations/src/redis/persist.rs
+++ b/swiftide-integrations/src/redis/persist.rs
@@ -9,6 +9,7 @@ use swiftide_core::{
 use super::Redis;
 
 #[async_trait]
+#[allow(dependency_on_unit_never_type_fallback)]
 impl Persist for Redis {
     async fn setup(&self) -> Result<()> {
         Ok(())


### PR DESCRIPTION
Fixing id generation properly as per #272, will be merged in together.

- **Clippy**
- **fix(qdrant)!: Default hasher changed in Rust 1.81**
