### PR TITLE
feat: Major performance improvements

### DIFF
--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -272,7 +272,7 @@ impl Pipeline {
             })
             .err_into::<anyhow::Error>()
             .try_buffer_unordered(concurrency)
-            .try_flatten_unordered(concurrency)
+            .try_flatten_unordered(None)
             .boxed()
             .into();
 
@@ -316,7 +316,7 @@ impl Pipeline {
                 })
                 .err_into::<anyhow::Error>()
                 .try_buffer_unordered(self.concurrency)
-                .try_flatten_unordered(self.concurrency)
+                .try_flatten_unordered(None)
                 .boxed().into();
         } else {
             self.stream = self

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use futures_util::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use futures_util::{StreamExt, TryFutureExt, TryStreamExt};
 use swiftide_core::{
     indexing::IndexingDefaults, BatchableTransformer, ChunkerTransformer, Loader, NodeCache,
     Persist, SimplePrompt, Transformer, WithBatchIndexingDefaults, WithIndexingDefaults,


### PR DESCRIPTION
Futures that do not yield were not run in parallel properly. With this futures are spawned on a tokio worker thread by default.

When embedding (fastembed) and storing a 85k row dataset, there's a ~1.35x performance improvement:
<img width="621" alt="image" src="https://github.com/user-attachments/assets/ba2d4d96-8d4a-44f1-b02d-6ac2af0cedb7">

~~Need to do one more test with IO bound futures as well. Pretty huge, not that it was slow.~~

With IO bound openai it's 1.5x.