### PR TITLE
fix(tree-sitter): Fix javascript and improve tests

### DIFF
--- a/swiftide-integrations/src/treesitter/code_tree.rs
+++ b/swiftide-integrations/src/treesitter/code_tree.rs
@@ -8,7 +8,7 @@ use tree_sitter::{Parser, Query, QueryCursor, Tree};
 use anyhow::{Context as _, Result};
 use std::collections::HashSet;
 
-use crate::treesitter::queries::{python, ruby, rust, typescript};
+use crate::treesitter::queries::{javascript, python, ruby, rust, typescript};
 
 use super::SupportedLanguages;
 
@@ -113,7 +113,8 @@ fn ts_queries_for_language(language: SupportedLanguages) -> (&'static str, &'sta
         Rust => (rust::DEFS, rust::REFS),
         Python => (python::DEFS, python::REFS),
         // The univocal proof that TS is just a linter
-        Typescript | Javascript => (typescript::DEFS, typescript::REFS),
+        Typescript => (typescript::DEFS, typescript::REFS),
+        Javascript => (javascript::DEFS, javascript::REFS),
         Ruby => (ruby::DEFS, ruby::REFS),
     }
 }
@@ -201,6 +202,30 @@ mod tests {
         }
         "#;
 
+        let tree = parser.parse(code).unwrap();
+        let result = tree.references_and_definitions().unwrap();
+        assert_eq!(result.definitions, vec!["MyClass", "Test", "myMethod"]);
+        assert_eq!(result.references, vec!["log", "otherThing"]);
+    }
+
+    #[test]
+    fn test_parsing_on_javascript() {
+        let parser = CodeParser::from_language(SupportedLanguages::Javascript);
+        let code = r#"
+        function Test() {
+            console.log("Hello, JavaScript!");
+            otherThing();
+        }
+        class MyClass {
+            constructor() {
+                let local = 5;
+                this.myMethod();
+            }
+            myMethod() {
+                console.log("Hello, JavaScript!");
+            }
+        }
+        "#;
         let tree = parser.parse(code).unwrap();
         let result = tree.references_and_definitions().unwrap();
         assert_eq!(result.definitions, vec!["MyClass", "Test", "myMethod"]);

--- a/swiftide-integrations/src/treesitter/queries.rs
+++ b/swiftide-integrations/src/treesitter/queries.rs
@@ -162,6 +162,94 @@ pub mod typescript {
         "#;
 }
 
+// https://github.com/tree-sitter/tree-sitter-javascript/blob/master/queries/tags.scm
+pub mod javascript {
+    pub const DEFS: &str = r#"
+        (
+        (method_definition
+            name: (property_identifier) @name)
+        (#not-eq? @name "constructor")
+        )
+
+        (
+        [
+            (class
+            name: (_) @name)
+            (class_declaration
+            name: (_) @name)
+        ] 
+        )
+
+        (
+        [
+            (function_expression
+            name: (identifier) @name)
+            (function_declaration
+            name: (identifier) @name)
+            (generator_function
+            name: (identifier) @name)
+            (generator_function_declaration
+            name: (identifier) @name)
+        ] 
+        )
+
+        (
+        (lexical_declaration
+            (variable_declarator
+            name: (identifier) @name
+            value: [(arrow_function) (function_expression)]) @definition.function)
+        )
+
+        (
+        (variable_declaration
+            (variable_declarator
+            name: (identifier) @name
+            value: [(arrow_function) (function_expression)]) @definition.function)
+        )
+
+        (assignment_expression
+        left: [
+            (identifier) @name
+            (member_expression
+            property: (property_identifier) @name)
+        ]
+        right: [(arrow_function) (function_expression)]
+        ) 
+
+        (pair
+        key: (property_identifier) @name
+        value: [(arrow_function) (function_expression)])
+
+        "#;
+
+    pub const REFS: &str = r#"
+        (
+        (call_expression
+            function: (identifier) @name) 
+        (#not-match? @name "^(require)$")
+        )
+
+        (call_expression
+        function: (member_expression
+            property: (property_identifier) @name)
+        arguments: (_))
+
+        (new_expression
+        constructor: (_) @name)
+
+        (export_statement value: (assignment_expression left: (identifier) @name right: ([
+        (number)
+        (string)
+        (identifier)
+        (undefined)
+        (null)
+        (new_expression)
+        (binary_expression)
+        (call_expression)
+        ]))) 
+    "#;
+}
+
 // https://github.com/tree-sitter/tree-sitter-rust/blob/master/queries/tags.scm
 pub mod rust {
     pub const DEFS: &str = "


### PR DESCRIPTION
As learned from #309, test coverage for the refs defs transformer was not great. There _are_ more tests in code_tree. Turns out, with the latest treesitter update, javascript broke as it was the only language not covered at all.