### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0](https://github.com/bosun-ai/swiftide/compare/v0.12.3...v0.13.0) - 2024-09-26
+
+### New features
+
+- [7d8a57f](https://github.com/bosun-ai/swiftide/commit/7d8a57f54b2c73267dfaa3b3a32079b11d9b32bc) *(indexing)*  [**breaking**] Removed duplication of batch_size. Pipeline owns the default ba… ([#336](https://github.com/bosun-ai/swiftide/pull/336))
+
+````text
+Fixes [#233](https://github.com/bosun-ai/swiftide/pull/233)
+````
+
+**BREAKING CHANGE**: The batch size of batch transformers when indexing is
+now configured on the batch transformer. If no batch size or default is
+configured, a configurable default is used from the pipeline. The
+default batch size is 256.
+
+---------
+
+- [fd110c8](https://github.com/bosun-ai/swiftide/commit/fd110c8efeb3af538d4e51d033b6df02e90e05d9) *(tree-sitter)*  Add support for Java 22 ([#309](https://github.com/bosun-ai/swiftide/pull/309))
+
+### Bug fixes
+
+- [23b96e0](https://github.com/bosun-ai/swiftide/commit/23b96e08b4e0f10f5faea0b193b404c9cd03f47f) *(tree-sitter)*  SupportedLanguages are now non-exhaustive ([#331](https://github.com/bosun-ai/swiftide/pull/331))
+
+### Miscellaneous
+
+- [923a8f0](https://github.com/bosun-ai/swiftide/commit/923a8f0663e7d2b7138f54069f7a74c3cf6663ed) *(fastembed,qdrant)*  Better batching defaults ([#334](https://github.com/bosun-ai/swiftide/pull/334))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.12.3...0.13.0
+
+
+
 ## [0.12.3](https://github.com/bosun-ai/swiftide/releases/tag/0.12.3) - 2024-09-23
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "fluvio",
  "qdrant-client",
@@ -7447,7 +7447,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7473,7 +7473,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7498,7 +7498,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7526,7 +7526,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7581,7 +7581,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7591,7 +7591,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7617,7 +7617,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.12.3"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.12" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.12" }
+swiftide-core = { path = "../swiftide-core", version = "0.13" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.13" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.12" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.12" }
+swiftide-core = { path = "../swiftide-core", version = "0.13" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.13" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.12.3" }
+swiftide-core = { path = "../swiftide-core", version = "0.13.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -14,10 +14,10 @@ homepage.workspace = true
 
 [dependencies]
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.12" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.12" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.12" }
-swiftide-query = { path = "../swiftide-query", version = "0.12" }
+swiftide-core = { path = "../swiftide-core", version = "0.13" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.13" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.13" }
+swiftide-query = { path = "../swiftide-query", version = "0.13" }
 
 [features]
 default = []


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.12.3 -> 0.13.0 (✓ API compatible changes)
* `swiftide-core`: 0.12.3 -> 0.13.0 (✓ API compatible changes)
* `swiftide-indexing`: 0.12.3 -> 0.13.0 (⚠️ API breaking changes)
* `swiftide-macros`: 0.12.3 -> 0.13.0
* `swiftide-integrations`: 0.12.3 -> 0.13.0 (⚠️ API breaking changes)
* `swiftide-query`: 0.12.3 -> 0.13.0

### ⚠️ `swiftide-indexing` breaking changes

```
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/method_parameter_count_changed.ron

Failed in:
  swiftide_indexing::Pipeline::then_in_batch now takes 2 parameters instead of 3, in /tmp/.tmptG2S5s/swiftide/swiftide-indexing/src/pipeline.rs:221
```

### ⚠️ `swiftide-integrations` breaking changes

```
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum SupportedLanguages in /tmp/.tmptG2S5s/swiftide/swiftide-integrations/src/treesitter/supported_languages.rs:37

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/inherent_method_missing.ron

Failed in:
  FastEmbed::with_batch_size, previously in file /tmp/.tmpdwSpSv/swiftide-integrations/src/fastembed/mod.rs:98
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.13.0](https://github.com/bosun-ai/swiftide/compare/v0.12.3...v0.13.0) - 2024-09-26

### New features

- [7d8a57f](https://github.com/bosun-ai/swiftide/commit/7d8a57f54b2c73267dfaa3b3a32079b11d9b32bc) *(indexing)*  [**breaking**] Removed duplication of batch_size. Pipeline owns the default ba… ([#336](https://github.com/bosun-ai/swiftide/pull/336))

````text
Fixes [#233](https://github.com/bosun-ai/swiftide/pull/233)
````

**BREAKING CHANGE**: The batch size of batch transformers when indexing is
now configured on the batch transformer. If no batch size or default is
configured, a configurable default is used from the pipeline. The
default batch size is 256.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).