### PR TITLE
fix(ci): Use llm-cov preview via nightly and improve test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
           tool: cargo-llvm-cov
       - name: Generate code coverage
         run: |
-          cargo +nightly llvm-cov --workspace --all-features
+          cargo +nightly llvm-cov --workspace --all-features --lcov --output-path lcov.info
 
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: llvm-cov
+          tool: cargo-llvm-cov
       - name: Generate code coverage
         run: |
           cargo +nightly llvm-cov --workspace --all-features

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,8 +24,6 @@ jobs:
           components: llvm-tools-preview
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
-      - name: Cache Cargo dependencies
-        uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
           tool: cargo-tarpaulin
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --workspace --all-features --all-targets --timeout 1200 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
+          cargo +nightly tarpaulin --workspace --all-features --timeout 1200 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
 
       # - name: Coveralls
       #   uses: coverallsapp/github-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
           tool: cargo-tarpaulin
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --workspace --all-features --tests --timeout 1200 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
+          cargo +nightly tarpaulin --workspace --all-features --all-targets --timeout 1200 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
 
       # - name: Coveralls
       #   uses: coverallsapp/github-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-tarpaulin
+          tool: llvm-cov
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --workspace --all-features --timeout 1200 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
+          cargo +nightly llvm-cov --workspace --all-features
 
-      # - name: Coveralls
-      #   uses: coverallsapp/github-action@v2
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,17 +14,14 @@ jobs:
   test:
     name: coverage
     runs-on: ubuntu-latest
-    env:
-      RUST_LOG: swiftide=debug
-      RUST_BACKTRACE: 1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          components: llvm-tools
+          components: llvm-tools-preview
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
       - name: Cache Cargo dependencies
@@ -32,10 +29,10 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-tarpaulin
       - name: Generate code coverage
         run: |
-          cargo llvm-cov --lcov --output-path target/lcov.info --all-features --workspace
+          cargo +nightly tarpaulin --workspace --all-features --tests --timeout 1200 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@v2
+      # - name: Coveralls
+      #   uses: coverallsapp/github-action@v2

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,14 +14,17 @@ jobs:
   test:
     name: coverage
     runs-on: ubuntu-latest
+    env:
+      RUST_LOG: swiftide=debug
+      RUST_BACKTRACE: 1
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          components: llvm-tools-preview
+          components: llvm-tools
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
       - name: Cache Cargo dependencies
@@ -29,10 +32,10 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-tarpaulin
+          tool: cargo-llvm-cov
       - name: Generate code coverage
         run: |
-          cargo +nightly tarpaulin --workspace --all-features --tests --timeout 1200 --coveralls ${{ secrets.COVERALLS_REPO_TOKEN }}
+          cargo llvm-cov --lcov --output-path target/lcov.info --all-features --workspace
 
-      # - name: Coveralls
-      #   uses: coverallsapp/github-action@v2
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,9 @@ insta = { version = "1.39.0", features = ["yaml"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(coverage)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(coverage,coverage_nightly)',
+] }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ insta = { version = "1.39.0", features = ["yaml"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ insta = { version = "1.39.0", features = ["yaml"] }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(coverage)'] }
 
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }

--- a/swiftide-core/src/lib.rs
+++ b/swiftide-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 mod indexing_defaults;
 mod indexing_stream;
 pub mod indexing_traits;

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -18,7 +18,7 @@ type Document = String;
 /// `states::Pending`: No documents have been retrieved
 /// `states::Retrieved`: Documents have been retrieved
 /// `states::Answered`: The query has been answered
-#[derive(Clone, Default, Builder)]
+#[derive(Clone, Default, Builder, PartialEq)]
 #[builder(setter(into))]
 pub struct Query<State> {
     original: String,
@@ -81,6 +81,10 @@ impl<T: Clone> Query<T> {
 }
 
 impl Query<states::Pending> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Transforms the current query
     pub fn transformed_query(&mut self, new_query: impl Into<String>) {
         let new_query = new_query.into();
@@ -111,6 +115,10 @@ impl Query<states::Pending> {
 }
 
 impl Query<states::Retrieved> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Transforms the current response
     pub fn transformed_response(&mut self, new_response: impl Into<String>) {
         let new_response = new_response.into();
@@ -140,6 +148,10 @@ impl Query<states::Retrieved> {
 }
 
 impl Query<states::Answered> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Returns the answer of the query
     pub fn answer(&self) -> &str {
         &self.state.answer
@@ -155,13 +167,13 @@ pub mod states {
     /// The query is pending and has not been used
     pub struct Pending;
 
-    #[derive(Debug, Default, Clone, Builder)]
+    #[derive(Debug, Default, Clone, Builder, PartialEq)]
     #[builder(setter(into))]
     /// Documents have been retrieved
     pub struct Retrieved {
         pub(crate) documents: Vec<Document>,
     }
-    #[derive(Debug, Default, Clone, Builder)]
+    #[derive(Debug, Default, Clone, Builder, PartialEq)]
     #[builder(setter(into))]
     /// The query has been answered
     pub struct Answered {

--- a/swiftide-core/src/query_evaluation.rs
+++ b/swiftide-core/src/query_evaluation.rs
@@ -38,3 +38,52 @@ impl QueryEvaluation {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_retrieved() {
+        let query = Query::<states::Retrieved>::new(); // Assuming Query has a new() method
+        let evaluation = QueryEvaluation::from(query.clone());
+
+        match evaluation {
+            QueryEvaluation::RetrieveDocuments(q) => assert_eq!(q, query),
+            QueryEvaluation::AnswerQuery(_) => panic!("Unexpected QueryEvaluation variant"),
+        }
+    }
+
+    #[test]
+    fn test_from_answered() {
+        let query = Query::<states::Answered>::new(); // Assuming Query has a new() method
+        let evaluation = QueryEvaluation::from(query.clone());
+
+        match evaluation {
+            QueryEvaluation::AnswerQuery(q) => assert_eq!(q, query),
+            QueryEvaluation::RetrieveDocuments(_) => panic!("Unexpected QueryEvaluation variant"),
+        }
+    }
+
+    #[test]
+    fn test_retrieve_documents_query() {
+        let query = Query::<states::Retrieved>::new(); // Assuming Query has a new() method
+        let evaluation = QueryEvaluation::RetrieveDocuments(query.clone());
+
+        match evaluation.retrieve_documents_query() {
+            Some(q) => assert_eq!(q, query),
+            None => panic!("Expected a query, got None"),
+        }
+    }
+
+    #[test]
+    fn test_answer_query() {
+        let query = Query::<states::Answered>::new(); // Assuming Query has a new() method
+        let evaluation = QueryEvaluation::AnswerQuery(query.clone());
+
+        match evaluation.answer_query() {
+            Some(q) => assert_eq!(q, query),
+            None => panic!("Expected a query, got None"),
+        }
+    }
+}

--- a/swiftide-core/src/query_traits.rs
+++ b/swiftide-core/src/query_traits.rs
@@ -9,7 +9,12 @@ use crate::{
     querying::QueryEvaluation,
 };
 
+#[cfg(feature = "test-utils")]
+#[doc(hidden)]
+use mockall::{automock, predicate::str};
+
 /// Can transform queries before retrieval
+#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 pub trait TransformQuery: Send + Sync {
     async fn transform_query(
@@ -81,6 +86,7 @@ where
 }
 
 /// Can transform a response after retrieval
+#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 pub trait TransformResponse: Send + Sync {
     async fn transform_response(&self, query: Query<Retrieved>)
@@ -105,6 +111,7 @@ impl TransformResponse for Box<dyn TransformResponse> {
 }
 
 /// Can answer the original query
+#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 pub trait Answer: Send + Sync {
     async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>>;
@@ -130,6 +137,7 @@ impl Answer for Box<dyn Answer> {
 /// Evaluates a query
 ///
 /// An evaluator needs to be able to respond to each step in the query pipeline
+#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 pub trait EvaluateQuery: Send + Sync {
     async fn evaluate(&self, evaluation: QueryEvaluation) -> Result<()>;

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(coverage_nightly, coverage(off))]
+
 use serde::{Deserialize, Serialize};
 
 pub type Embedding = Vec<f32>;

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -1,4 +1,4 @@
-#![cfg(not(tarpaulin_include))]
+#![cfg(not(coverage))]
 
 use serde::{Deserialize, Serialize};
 

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -1,3 +1,5 @@
+#![cfg(not(tarpaulin_include))]
+
 use serde::{Deserialize, Serialize};
 
 pub type Embedding = Vec<f32>;

--- a/swiftide-core/src/type_aliases.rs
+++ b/swiftide-core/src/type_aliases.rs
@@ -1,5 +1,3 @@
-#![cfg(not(coverage))]
-
 use serde::{Deserialize, Serialize};
 
 pub type Embedding = Vec<f32>;

--- a/swiftide-macros/src/lib.rs
+++ b/swiftide-macros/src/lib.rs
@@ -6,7 +6,6 @@ mod indexing_transformer;
 use indexing_transformer::indexing_transformer_impl;
 
 /// Generates boilerplate for an indexing transformer.
-#[cfg(not(coverage))]
 #[proc_macro_attribute]
 pub fn indexing_transformer(args: TokenStream, item: TokenStream) -> TokenStream {
     indexing_transformer_impl(args, item)

--- a/swiftide-macros/src/lib.rs
+++ b/swiftide-macros/src/lib.rs
@@ -6,7 +6,7 @@ mod indexing_transformer;
 use indexing_transformer::indexing_transformer_impl;
 
 /// Generates boilerplate for an indexing transformer.
-#[cfg(not(tarpaulin_include))]
+#[cfg(not(coverage))]
 #[proc_macro_attribute]
 pub fn indexing_transformer(args: TokenStream, item: TokenStream) -> TokenStream {
     indexing_transformer_impl(args, item)

--- a/swiftide-macros/src/lib.rs
+++ b/swiftide-macros/src/lib.rs
@@ -6,6 +6,7 @@ mod indexing_transformer;
 use indexing_transformer::indexing_transformer_impl;
 
 /// Generates boilerplate for an indexing transformer.
+#[cfg(not(tarpaulin_include))]
 #[proc_macro_attribute]
 pub fn indexing_transformer(args: TokenStream, item: TokenStream) -> TokenStream {
     indexing_transformer_impl(args, item)


### PR DESCRIPTION
Fix test coverage in CI. Simplified the trait bounds on the query pipeline for now to make it all work and fit together, and added more tests to assert boxed versions of trait objects work in tests.
