### PR TITLE
docs: fix broken documentation links and other cargo doc warnings

### DIFF
--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -224,8 +224,6 @@ impl<T: Into<String>> From<T> for Node {
 }
 
 /// Embed mode of the pipeline.
-///
-/// See also [`super::pipeline::Pipeline::with_embed_mode`].
 #[derive(Copy, Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub enum EmbedMode {
     #[default]

--- a/swiftide-core/src/prompt.rs
+++ b/swiftide-core/src/prompt.rs
@@ -4,7 +4,7 @@
 //! uses jinja style templates which allows for a lot of flexibility.
 //!
 //! Conceptually, a [Prompt] is something you send to i.e.
-//! [`SimplePrompt`][crate::traits::SimplePrompt]. A prompt can have
+//! [`SimplePrompt`][crate::SimplePrompt]. A prompt can have
 //! added context for substitution and other templating features.
 //!
 //! Transformers in Swiftide come with default prompts, and they can be customized or replaced as

--- a/swiftide-core/src/query_evaluation.rs
+++ b/swiftide-core/src/query_evaluation.rs
@@ -1,6 +1,6 @@
 use crate::querying::{states, Query};
 
-/// Wraps a query for evaluation. Used by the [`EvaluateQuery`] trait.
+/// Wraps a query for evaluation. Used by the [`crate::query_traits::EvaluateQuery`] trait.
 pub enum QueryEvaluation {
     /// Retrieve documents
     RetrieveDocuments(Query<states::Retrieved>),

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -22,7 +22,6 @@ use swiftide_core::indexing::{EmbedMode, IndexingStream, Node};
 /// * `storage` - Optional storage backend where the processed nodes will be stored.
 /// * `concurrency` - The level of concurrency for processing nodes.
 ///
-/// ```
 pub struct Pipeline {
     stream: IndexingStream,
     storage: Vec<Arc<dyn Persist>>,
@@ -103,7 +102,7 @@ impl Pipeline {
     /// Sets the embed mode for the pipeline. The embed mode controls what (combination) fields of a [`Node`]
     /// be embedded with a vector when transforming with [`crate::transformers::Embed`]
     ///
-    /// See also [`swiftide::indexing::EmbedMode`].
+    /// See also [`swiftide_core::indexing::EmbedMode`].
     ///
     /// # Arguments
     ///

--- a/swiftide-indexing/src/transformers/mod.rs
+++ b/swiftide-indexing/src/transformers/mod.rs
@@ -1,10 +1,12 @@
 //! Various transformers for chunking, embedding and transforming data
 //!
-//! These transformers are generic over their implementation and many require an
-//! [`swiftide::integrations`] to be configured.
+//! These transformers are generic over their implementation and many require a
+//! swiftide integration to be configured.
 //!
 //! Transformers that prompt have a default prompt configured. Prompts can be customized
-//! and tailored, supporting Jinja style templating based on [`tera`]. See [`swiftide::prompt::Prompt`] and [`swiftide::prompt::PromptTemplate`]
+//! and tailored, supporting Jinja style templating based on [tera](https://docs.rs/tera/latest/tera/).
+//!
+//!  See [`swiftide_core::prompt::Prompt`] and [`swiftide_core::prompt::PromptTemplate`]
 
 pub mod chunk_markdown;
 pub mod chunk_text;

--- a/swiftide-integrations/src/groq/mod.rs
+++ b/swiftide-integrations/src/groq/mod.rs
@@ -10,7 +10,7 @@ use self::config::GroqConfig;
 mod config;
 mod simple_prompt;
 
-/// The `Groq` struct encapsulates a `Groq` client that implements [`swiftide::traits::SimplePrompt`]
+/// The `Groq` struct encapsulates a `Groq` client that implements [`swiftide_core::SimplePrompt`]
 ///
 /// There is also a builder available.
 ///

--- a/swiftide-integrations/src/qdrant/mod.rs
+++ b/swiftide-integrations/src/qdrant/mod.rs
@@ -191,8 +191,8 @@ impl QdrantBuilder {
     /// Configures a dense vector on the collection
     ///
     /// When not configured Pipeline by default configures vector only for [`EmbeddedField::Combined`]
-    /// Default config is enough when [`swiftide::indexing::Pipeline::with_embed_mode`] is not set
-    /// or when the value is set to [`swiftide::indexing::EmbedMode::SingleWithMetadata`].
+    /// Default config is enough when `indexing::Pipeline::with_embed_mode` is not set
+    /// or when the value is set to [`swiftide_core::indexing::EmbedMode::SingleWithMetadata`].
     #[must_use]
     pub fn with_vector(mut self, vector: impl Into<VectorConfig>) -> QdrantBuilder {
         if self.vectors.is_none() {

--- a/swiftide-integrations/src/treesitter/metadata_refs_defs_code.rs
+++ b/swiftide-integrations/src/treesitter/metadata_refs_defs_code.rs
@@ -3,7 +3,7 @@
 //! Uses tree-sitter to do the extractions. It tries to only get unique definitions and references,
 //! and only references that are not local.
 //!
-//! See the [`swiftide::integrations::treesitter::CodeParser`] tests for some examples.
+//! See the [`crate::treesitter::CodeParser`] tests for some examples.
 //!
 //! # Example
 //!

--- a/swiftide-query/src/evaluators/mod.rs
+++ b/swiftide-query/src/evaluators/mod.rs
@@ -1,6 +1,4 @@
 /*!
 This module contains evaluators for evaluating the quality of a pipeline.
-
-Evaluators must implement the [`swiftide_core::traits::Evaluator`] trait.
 */
 pub mod ragas;

--- a/swiftide/src/lib.rs
+++ b/swiftide/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! ## Querying
 //!
-//! We are working on an experimental query pipeline, which you can find in [`swiftide::query`]
+//! We are working on an experimental query pipeline, which you can find in [`swiftide_query`]
 //!
 //! ## Examples
 //!


### PR DESCRIPTION
Running `cargo doc --all-features` resulted in a lot of warnings. We should probably add this to the CI/CD pipeline to prevent it from degrading again.