### PR TITLE
chore: release v0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.3](https://github.com/bosun-ai/swiftide/releases/tag/0.12.3) - 2024-09-23
+
+### New features
+
+- [da5df22](https://github.com/bosun-ai/swiftide/commit/da5df2230da81e9fe1e6ab74150511cbe1e3d769) *(tree-sitter)*  Implement Serialize and Deserialize for SupportedLanguages ([#314](https://github.com/bosun-ai/swiftide/pull/314))
+
+### Bug fixes
+
+- [a756148](https://github.com/bosun-ai/swiftide/commit/a756148f85faa15b1a79db8ec8106f0e15e4d6a2) *(tree-sitter)*  Fix javascript and improve tests ([#313](https://github.com/bosun-ai/swiftide/pull/313))
+
+````text
+As learned from [#309](https://github.com/bosun-ai/swiftide/pull/309), test coverage for the refs defs transformer was
+  not great. There _are_ more tests in code_tree. Turns out, with the
+  latest treesitter update, javascript broke as it was the only language
+  not covered at all.
+````
+
+### Miscellaneous
+
+- [e8e9d80](https://github.com/bosun-ai/swiftide/commit/e8e9d80f2b4fbfe7ca2818dc542ca0a907a17da5) *(docs)*  Add documentation to query module ([#276](https://github.com/bosun-ai/swiftide/pull/276))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.12.2...0.12.3
+
+
+
 
 ## [v0.12.2](https://github.com/bosun-ai/swiftide/releases/tag/v0.12.2) - 2024-09-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "fluvio",
  "qdrant-client",
@@ -7447,7 +7447,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7473,7 +7473,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7498,7 +7498,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7526,7 +7526,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7580,7 +7580,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7616,7 +7616,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.12.2"
+version = "0.12.3"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.12.2" }
+swiftide-core = { path = "../swiftide-core", version = "0.12.3" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.12.2 -> 0.12.3 (✓ API compatible changes)
* `swiftide-core`: 0.12.2 -> 0.12.3 (✓ API compatible changes)
* `swiftide-indexing`: 0.12.2 -> 0.12.3 (✓ API compatible changes)
* `swiftide-macros`: 0.12.2 -> 0.12.3
* `swiftide-integrations`: 0.12.2 -> 0.12.3 (✓ API compatible changes)
* `swiftide-query`: 0.12.2 -> 0.12.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.12.3](https://github.com/bosun-ai/swiftide/releases/tag/0.12.3) - 2024-09-23

### New features

- [da5df22](https://github.com/bosun-ai/swiftide/commit/da5df2230da81e9fe1e6ab74150511cbe1e3d769) *(tree-sitter)*  Implement Serialize and Deserialize for SupportedLanguages ([#314](https://github.com/bosun-ai/swiftide/pull/314))

### Bug fixes

- [a756148](https://github.com/bosun-ai/swiftide/commit/a756148f85faa15b1a79db8ec8106f0e15e4d6a2) *(tree-sitter)*  Fix javascript and improve tests ([#313](https://github.com/bosun-ai/swiftide/pull/313))

````text
As learned from [#309](https://github.com/bosun-ai/swiftide/pull/309), test coverage for the refs defs transformer was
  not great. There _are_ more tests in code_tree. Turns out, with the
  latest treesitter update, javascript broke as it was the only language
  not covered at all.
````

### Miscellaneous

- [e8e9d80](https://github.com/bosun-ai/swiftide/commit/e8e9d80f2b4fbfe7ca2818dc542ca0a907a17da5) *(docs)*  Add documentation to query module ([#276](https://github.com/bosun-ai/swiftide/pull/276))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.12.2...0.12.3
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).