### PR TITLE
fix: Bad embed error propagation

### DIFF
--- a/swiftide-core/src/indexing_stream.rs
+++ b/swiftide-core/src/indexing_stream.rs
@@ -84,6 +84,10 @@ impl IndexingStream {
         }
     }
 
+    /// Creates an `IndexingStream` from an iterator of `Result<Node>`.
+    ///
+    /// WARN: Also works with Err items directly, which will result
+    /// in an _incorrect_ stream
     pub fn iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = Result<Node>> + Send + 'static,

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -66,7 +66,14 @@ impl Debug for Node {
         f.debug_struct("Node")
             .field("id", &self.id)
             .field("path", &self.path)
-            .field("chunk", &self.chunk)
+            .field(
+                "chunk",
+                &format!(
+                    "{} ({})",
+                    &self.chunk.as_str()[..std::cmp::min(100, self.chunk.len())],
+                    self.chunk.chars().count()
+                ),
+            )
             .field("metadata", &self.metadata)
             .field(
                 "vectors",

--- a/swiftide-integrations/src/openai/embed.rs
+++ b/swiftide-integrations/src/openai/embed.rs
@@ -17,10 +17,11 @@ impl EmbeddingModel for OpenAI {
 
         let request = CreateEmbeddingRequestArgs::default()
             .model(model)
-            .input(input)
+            .input(&input)
             .build()?;
         tracing::debug!(
-            messages = serde_json::to_string_pretty(&request)?,
+            num_chunks = input.len(),
+            model = &model,
             "[Embed] Request to openai"
         );
         let response = self
@@ -30,7 +31,8 @@ impl EmbeddingModel for OpenAI {
             .await
             .context("Request to OpenAI Failed")?;
 
-        tracing::debug!("[Embed] Response openai");
+        let num_embeddings = response.data.len();
+        tracing::debug!(num_embeddings = num_embeddings, "[Embed] Response openai");
 
         // WARN: Naively assumes that the order is preserved. Might not always be the case.
         Ok(response.data.into_iter().map(|d| d.embedding).collect())


### PR DESCRIPTION
- **fix(indexing): Limit logged chunk to max 100 chars**
- **fix: Embed transformers must correctly propagate errors**
