### PR TITLE
feat: debugging verbosity improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         uses: arduino/setup-protoc@v3
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
       - uses: r7kamura/rust-problem-matchers@v1
       - name: Check typos
         uses: crate-ci/typos@master
@@ -53,6 +55,8 @@ jobs:
         uses: arduino/setup-protoc@v3
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
       - uses: r7kamura/rust-problem-matchers@v1
       - name: "Test"
         run: cargo test --all-features --tests
@@ -72,6 +76,8 @@ jobs:
         uses: arduino/setup-protoc@v3
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v1-rust"
       - uses: r7kamura/rust-problem-matchers@v1
       - name: clippy
         run: cargo clippy --workspace --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,7 +3760,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6432,9 +6432,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6408b7e62e108fa36b8e44cffa98ae36570cf32cbc996cc3af1f5ecde8782c37"
+checksum = "a7e86f5670bd8b028edfb240f0616cad620705b31ec389d55e4f3da2c38dcd48"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -8948,7 +8948,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arbitrary"
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.2.4"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a07789659a4d385b79b18b9127fc27e1a59e1e89117c78c5ea3b806f016374"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
  "async-channel 2.3.1",
  "async-io 2.3.4",
@@ -608,7 +608,6 @@ dependencies = [
  "futures-lite 2.3.0",
  "rustix 0.38.37",
  "tracing",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1537,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800"
 dependencies = [
  "jobserver",
  "libc",
@@ -2860,16 +2859,14 @@ dependencies = [
 
 [[package]]
 name = "fluvio"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a437bef3baa91c0a29bc3a3641e14c7cd3a9ce3243fadefb30bb72a44acb064f"
+checksum = "68d0a53efe9832626f6c56dcf9826a1a119fc237a7b2715f3f68eb4f7d7244a6"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
  "async-lock 3.4.0",
  "async-trait",
- "base64 0.22.1",
- "bytes",
  "cfg-if",
  "chrono",
  "derive_builder",
@@ -2884,13 +2881,11 @@ dependencies = [
  "fluvio-spu-schema",
  "fluvio-stream-dispatcher",
  "fluvio-types",
- "futures-lite 2.3.0",
  "futures-util",
  "once_cell",
  "pin-project",
  "semver",
  "serde",
- "serde_json",
  "siphasher 1.0.1",
  "thiserror",
  "tokio",
@@ -2911,18 +2906,16 @@ dependencies = [
 
 [[package]]
 name = "fluvio-controlplane-metadata"
-version = "0.29.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e92bd947b7a1877ba8eb36b379b478e92148947b407c375e758fe9be2cee92d2"
+checksum = "8aff317349d026baa29745a4dd7c3fc22e5b8652646bc3640150d6cee9abfda6"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "bytes",
  "bytesize",
  "derive_builder",
  "flate2",
- "fluvio-future",
  "fluvio-protocol",
  "fluvio-stream-model",
  "fluvio-types",
@@ -2996,16 +2989,15 @@ dependencies = [
 
 [[package]]
 name = "fluvio-sc-schema"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc1314d904319cf2a2e89bfb9f113f2700a5e6c5179753779efcb221f40bc24"
+checksum = "507c721d21b8d6b2be4c7f9016803df9f3c69e6f83498f64fc12b1b565d93f9a"
 dependencies = [
  "anyhow",
  "fluvio-controlplane-metadata",
  "fluvio-protocol",
  "fluvio-socket",
  "fluvio-stream-model",
- "fluvio-types",
  "paste",
  "static_assertions",
  "thiserror",
@@ -3038,11 +3030,10 @@ dependencies = [
 
 [[package]]
 name = "fluvio-socket"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98d2c341d5aaa1d08162a7936e87f5da3110eafcc3bd84a79e850053c554877"
+checksum = "c945f5ade92202b9588a2114a45323048e7c49c5c434b69086a9d7b2297ad4c1"
 dependencies = [
- "anyhow",
  "async-channel 1.9.0",
  "async-lock 3.4.0",
  "async-trait",
@@ -3065,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "fluvio-spu-schema"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7856cf9d5330aa74ce168284f5a9aeb2782c6961c191b9ffd5424250b847edf3"
+checksum = "8d5566353fe913eaf07b73aacbd54fc55a497e0fd6fba30f8acbea9277ac9f28"
 dependencies = [
  "bytes",
  "derive_builder",
@@ -3084,25 +3075,24 @@ dependencies = [
 
 [[package]]
 name = "fluvio-stream-dispatcher"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f7f45291006e26eb43826b130f1f01ba8428312bc88c398c0faef0f960ad11"
+checksum = "0b5b7e4a1f1241cf750babfc5d99db4b965524f7e35a9c1fdefd6ec74616cc03"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",
  "async-lock 3.4.0",
  "async-trait",
  "cfg-if",
- "event-listener 5.3.1",
  "fluvio-future",
  "fluvio-stream-model",
  "fluvio-types",
  "futures-util",
  "once_cell",
+ "parking_lot 0.12.3",
  "serde",
  "serde_yaml",
  "tempfile",
- "thiserror",
  "tokio",
  "tracing",
 ]
@@ -3760,7 +3750,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -5013,9 +5003,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
@@ -5406,9 +5396,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "oneshot"
@@ -7257,9 +7247,9 @@ dependencies = [
 
 [[package]]
 name = "spider"
-version = "2.4.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9ca45d8dcb92b41659362a05e7f4ead2910bcda9c8c16869d62b076eccdf3"
+checksum = "a7d72ef2496a6893ef1a5d3acd2d3db0c3b3c46270904beba239c572dd4897cd"
 dependencies = [
  "ahash",
  "auto_encoder",
@@ -7279,6 +7269,7 @@ dependencies = [
  "reqwest",
  "selectors",
  "smallvec",
+ "string-interner",
  "string_concat",
  "strum",
  "tendril",
@@ -7353,6 +7344,17 @@ name = "stfu8"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51f1e89f093f99e7432c491c382b88a6860a5adbe6bf02574bf0a08efff1978"
+
+[[package]]
+name = "string-interner"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6a0d765f5807e98a091107bae0a56ea3799f66a5de47b2c84c94a39c09974e"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "serde",
+]
 
 [[package]]
 name = "string_cache"
@@ -8640,9 +8642,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -8948,7 +8950,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -29,6 +29,11 @@ pub trait Transformer: Send + Sync {
     fn concurrency(&self) -> Option<usize> {
         None
     }
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -72,6 +77,11 @@ pub trait BatchableTransformer: Send + Sync {
     /// Overrides the default concurrency of the pipeline
     fn concurrency(&self) -> Option<usize> {
         None
+    }
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
     }
 }
 
@@ -125,6 +135,11 @@ pub trait Loader {
     fn into_stream_boxed(self: Box<Self>) -> IndexingStream {
         unimplemented!("Please implement into_stream_boxed for your loader, it needs to be implemented on the concrete type")
     }
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 impl Loader for Box<dyn Loader> {
@@ -157,6 +172,11 @@ pub trait ChunkerTransformer: Send + Sync + Debug {
     fn concurrency(&self) -> Option<usize> {
         None
     }
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -188,6 +208,11 @@ impl ChunkerTransformer for &dyn ChunkerTransformer {
 pub trait NodeCache: Send + Sync + Debug {
     async fn get(&self, node: &Node) -> bool;
     async fn set(&self, node: &Node);
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -216,6 +241,11 @@ impl NodeCache for &dyn NodeCache {
 /// Assumes the strings will be moved.
 pub trait EmbeddingModel: Send + Sync + Debug {
     async fn embed(&self, input: Vec<String>) -> Result<Embeddings>;
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -238,6 +268,11 @@ impl EmbeddingModel for &dyn EmbeddingModel {
 /// Assumes the strings will be moved.
 pub trait SparseEmbeddingModel: Send + Sync + Debug {
     async fn sparse_embed(&self, input: Vec<String>) -> Result<SparseEmbeddings>;
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -260,6 +295,11 @@ impl SparseEmbeddingModel for &dyn SparseEmbeddingModel {
 pub trait SimplePrompt: Debug + Send + Sync {
     // Takes a simple prompt, prompts the llm and returns the response
     async fn prompt(&self, prompt: Prompt) -> Result<String>;
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -285,6 +325,11 @@ pub trait Persist: Debug + Send + Sync {
     async fn batch_store(&self, nodes: Vec<Node>) -> IndexingStream;
     fn batch_size(&self) -> Option<usize> {
         None
+    }
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
     }
 }
 

--- a/swiftide-core/src/lib.rs
+++ b/swiftide-core/src/lib.rs
@@ -43,3 +43,5 @@ pub mod prelude;
 
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
+
+pub mod util;

--- a/swiftide-core/src/metadata.rs
+++ b/swiftide-core/src/metadata.rs
@@ -7,9 +7,30 @@ use std::collections::{btree_map::IntoValues, BTreeMap};
 
 use serde::Deserializer;
 
-#[derive(Debug, Clone, Default, PartialEq)]
+use crate::util::debug_long_utf8;
+
+#[derive(Clone, Default, PartialEq)]
 pub struct Metadata {
     inner: BTreeMap<String, serde_json::Value>,
+}
+
+impl std::fmt::Debug for Metadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map()
+            .entries(
+                self.inner
+                    .iter()
+                    .map(|(k, v): (&String, &serde_json::Value)| {
+                        let fvalue = v.as_str().map_or_else(
+                            || debug_long_utf8(v.to_string(), 100),
+                            ToString::to_string,
+                        );
+
+                        (k, fvalue)
+                    }),
+            )
+            .finish()
+    }
 }
 
 impl Metadata {

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     metadata::Metadata,
-    util::{debug_long_utf8, safe_truncate_utf8},
+    util::debug_long_utf8,
     Embedding, SparseEmbedding,
 };
 

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -28,7 +28,11 @@ use std::{
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::{metadata::Metadata, Embedding, SparseEmbedding};
+use crate::{
+    metadata::Metadata,
+    util::{debug_long_utf8, safe_truncate_utf8},
+    Embedding, SparseEmbedding,
+};
 
 /// Represents a unit of data in the indexing process.
 ///
@@ -66,14 +70,7 @@ impl Debug for Node {
         f.debug_struct("Node")
             .field("id", &self.id)
             .field("path", &self.path)
-            .field(
-                "chunk",
-                &format!(
-                    "{} ({})",
-                    &self.chunk.chars().take(100).collect::<String>(),
-                    self.chunk.chars().count()
-                ),
-            )
+            .field("chunk", &debug_long_utf8(&self.chunk, 100))
             .field("metadata", &self.metadata)
             .field(
                 "vectors",

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -28,11 +28,7 @@ use std::{
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    metadata::Metadata,
-    util::debug_long_utf8,
-    Embedding, SparseEmbedding,
-};
+use crate::{metadata::Metadata, util::debug_long_utf8, Embedding, SparseEmbedding};
 
 /// Represents a unit of data in the indexing process.
 ///

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -195,8 +195,7 @@ impl<T: AsRef<str>> From<T> for Query<states::Pending> {
     }
 }
 
-#[allow(dead_code)]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 /// Records changes to a query
 pub enum TransformationEvent {
     Transformed {
@@ -208,6 +207,29 @@ pub enum TransformationEvent {
         after: String,
         documents: Vec<Document>,
     },
+}
+
+impl std::fmt::Debug for TransformationEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TransformationEvent::Transformed { before, after } => {
+                write!(f, "Transformed: {before} -> {after}")
+            }
+            TransformationEvent::Retrieved {
+                before,
+                after,
+                documents,
+            } => {
+                write!(
+                    f,
+                    "Retrieved: {} -> {}\nDocuments: {:?}",
+                    before,
+                    after,
+                    documents.len()
+                )
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/swiftide-core/src/query_evaluation.rs
+++ b/swiftide-core/src/query_evaluation.rs
@@ -8,6 +8,17 @@ pub enum QueryEvaluation {
     AnswerQuery(Query<states::Answered>),
 }
 
+impl std::fmt::Debug for QueryEvaluation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            QueryEvaluation::RetrieveDocuments(query) => {
+                write!(f, "RetrieveDocuments({:?})", query)
+            }
+            QueryEvaluation::AnswerQuery(query) => write!(f, "AnswerQuery({:?})", query),
+        }
+    }
+}
+
 impl From<Query<states::Retrieved>> for QueryEvaluation {
     fn from(val: Query<states::Retrieved>) -> Self {
         QueryEvaluation::RetrieveDocuments(val)

--- a/swiftide-core/src/query_evaluation.rs
+++ b/swiftide-core/src/query_evaluation.rs
@@ -12,9 +12,9 @@ impl std::fmt::Debug for QueryEvaluation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             QueryEvaluation::RetrieveDocuments(query) => {
-                write!(f, "RetrieveDocuments({:?})", query)
+                write!(f, "RetrieveDocuments({query:?})")
             }
-            QueryEvaluation::AnswerQuery(query) => write!(f, "AnswerQuery({:?})", query),
+            QueryEvaluation::AnswerQuery(query) => write!(f, "AnswerQuery({query:?})"),
         }
     }
 }

--- a/swiftide-core/src/query_traits.rs
+++ b/swiftide-core/src/query_traits.rs
@@ -21,6 +21,11 @@ pub trait TransformQuery: Send + Sync {
         &self,
         query: Query<states::Pending>,
     ) -> Result<Query<states::Pending>>;
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -57,6 +62,11 @@ pub trait Retrieve<S: SearchStrategy>: Send + Sync {
         search_strategy: &S,
         query: Query<states::Pending>,
     ) -> Result<Query<states::Retrieved>>;
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -91,6 +101,11 @@ where
 pub trait TransformResponse: Send + Sync {
     async fn transform_response(&self, query: Query<Retrieved>)
         -> Result<Query<states::Retrieved>>;
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]
@@ -115,6 +130,11 @@ impl TransformResponse for Box<dyn TransformResponse> {
 #[async_trait]
 pub trait Answer: Send + Sync {
     async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>>;
+
+    fn name(&self) -> &'static str {
+        let name = std::any::type_name::<Self>();
+        name.split("::").last().unwrap_or(name)
+    }
 }
 
 #[async_trait]

--- a/swiftide-core/src/util.rs
+++ b/swiftide-core/src/util.rs
@@ -1,0 +1,41 @@
+//! Utility functions for Swiftide
+
+/// Safely truncates a string to a maximum number of characters.
+///
+/// Respects utf8 character boundaries.
+pub fn safe_truncate_utf8(s: impl AsRef<str>, max_chars: usize) -> String {
+    s.as_ref().chars().take(max_chars).collect()
+}
+
+/// Debug print a long string by truncating to n characters
+///
+/// # Example
+///
+/// ```
+/// # use swiftide_core::util::debug_long_utf8;
+/// let s = debug_long_utf8("🦀".repeat(10), 3);
+///
+/// assert_eq!(s, "🦀🦀🦀 (10)");
+/// ```
+pub fn debug_long_utf8(s: impl AsRef<str>, max_chars: usize) -> String {
+    let trunc = safe_truncate_utf8(&s, max_chars);
+
+    format!("{} ({})", trunc, s.as_ref().chars().count())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_safe_truncate_str_with_utf8_char_boundary() {
+        let s = "🦀".repeat(101);
+
+        // Single char
+        assert_eq!(safe_truncate_utf8(&s, 100).chars().count(), 100);
+
+        // With invalid char boundary
+        let s = "Jürgen".repeat(100);
+        assert_eq!(safe_truncate_utf8(&s, 100).chars().count(), 100);
+    }
+}

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -598,6 +598,7 @@ mod tests {
             Ok(node)
         });
         transformer.expect_concurrency().returning(|| None);
+        transformer.expect_name().returning(|| "transformer");
 
         batch_transformer
             .expect_batch_transform()
@@ -605,6 +606,7 @@ mod tests {
             .in_sequence(&mut seq)
             .returning(|nodes| IndexingStream::iter(nodes.into_iter().map(Ok)));
         batch_transformer.expect_concurrency().returning(|| None);
+        batch_transformer.expect_name().returning(|| "transformer");
 
         chunker
             .expect_transform_node()
@@ -620,6 +622,7 @@ mod tests {
                 nodes.into()
             });
         chunker.expect_concurrency().returning(|| None);
+        chunker.expect_name().returning(|| "chunker");
 
         storage.expect_setup().returning(|| Ok(()));
         storage.expect_batch_size().returning(|| None);
@@ -629,6 +632,7 @@ mod tests {
             .in_sequence(&mut seq)
             .withf(|node| node.chunk.starts_with("transformed_chunk_"))
             .returning(Ok);
+        storage.expect_name().returning(|| "storage");
 
         let pipeline = Pipeline::from_loader(loader)
             .then(transformer)
@@ -691,9 +695,11 @@ mod tests {
                 Ok(node)
             });
         transformer.expect_concurrency().returning(|| Some(3));
+        transformer.expect_name().returning(|| "transformer");
         storage.expect_setup().returning(|| Ok(()));
         storage.expect_batch_size().returning(|| None);
         storage.expect_store().times(3).returning(Ok);
+        storage.expect_name().returning(|| "storage");
 
         let pipeline = Pipeline::from_loader(loader)
             .then(transformer)

--- a/swiftide-integrations/src/openai/simple_prompt.rs
+++ b/swiftide-integrations/src/openai/simple_prompt.rs
@@ -3,7 +3,7 @@
 //! and generating responses as part of the Swiftide system.
 use async_openai::types::{ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs};
 use async_trait::async_trait;
-use swiftide_core::{prompt::Prompt, SimplePrompt};
+use swiftide_core::{prompt::Prompt, util::debug_long_utf8, SimplePrompt};
 
 use super::OpenAI;
 use anyhow::{Context as _, Result};
@@ -44,7 +44,7 @@ impl SimplePrompt for OpenAI {
 
         // Log the request for debugging purposes.
         tracing::debug!(
-            messages = serde_json::to_string_pretty(&request)?,
+            messages = debug_long_utf8(serde_json::to_string_pretty(&request)?, 100),
             "[SimplePrompt] Request to openai"
         );
 
@@ -53,7 +53,7 @@ impl SimplePrompt for OpenAI {
 
         // Log the response for debugging purposes.
         tracing::debug!(
-            response = serde_json::to_string_pretty(&response)?,
+            response = debug_long_utf8(serde_json::to_string_pretty(&response)?, 100),
             "[SimplePrompt] Response from openai"
         );
 

--- a/swiftide-integrations/src/qdrant/persist.rs
+++ b/swiftide-integrations/src/qdrant/persist.rs
@@ -58,7 +58,7 @@ impl Persist for Qdrant {
         let node_with_vectors = NodeWithVectors::new(&node, self.vector_fields());
         let point = node_with_vectors.try_into()?;
 
-        tracing::debug!(?point, "Storing node");
+        tracing::debug!("Storing node");
 
         self.client
             .upsert_points(

--- a/swiftide-query/src/answers/simple.rs
+++ b/swiftide-query/src/answers/simple.rs
@@ -74,7 +74,7 @@ fn default_prompt() -> PromptTemplate {
 
 #[async_trait]
 impl Answer for Simple {
-    #[tracing::instrument(skip_self)]
+    #[tracing::instrument(skip_all)]
     async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>> {
         let context = if query.current().is_empty() {
             &query.documents().join("\n---\n")

--- a/swiftide-query/src/answers/simple.rs
+++ b/swiftide-query/src/answers/simple.rs
@@ -74,7 +74,7 @@ fn default_prompt() -> PromptTemplate {
 
 #[async_trait]
 impl Answer for Simple {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_self)]
     async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>> {
         let context = if query.current().is_empty() {
             &query.documents().join("\n---\n")

--- a/swiftide-query/src/answers/simple.rs
+++ b/swiftide-query/src/answers/simple.rs
@@ -82,14 +82,6 @@ impl Answer for Simple {
             query.current()
         };
 
-        let prompt = self
-            .prompt_template
-            .to_prompt()
-            .with_context_value("question", query.original())
-            .with_context_value("context", context);
-
-        tracing::debug!(prompt = ?prompt, "Prompting from Simple for answer");
-
         let answer = self
             .client
             .prompt(

--- a/swiftide-query/src/evaluators/ragas.rs
+++ b/swiftide-query/src/evaluators/ragas.rs
@@ -91,7 +91,7 @@ impl Ragas {
 
 #[async_trait]
 impl EvaluateQuery for Ragas {
-    #[tracing::instrument(skip_self)]
+    #[tracing::instrument(skip_all)]
     async fn evaluate(&self, query: QueryEvaluation) -> Result<()> {
         let mut dataset = self.dataset.write().await;
         dataset.upsert_evaluation(&query)

--- a/swiftide-query/src/evaluators/ragas.rs
+++ b/swiftide-query/src/evaluators/ragas.rs
@@ -91,6 +91,7 @@ impl Ragas {
 
 #[async_trait]
 impl EvaluateQuery for Ragas {
+    #[tracing::instrument(skip_self)]
     async fn evaluate(&self, query: QueryEvaluation) -> Result<()> {
         let mut dataset = self.dataset.write().await;
         dataset.upsert_evaluation(&query)

--- a/swiftide-query/src/query_transformers/embed.rs
+++ b/swiftide-query/src/query_transformers/embed.rs
@@ -21,7 +21,7 @@ impl Embed {
 
 #[async_trait]
 impl TransformQuery for Embed {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_self)]
     async fn transform_query(
         &self,
         mut query: Query<states::Pending>,

--- a/swiftide-query/src/query_transformers/embed.rs
+++ b/swiftide-query/src/query_transformers/embed.rs
@@ -21,7 +21,7 @@ impl Embed {
 
 #[async_trait]
 impl TransformQuery for Embed {
-    #[tracing::instrument(skip_self)]
+    #[tracing::instrument(skip_all)]
     async fn transform_query(
         &self,
         mut query: Query<states::Pending>,

--- a/swiftide-query/src/query_transformers/generate_subquestions.rs
+++ b/swiftide-query/src/query_transformers/generate_subquestions.rs
@@ -71,7 +71,7 @@ fn default_prompt() -> PromptTemplate {
 
 #[async_trait]
 impl TransformQuery for GenerateSubquestions {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_self)]
     async fn transform_query(
         &self,
         mut query: Query<states::Pending>,

--- a/swiftide-query/src/query_transformers/sparse_embed.rs
+++ b/swiftide-query/src/query_transformers/sparse_embed.rs
@@ -22,7 +22,7 @@ impl SparseEmbed {
 
 #[async_trait]
 impl TransformQuery for SparseEmbed {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_self)]
     async fn transform_query(
         &self,
         mut query: Query<states::Pending>,

--- a/swiftide-query/src/query_transformers/sparse_embed.rs
+++ b/swiftide-query/src/query_transformers/sparse_embed.rs
@@ -22,7 +22,7 @@ impl SparseEmbed {
 
 #[async_trait]
 impl TransformQuery for SparseEmbed {
-    #[tracing::instrument(skip_self)]
+    #[tracing::instrument(skip_all)]
     async fn transform_query(
         &self,
         mut query: Query<states::Pending>,

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -70,7 +70,7 @@ fn default_prompt() -> PromptTemplate {
 
 #[async_trait]
 impl TransformResponse for Summary {
-    #[tracing::instrument(skip_self)]
+    #[tracing::instrument(skip_all)]
     async fn transform_response(
         &self,
         mut query: Query<states::Retrieved>,

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -70,7 +70,7 @@ fn default_prompt() -> PromptTemplate {
 
 #[async_trait]
 impl TransformResponse for Summary {
-    #[tracing::instrument]
+    #[tracing::instrument(skip_self)]
     async fn transform_response(
         &self,
         mut query: Query<states::Retrieved>,

--- a/swiftide-test-utils/src/test_utils.rs
+++ b/swiftide-test-utils/src/test_utils.rs
@@ -33,7 +33,7 @@ pub fn openai_client(
 /// Setup Qdrant container.
 /// Returns container server and `server_url`.
 pub async fn start_qdrant() -> (ContainerAsync<GenericImage>, String) {
-    let qdrant = testcontainers::GenericImage::new("qdrant/qdrant", "v1.10.1")
+    let qdrant = testcontainers::GenericImage::new("qdrant/qdrant", "v1.11.3")
         .with_exposed_port(6334.into())
         .with_exposed_port(6333.into())
         .with_wait_for(testcontainers::core::WaitFor::http(
@@ -54,7 +54,7 @@ pub async fn start_qdrant() -> (ContainerAsync<GenericImage>, String) {
 /// Setup Redis container for caching in the test.
 /// Returns container server and `server_url`.
 pub async fn start_redis() -> (ContainerAsync<GenericImage>, String) {
-    let redis = testcontainers::GenericImage::new("redis", "7.2.4")
+    let redis = testcontainers::GenericImage::new("redis", "7-alpine")
         .with_exposed_port(6379.into())
         .with_wait_for(testcontainers::core::WaitFor::message_on_stdout(
             "Ready to accept connections",


### PR DESCRIPTION
Cleans up and by default truncates the verbosity of any long strings to 100 chars. Every step now has an info log with the inferred name of the step as well. 

Let's add more verbosity when it's needed, there is still a good case to be made when evaluating pipelines, but the default does not scale.
