### PR TITLE
feat(indexing)!: Removed duplication of batch_size. Pipeline owns the default ba…

### DIFF
--- a/examples/fastembed.rs
+++ b/examples/fastembed.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .to_owned();
 
     indexing::Pipeline::from_loader(FileLoader::new(".").with_extensions(&["rs"]))
-        .then_in_batch(10, Embed::new(FastEmbed::builder().batch_size(10).build()?))
+        .then_in_batch(Embed::new(FastEmbed::builder().batch_size(10).build()?))
         .then_store_with(
             Qdrant::try_from_url(qdrant_url)?
                 .batch_size(50)

--- a/examples/fluvio.rs
+++ b/examples/fluvio.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
 
     indexing::Pipeline::from_loader(loader)
-        .then_in_batch(10, Embed::new(FastEmbed::try_default().unwrap()))
+        .then_in_batch(Embed::new(FastEmbed::try_default().unwrap()).with_batch_size(10))
         .then_store_with(
             Qdrant::builder()
                 .batch_size(50)

--- a/examples/index_codebase.rs
+++ b/examples/index_codebase.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "rust",
             10..2048,
         )?)
-        .then_in_batch(10, Embed::new(openai_client.clone()))
+        .then_in_batch(Embed::new(openai_client.clone()).with_batch_size(10))
         .then_store_with(
             Qdrant::builder()
                 .batch_size(50)

--- a/examples/index_codebase_reduced_context.rs
+++ b/examples/index_codebase_reduced_context.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .then(indexing::transformers::CompressCodeOutline::new(
             openai_client.clone(),
         ))
-        .then_in_batch(10, Embed::new(openai_client.clone()))
+        .then_in_batch(Embed::new(openai_client.clone()).with_batch_size(10))
         .then_store_with(
             Qdrant::builder()
                 .batch_size(50)

--- a/examples/index_groq.rs
+++ b/examples/index_groq.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     indexing::Pipeline::from_loader(FileLoader::new("README.md"))
         .then_chunk(ChunkMarkdown::from_chunk_range(10..2048))
         .then(MetadataQAText::new(groq_client.clone()))
-        .then_in_batch(10, Embed::new(fastembed))
+        .then_in_batch(Embed::new(fastembed).with_batch_size(10))
         .then_store_with(memory_store.clone())
         .run()
         .await?;

--- a/examples/index_markdown_lots_of_metadata.rs
+++ b/examples/index_markdown_lots_of_metadata.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .then(MetadataSummary::new(openai_client.clone()))
         .then(MetadataTitle::new(openai_client.clone()))
         .then(MetadataKeywords::new(openai_client.clone()))
-        .then_in_batch(10, Embed::new(openai_client.clone()))
+        .then_in_batch(Embed::new(openai_client.clone()))
         .log_all()
         .filter_errors()
         .then_store_with(

--- a/examples/index_ollama.rs
+++ b/examples/index_ollama.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     indexing::Pipeline::from_loader(FileLoader::new("README.md"))
         .then_chunk(ChunkMarkdown::from_chunk_range(10..2048))
         .then(MetadataQAText::new(ollama_client.clone()))
-        .then_in_batch(10, Embed::new(fastembed))
+        .then_in_batch(Embed::new(fastembed).with_batch_size(10))
         .then_store_with(memory_store.clone())
         .run()
         .await?;

--- a/examples/lancedb.rs
+++ b/examples/lancedb.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     indexing::Pipeline::from_loader(FileLoader::new("README.md"))
         .then_chunk(ChunkMarkdown::from_chunk_range(10..2048))
         .then(MetadataQAText::new(openai_client.clone()))
-        .then_in_batch(10, Embed::new(openai_client.clone()))
+        .then_in_batch(Embed::new(openai_client.clone()).with_batch_size(10))
         .then_store_with(lancedb.clone())
         .run()
         .await?;

--- a/examples/query_pipeline.rs
+++ b/examples/query_pipeline.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     indexing::Pipeline::from_loader(FileLoader::new("README.md"))
         .then_chunk(ChunkMarkdown::from_chunk_range(10..2048))
         .then(MetadataQAText::new(openai_client.clone()))
-        .then_in_batch(10, Embed::new(openai_client.clone()))
+        .then_in_batch(Embed::new(openai_client.clone()).with_batch_size(10))
         .then_store_with(qdrant.clone())
         .run()
         .await?;

--- a/examples/store_multiple_vectors.rs
+++ b/examples/store_multiple_vectors.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .then(MetadataSummary::new(openai_client.clone()))
         .then(MetadataTitle::new(openai_client.clone()))
         .then(MetadataKeywords::new(openai_client.clone()))
-        .then_in_batch(10, Embed::new(openai_client.clone()))
+        .then_in_batch(Embed::new(openai_client.clone()).with_batch_size(10))
         .log_all()
         .filter_errors()
         .then_store_with(

--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -83,6 +83,11 @@ pub trait BatchableTransformer: Send + Sync {
         let name = std::any::type_name::<Self>();
         name.split("::").last().unwrap_or(name)
     }
+
+    /// Overrides the default batch size of the pipeline
+    fn batch_size(&self) -> Option<usize> {
+        None
+    }
 }
 
 #[async_trait]

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -11,6 +11,9 @@ use std::{sync::Arc, time::Duration};
 
 use swiftide_core::indexing::{EmbedMode, IndexingStream, Node};
 
+/// The default batch size for batch processing.
+const DEFAULT_BATCH_SIZE: usize = 256;
+
 /// A pipeline for indexing files, adding metadata, chunking, transforming, embedding, and then storing them.
 ///
 /// The `Pipeline` struct orchestrates the entire file indexing process. It is designed to be flexible and
@@ -38,7 +41,7 @@ impl Default for Pipeline {
             storage: Vec::default(),
             concurrency: num_cpus::get(),
             indexing_defaults: IndexingDefaults::default(),
-            batch_size: 256, //TODO: make this configurable
+            batch_size: DEFAULT_BATCH_SIZE,
         }
     }
 }

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -208,7 +208,7 @@ impl Pipeline {
 
     /// Adds a batch transformer to the pipeline.
     ///
-    /// If the transformer has a batch size set, the pipeline will bach nodes on transformer batch size otherwise on pipeline default batch size ([`DEFAULT_BATCH_SIZE`]).
+    /// If the transformer has a batch size set, the batch size from the transformer is used, otherwise the pipeline default batch size ([`DEFAULT_BATCH_SIZE`]).
     ///
     /// # Arguments
     ///

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -208,7 +208,7 @@ impl Pipeline {
 
     /// Adds a batch transformer to the pipeline.
     ///
-    /// Closures can also be provided as batch transformers.
+    /// If the transformer has a batch size set, the pipeline will bach nodes on transformer batch size otherwise on pipeline default batch size ([`DEFAULT_BATCH_SIZE`]).
     ///
     /// # Arguments
     ///

--- a/swiftide-indexing/src/transformers/embed.rs
+++ b/swiftide-indexing/src/transformers/embed.rs
@@ -14,12 +14,14 @@ use swiftide_core::{
 pub struct Embed {
     embed_model: Arc<dyn EmbeddingModel>,
     concurrency: Option<usize>,
+    batch_size: Option<usize>,
 }
 
 impl std::fmt::Debug for Embed {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Embed")
             .field("concurrency", &self.concurrency)
+            .field("batch_size", &self.batch_size)
             .finish()
     }
 }
@@ -38,12 +40,27 @@ impl Embed {
         Self {
             embed_model: Arc::new(model),
             concurrency: None,
+            batch_size: None,
         }
     }
 
     #[must_use]
     pub fn with_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = Some(concurrency);
+        self
+    }
+
+    /// Sets the batch size for the transformer.
+    /// If the batch size is not set, the transformer will use the default batch size set by the pipeline
+    /// # Parameters
+    ///
+    /// * `batch_size` - The batch size to use for the transformer.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `Embed`.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = Some(batch_size);
         self
     }
 }

--- a/swiftide-indexing/src/transformers/embed.rs
+++ b/swiftide-indexing/src/transformers/embed.rs
@@ -59,6 +59,7 @@ impl Embed {
     /// # Returns
     ///
     /// A new instance of `Embed`.
+    #[must_use]
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = Some(batch_size);
         self

--- a/swiftide-indexing/src/transformers/sparse_embed.rs
+++ b/swiftide-indexing/src/transformers/sparse_embed.rs
@@ -14,6 +14,7 @@ use swiftide_core::{
 pub struct SparseEmbed {
     embed_model: Arc<dyn SparseEmbeddingModel>,
     concurrency: Option<usize>,
+    batch_size: Option<usize>,
 }
 
 impl std::fmt::Debug for SparseEmbed {
@@ -38,12 +39,27 @@ impl SparseEmbed {
         Self {
             embed_model: Arc::new(model),
             concurrency: None,
+            batch_size: None,
         }
     }
 
     #[must_use]
     pub fn with_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = Some(concurrency);
+        self
+    }
+
+    /// Sets the batch size for the transformer.
+    /// If the batch size is not set, the transformer will use the default batch size set by the pipeline
+    /// # Parameters
+    ///
+    /// * `batch_size` - The batch size to use for the transformer.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `Embed`.
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = Some(batch_size);
         self
     }
 }
@@ -113,6 +129,10 @@ impl BatchableTransformer for SparseEmbed {
 
     fn concurrency(&self) -> Option<usize> {
         self.concurrency
+    }
+
+    fn batch_size(&self) -> Option<usize> {
+        self.batch_size
     }
 }
 

--- a/swiftide-indexing/src/transformers/sparse_embed.rs
+++ b/swiftide-indexing/src/transformers/sparse_embed.rs
@@ -58,6 +58,7 @@ impl SparseEmbed {
     /// # Returns
     ///
     /// A new instance of `Embed`.
+    #[must_use]
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
         self.batch_size = Some(batch_size);
         self

--- a/swiftide-integrations/src/fastembed/mod.rs
+++ b/swiftide-integrations/src/fastembed/mod.rs
@@ -95,11 +95,6 @@ impl FastEmbed {
             .build()
     }
 
-    pub fn with_batch_size(&mut self, batch_size: usize) -> &mut Self {
-        self.batch_size = Some(batch_size);
-        self
-    }
-
     pub fn builder() -> FastEmbedBuilder {
         FastEmbedBuilder::default()
     }

--- a/swiftide/src/lib.rs
+++ b/swiftide/src/lib.rs
@@ -41,7 +41,7 @@
 //!  Pipeline::from_loader(FileLoader::new(".").with_extensions(&["md"]))
 //!          .then_chunk(ChunkMarkdown::from_chunk_range(10..512))
 //!          .then(MetadataQAText::new(openai_client.clone()))
-//!          .then_in_batch(10, Embed::new(openai_client.clone()))
+//!          .then_in_batch(Embed::new(openai_client.clone()).with_batch_size(10))
 //!          .then_store_with(
 //!              Qdrant::try_from_url(qdrant_url)?
 //!                  .batch_size(50)
@@ -165,7 +165,7 @@ pub mod indexing {
 ///   indexing::Pipeline::from_loader(FileLoader::new("README.md"))
 ///       .then_chunk(ChunkMarkdown::from_chunk_range(10..2048))
 ///       .then(MetadataQAText::new(openai_client.clone()))
-///       .then_in_batch(10, Embed::new(openai_client.clone()))
+///       .then_in_batch(Embed::new(openai_client.clone()).with_batch_size(10))
 ///       .then_store_with(qdrant.clone())
 ///       .run()
 ///       .await?;

--- a/swiftide/tests/indexing_pipeline.rs
+++ b/swiftide/tests/indexing_pipeline.rs
@@ -54,7 +54,7 @@ async fn test_indexing_pipeline() {
             .then_chunk(transformers::ChunkCode::try_for_language("rust").unwrap())
             .then(transformers::MetadataQACode::default())
             .filter_cached(integrations::redis::Redis::try_from_url(&redis_url, "prefix").unwrap())
-            .then_in_batch(1, transformers::Embed::new(openai_client.clone()))
+            .then_in_batch(transformers::Embed::new(openai_client.clone()).with_batch_size(1))
             .log_nodes()
             .then_store_with(
                 integrations::qdrant::Qdrant::try_from_url(&qdrant_url)
@@ -184,7 +184,7 @@ async fn test_named_vectors() {
             .then_chunk(transformers::ChunkCode::try_for_language("rust").unwrap())
             .then(transformers::MetadataQACode::new(openai_client.clone()))
             .filter_cached(integrations::redis::Redis::try_from_url(&redis_url, "prefix").unwrap())
-            .then_in_batch(10, transformers::Embed::new(openai_client.clone()))
+            .then_in_batch(transformers::Embed::new(openai_client.clone()).with_batch_size(10))
             .then_store_with(
                 integrations::qdrant::Qdrant::try_from_url(&qdrant_url)
                     .unwrap()

--- a/swiftide/tests/lancedb.rs
+++ b/swiftide/tests/lancedb.rs
@@ -52,7 +52,7 @@ async fn test_lancedb() {
                 .insert("filter".to_string(), "true".to_string());
             Ok(node)
         })
-        .then_in_batch(20, transformers::Embed::new(fastembed.clone()))
+        .then_in_batch(transformers::Embed::new(fastembed.clone()).with_batch_size(20))
         .log_nodes()
         .then_store_with(lancedb.clone())
         .run()

--- a/swiftide/tests/query_pipeline.rs
+++ b/swiftide/tests/query_pipeline.rs
@@ -38,7 +38,7 @@ async fn test_query_pipeline() {
         loaders::FileLoader::new(tempdir.path()).with_extensions(&["rs"]),
     )
     .then_chunk(transformers::ChunkCode::try_for_language("rust").unwrap())
-    .then_in_batch(1, transformers::Embed::new(fastembed.clone()))
+    .then_in_batch(transformers::Embed::new(fastembed.clone()).with_batch_size(1))
     .then_store_with(qdrant_client.clone())
     .run()
     .await
@@ -89,14 +89,8 @@ async fn test_hybrid_search_qdrant() {
         .build()
         .unwrap();
 
-    let fastembed_sparse = FastEmbed::try_default_sparse()
-        .unwrap()
-        .with_batch_size(batch_size)
-        .to_owned();
-    let fastembed = FastEmbed::try_default()
-        .unwrap()
-        .with_batch_size(batch_size)
-        .to_owned();
+    let fastembed_sparse = FastEmbed::try_default_sparse().unwrap().to_owned();
+    let fastembed = FastEmbed::try_default().unwrap().to_owned();
 
     println!("Qdrant URL: {qdrant_url}");
 
@@ -104,10 +98,9 @@ async fn test_hybrid_search_qdrant() {
         loaders::FileLoader::new(tempdir.path()).with_extensions(&["rs"]),
     )
     .then_chunk(transformers::ChunkCode::try_for_language("rust").unwrap())
-    .then_in_batch(batch_size, transformers::Embed::new(fastembed.clone()))
+    .then_in_batch(transformers::Embed::new(fastembed.clone()).with_batch_size(batch_size))
     .then_in_batch(
-        batch_size,
-        transformers::SparseEmbed::new(fastembed_sparse.clone()),
+        transformers::SparseEmbed::new(fastembed_sparse.clone()).with_batch_size(batch_size),
     )
     .then_store_with(qdrant_client.clone())
     .run()

--- a/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
+++ b/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
@@ -48,8 +48,8 @@ async fn test_sparse_indexing_pipeline() {
     let result =
         Pipeline::from_loader(loaders::FileLoader::new(tempdir.path()).with_extensions(&["rs"]))
             .then_chunk(transformers::ChunkCode::try_for_language("rust").unwrap())
-            .then_in_batch(20, transformers::SparseEmbed::new(fastembed_sparse))
-            .then_in_batch(20, transformers::Embed::new(fastembed))
+            .then_in_batch(transformers::SparseEmbed::new(fastembed_sparse).with_batch_size(20))
+            .then_in_batch(transformers::Embed::new(fastembed).with_batch_size(20))
             .log_nodes()
             .then_store_with(
                 integrations::qdrant::Qdrant::try_from_url(&qdrant_url)


### PR DESCRIPTION
Fixes #233

BREAKING CHANGE: The batch size of batch transformers when indexing is now configured on the batch transformer. If no batch size or default is configured, a configurable default is used from the pipeline. The default batch size is 256.