### PR TITLE
feat(integrations): Add ollama embeddings support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5411,10 +5411,11 @@ dependencies = [
 
 [[package]]
 name = "ollama-rs"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255252ec57e13d2d6ae074c7b7cd8c004d17dafb1e03f954ba2fd5cc226f8f49"
+checksum = "46483ac9e1f9e93da045b5875837ca3c9cf014fd6ab89b4d9736580ddefc4759"
 dependencies = [
+ "async-stream",
  "async-trait",
  "log",
  "reqwest",

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -60,7 +60,7 @@ aws-sdk-bedrockruntime = { version = "1.37", features = [
 ], optional = true }
 secrecy = { version = "0.8.0", optional = true }
 reqwest = { version = "0.12.5", optional = true, default-features = false }
-ollama-rs = { version = "0.2.0", optional = true }
+ollama-rs = { version = "0.2.1", optional = true }
 deadpool = { version = "0.12", optional = true, features = [
   "managed",
   "rt_tokio_1",

--- a/swiftide-integrations/src/ollama/embed.rs
+++ b/swiftide-integrations/src/ollama/embed.rs
@@ -1,0 +1,33 @@
+use anyhow::{Context as _, Result};
+use async_trait::async_trait;
+
+use ollama_rs::generation::embeddings::request::GenerateEmbeddingsRequest;
+use swiftide_core::{EmbeddingModel, Embeddings};
+
+use super::Ollama;
+
+#[async_trait]
+impl EmbeddingModel for Ollama {
+    async fn embed(&self, input: Vec<String>) -> Result<Embeddings> {
+        let model = self
+            .default_options
+            .embed_model
+            .as_ref()
+            .context("Model not set")?;
+
+        let request = GenerateEmbeddingsRequest::new(model.to_string(), input.into());
+        tracing::debug!(
+            messages = serde_json::to_string_pretty(&request)?,
+            "[Embed] Request to ollama"
+        );
+        let response = self
+            .client
+            .generate_embeddings(request)
+            .await
+            .context("Request to Ollama Failed")?;
+
+        tracing::debug!("[Embed] Response ollama");
+
+        Ok(response.embeddings)
+    }
+}

--- a/swiftide-integrations/src/ollama/mod.rs
+++ b/swiftide-integrations/src/ollama/mod.rs
@@ -157,29 +157,29 @@ mod test {
 
     #[test]
     fn test_default_embed_model() {
-        let openai = Ollama::builder()
+        let ollama = Ollama::builder()
             .default_embed_model("mxbai-embed-large")
             .build()
             .unwrap();
         assert_eq!(
-            openai.default_options.embed_model,
+            ollama.default_options.embed_model,
             Some("mxbai-embed-large".to_string())
         );
     }
 
     #[test]
     fn test_default_models() {
-        let openai = Ollama::builder()
+        let ollama = Ollama::builder()
             .default_embed_model("mxbai-embed-large")
             .default_prompt_model("llama3.1")
             .build()
             .unwrap();
         assert_eq!(
-            openai.default_options.embed_model,
+            ollama.default_options.embed_model,
             Some("mxbai-embed-large".to_string())
         );
         assert_eq!(
-            openai.default_options.prompt_model,
+            ollama.default_options.prompt_model,
             Some("llama3.1".to_string())
         );
     }


### PR DESCRIPTION
Update to the most recent ollama-rs, which exposes the batch embedding API Ollama exposes (https://github.com/pepperoni21/ollama-rs/pull/61). This allows the Ollama struct in Swiftide to implement `EmbeddingModel`. 

Use the same pattern that the OpenAI struct uses to manage separate embedding and prompt models.