### PR TITLE
feat(core): Add support for cloning all trait objects

### DIFF
--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -14,16 +14,15 @@ use crate::prompt::Prompt;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use dyn_clone::DynClone;
+pub use dyn_clone::DynClone;
 /// All traits are easily mockable under tests
 #[cfg(feature = "test-utils")]
 #[doc(hidden)]
-use mockall::{automock, mock, predicate::str};
+use mockall::{mock, predicate::str};
 
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 /// Transforms single nodes into single nodes
-pub trait Transformer: Send + Sync {
+pub trait Transformer: Send + Sync + DynClone {
     async fn transform_node(&self, node: Node) -> Result<Node>;
 
     /// Overrides the default concurrency of the pipeline
@@ -34,6 +33,26 @@ pub trait Transformer: Send + Sync {
     fn name(&self) -> &'static str {
         let name = std::any::type_name::<Self>();
         name.split("::").last().unwrap_or(name)
+    }
+}
+
+dyn_clone::clone_trait_object!(Transformer);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub Transformer {}
+
+    #[async_trait]
+    impl Transformer for Transformer {
+        async fn transform_node(&self, node: Node) -> Result<Node>;
+        fn concurrency(&self) -> Option<usize>;
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for Transformer {
+        fn clone(&self) -> Self;
     }
 }
 
@@ -64,17 +83,16 @@ impl Transformer for &dyn Transformer {
 /// Use a closure as a transformer
 impl<F> Transformer for F
 where
-    F: Fn(Node) -> Result<Node> + Send + Sync,
+    F: Fn(Node) -> Result<Node> + Send + Sync + Clone,
 {
     async fn transform_node(&self, node: Node) -> Result<Node> {
         self(node)
     }
 }
 
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 /// Transforms batched single nodes into streams of nodes
-pub trait BatchableTransformer: Send + Sync {
+pub trait BatchableTransformer: Send + Sync + DynClone {
     /// Transforms a batch of nodes into a stream of nodes
     async fn batch_transform(&self, nodes: Vec<Node>) -> IndexingStream;
 
@@ -94,11 +112,31 @@ pub trait BatchableTransformer: Send + Sync {
     }
 }
 
+dyn_clone::clone_trait_object!(BatchableTransformer);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[derive(Debug)]
+    #[doc(hidden)]
+    pub BatchableTransformer {}
+
+    #[async_trait]
+    impl BatchableTransformer for BatchableTransformer {
+        async fn batch_transform(&self, nodes: Vec<Node>) -> IndexingStream;
+        fn name(&self) -> &'static str;
+        fn batch_size(&self) -> Option<usize>;
+        fn concurrency(&self) -> Option<usize>;
+    }
+
+    impl Clone for BatchableTransformer {
+        fn clone(&self) -> Self;
+    }
+}
 #[async_trait]
 /// Use a closure as a batchable transformer
 impl<F> BatchableTransformer for F
 where
-    F: Fn(Vec<Node>) -> IndexingStream + Send + Sync,
+    F: Fn(Vec<Node>) -> IndexingStream + Send + Sync + Clone,
 {
     async fn batch_transform(&self, nodes: Vec<Node>) -> IndexingStream {
         self(nodes)
@@ -129,8 +167,7 @@ impl BatchableTransformer for &dyn BatchableTransformer {
 }
 
 /// Starting point of a stream
-#[cfg_attr(feature = "test-utils", automock, doc(hidden))]
-pub trait Loader {
+pub trait Loader: DynClone {
     fn into_stream(self) -> IndexingStream;
 
     /// Intended for use with Box<dyn Loader>
@@ -151,6 +188,25 @@ pub trait Loader {
     fn name(&self) -> &'static str {
         let name = std::any::type_name::<Self>();
         name.split("::").last().unwrap_or(name)
+    }
+}
+
+dyn_clone::clone_trait_object!(Loader);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[derive(Debug)]
+    #[doc(hidden)]
+    pub Loader {}
+
+    #[async_trait]
+    impl Loader for Loader {
+        fn into_stream(self) -> IndexingStream;
+        fn into_stream_boxed(self: Box<Self>) -> IndexingStream;
+    }
+
+    impl Clone for Loader {
+        fn clone(&self) -> Self;
     }
 }
 
@@ -177,10 +233,9 @@ impl Loader for &dyn Loader {
     }
 }
 
-#[cfg_attr(feature = "test-utils", automock, doc(hidden))]
 #[async_trait]
 /// Turns one node into many nodes
-pub trait ChunkerTransformer: Send + Sync + Debug {
+pub trait ChunkerTransformer: Send + Sync + Debug + DynClone {
     async fn transform_node(&self, node: Node) -> IndexingStream;
 
     /// Overrides the default concurrency of the pipeline
@@ -194,6 +249,25 @@ pub trait ChunkerTransformer: Send + Sync + Debug {
     }
 }
 
+dyn_clone::clone_trait_object!(ChunkerTransformer);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[derive(Debug)]
+    #[doc(hidden)]
+    pub ChunkerTransformer {}
+
+    #[async_trait]
+    impl ChunkerTransformer for ChunkerTransformer {
+    async fn transform_node(&self, node: Node) -> IndexingStream;
+        fn name(&self) -> &'static str;
+        fn concurrency(&self) -> Option<usize>;
+    }
+
+    impl Clone for ChunkerTransformer {
+        fn clone(&self) -> Self;
+    }
+}
 #[async_trait]
 impl ChunkerTransformer for Box<dyn ChunkerTransformer> {
     async fn transform_node(&self, node: Node) -> IndexingStream {
@@ -243,6 +317,7 @@ dyn_clone::clone_trait_object!(NodeCache);
 #[cfg(feature = "test-utils")]
 mock! {
     #[derive(Debug)]
+    #[doc(hidden)]
     pub NodeCache {}
 
     #[async_trait]
@@ -287,16 +362,34 @@ impl NodeCache for &dyn NodeCache {
     }
 }
 
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 /// Embeds a list of strings and returns its embeddings.
 /// Assumes the strings will be moved.
-pub trait EmbeddingModel: Send + Sync + Debug {
+pub trait EmbeddingModel: Send + Sync + Debug + DynClone {
     async fn embed(&self, input: Vec<String>) -> Result<Embeddings>;
 
     fn name(&self) -> &'static str {
         let name = std::any::type_name::<Self>();
         name.split("::").last().unwrap_or(name)
+    }
+}
+
+dyn_clone::clone_trait_object!(EmbeddingModel);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[derive(Debug)]
+    #[doc(hidden)]
+    pub EmbeddingModel {}
+
+    #[async_trait]
+    impl EmbeddingModel for EmbeddingModel {
+        async fn embed(&self, input: Vec<String>) -> Result<Embeddings>;
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for EmbeddingModel {
+        fn clone(&self) -> Self;
     }
 }
 
@@ -318,16 +411,34 @@ impl EmbeddingModel for &dyn EmbeddingModel {
     }
 }
 
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 /// Embeds a list of strings and returns its embeddings.
 /// Assumes the strings will be moved.
-pub trait SparseEmbeddingModel: Send + Sync + Debug {
+pub trait SparseEmbeddingModel: Send + Sync + Debug + DynClone {
     async fn sparse_embed(&self, input: Vec<String>) -> Result<SparseEmbeddings>;
 
     fn name(&self) -> &'static str {
         let name = std::any::type_name::<Self>();
         name.split("::").last().unwrap_or(name)
+    }
+}
+
+dyn_clone::clone_trait_object!(SparseEmbeddingModel);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[derive(Debug)]
+    #[doc(hidden)]
+    pub SparseEmbeddingModel {}
+
+    #[async_trait]
+    impl SparseEmbeddingModel for SparseEmbeddingModel {
+    async fn sparse_embed(&self, input: Vec<String>) -> Result<SparseEmbeddings>;
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for SparseEmbeddingModel {
+        fn clone(&self) -> Self;
     }
 }
 
@@ -349,16 +460,34 @@ impl SparseEmbeddingModel for &dyn SparseEmbeddingModel {
     }
 }
 
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 /// Given a string prompt, queries an LLM
-pub trait SimplePrompt: Debug + Send + Sync {
+pub trait SimplePrompt: Debug + Send + Sync + DynClone {
     // Takes a simple prompt, prompts the llm and returns the response
     async fn prompt(&self, prompt: Prompt) -> Result<String>;
 
     fn name(&self) -> &'static str {
         let name = std::any::type_name::<Self>();
         name.split("::").last().unwrap_or(name)
+    }
+}
+
+dyn_clone::clone_trait_object!(SimplePrompt);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[derive(Debug)]
+    #[doc(hidden)]
+    pub SimplePrompt {}
+
+    #[async_trait]
+    impl SimplePrompt for SimplePrompt {
+        async fn prompt(&self, prompt: Prompt) -> Result<String>;
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for SimplePrompt {
+        fn clone(&self) -> Self;
     }
 }
 
@@ -380,10 +509,9 @@ impl SimplePrompt for &dyn SimplePrompt {
     }
 }
 
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
 /// Persists nodes
-pub trait Persist: Debug + Send + Sync {
+pub trait Persist: Debug + Send + Sync + DynClone {
     async fn setup(&self) -> Result<()>;
     async fn store(&self, node: Node) -> Result<Node>;
     async fn batch_store(&self, nodes: Vec<Node>) -> IndexingStream;
@@ -394,6 +522,29 @@ pub trait Persist: Debug + Send + Sync {
     fn name(&self) -> &'static str {
         let name = std::any::type_name::<Self>();
         name.split("::").last().unwrap_or(name)
+    }
+}
+
+dyn_clone::clone_trait_object!(Persist);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[derive(Debug)]
+    #[doc(hidden)]
+    pub Persist {}
+
+    #[async_trait]
+    impl Persist for Persist {
+        async fn setup(&self) -> Result<()>;
+        async fn store(&self, node: Node) -> Result<Node>;
+        async fn batch_store(&self, nodes: Vec<Node>) -> IndexingStream;
+        fn batch_size(&self) -> Option<usize>;
+
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for Persist {
+        fn clone(&self) -> Self;
     }
 }
 

--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -203,6 +203,7 @@ mock! {
     impl Loader for Loader {
         fn into_stream(self) -> IndexingStream;
         fn into_stream_boxed(self: Box<Self>) -> IndexingStream;
+        fn name(&self) -> &'static str;
     }
 
     impl Clone for Loader {
@@ -325,6 +326,7 @@ mock! {
         async fn get(&self, node: &Node) -> bool;
         async fn set(&self, node: &Node);
         async fn clear(&self) -> Result<()>;
+        fn name(&self) -> &'static str;
 
     }
 

--- a/swiftide-core/src/query_traits.rs
+++ b/swiftide-core/src/query_traits.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use dyn_clone::DynClone;
 
 use crate::{
     query::{
@@ -11,12 +12,11 @@ use crate::{
 
 #[cfg(feature = "test-utils")]
 #[doc(hidden)]
-use mockall::{automock, predicate::str};
+use mockall::{mock, predicate::str};
 
 /// Can transform queries before retrieval
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
-pub trait TransformQuery: Send + Sync {
+pub trait TransformQuery: Send + Sync + DynClone {
     async fn transform_query(
         &self,
         query: Query<states::Pending>,
@@ -28,10 +28,32 @@ pub trait TransformQuery: Send + Sync {
     }
 }
 
+dyn_clone::clone_trait_object!(TransformQuery);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub TransformQuery {}
+
+    #[async_trait]
+    impl TransformQuery for TransformQuery {
+        async fn transform_query(
+            &self,
+            query: Query<states::Pending>,
+        ) -> Result<Query<states::Pending>>;
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for TransformQuery {
+        fn clone(&self) -> Self;
+    }
+}
+
 #[async_trait]
 impl<F> TransformQuery for F
 where
-    F: Fn(Query<states::Pending>) -> Result<Query<states::Pending>> + Send + Sync,
+    F: Fn(Query<states::Pending>) -> Result<Query<states::Pending>> + Send + Sync + Clone,
 {
     async fn transform_query(
         &self,
@@ -56,7 +78,7 @@ pub trait SearchStrategy: Clone + Send + Sync + Default {}
 
 /// Can retrieve documents given a SearchStrategy
 #[async_trait]
-pub trait Retrieve<S: SearchStrategy>: Send + Sync {
+pub trait Retrieve<S: SearchStrategy>: Send + Sync + DynClone {
     async fn retrieve(
         &self,
         search_strategy: &S,
@@ -68,6 +90,8 @@ pub trait Retrieve<S: SearchStrategy>: Send + Sync {
         name.split("::").last().unwrap_or(name)
     }
 }
+
+dyn_clone::clone_trait_object!(<S> Retrieve<S>);
 
 #[async_trait]
 impl<S: SearchStrategy> Retrieve<S> for Box<dyn Retrieve<S>> {
@@ -84,7 +108,7 @@ impl<S: SearchStrategy> Retrieve<S> for Box<dyn Retrieve<S>> {
 impl<S, F> Retrieve<S> for F
 where
     S: SearchStrategy,
-    F: Fn(&S, Query<states::Pending>) -> Result<Query<states::Retrieved>> + Send + Sync,
+    F: Fn(&S, Query<states::Pending>) -> Result<Query<states::Retrieved>> + Send + Sync + Clone,
 {
     async fn retrieve(
         &self,
@@ -96,9 +120,8 @@ where
 }
 
 /// Can transform a response after retrieval
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
-pub trait TransformResponse: Send + Sync {
+pub trait TransformResponse: Send + Sync + DynClone {
     async fn transform_response(&self, query: Query<Retrieved>)
         -> Result<Query<states::Retrieved>>;
 
@@ -108,10 +131,29 @@ pub trait TransformResponse: Send + Sync {
     }
 }
 
+dyn_clone::clone_trait_object!(TransformResponse);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub TransformResponse {}
+
+    #[async_trait]
+    impl TransformResponse for TransformResponse {
+        async fn transform_response(&self, query: Query<Retrieved>)
+            -> Result<Query<states::Retrieved>>;
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for TransformResponse {
+        fn clone(&self) -> Self;
+    }
+}
 #[async_trait]
 impl<F> TransformResponse for F
 where
-    F: Fn(Query<Retrieved>) -> Result<Query<Retrieved>> + Send + Sync,
+    F: Fn(Query<Retrieved>) -> Result<Query<Retrieved>> + Send + Sync + Clone,
 {
     async fn transform_response(&self, query: Query<Retrieved>) -> Result<Query<Retrieved>> {
         (self)(query)
@@ -126,9 +168,8 @@ impl TransformResponse for Box<dyn TransformResponse> {
 }
 
 /// Can answer the original query
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
-pub trait Answer: Send + Sync {
+pub trait Answer: Send + Sync + DynClone {
     async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>>;
 
     fn name(&self) -> &'static str {
@@ -137,10 +178,28 @@ pub trait Answer: Send + Sync {
     }
 }
 
+dyn_clone::clone_trait_object!(Answer);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub Answer {}
+
+    #[async_trait]
+    impl Answer for Answer {
+        async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>>;
+        fn name(&self) -> &'static str;
+    }
+
+    impl Clone for Answer {
+        fn clone(&self) -> Self;
+    }
+}
 #[async_trait]
 impl<F> Answer for F
 where
-    F: Fn(Query<Retrieved>) -> Result<Query<states::Answered>> + Send + Sync,
+    F: Fn(Query<Retrieved>) -> Result<Query<states::Answered>> + Send + Sync + Clone,
 {
     async fn answer(&self, query: Query<Retrieved>) -> Result<Query<states::Answered>> {
         (self)(query)
@@ -157,12 +216,28 @@ impl Answer for Box<dyn Answer> {
 /// Evaluates a query
 ///
 /// An evaluator needs to be able to respond to each step in the query pipeline
-#[cfg_attr(feature = "test-utils", automock)]
 #[async_trait]
-pub trait EvaluateQuery: Send + Sync {
+pub trait EvaluateQuery: Send + Sync + DynClone {
     async fn evaluate(&self, evaluation: QueryEvaluation) -> Result<()>;
 }
 
+dyn_clone::clone_trait_object!(EvaluateQuery);
+
+#[cfg(feature = "test-utils")]
+mock! {
+    #[doc(hidden)]
+    #[derive(Debug)]
+    pub EvaluateQuery {}
+
+    #[async_trait]
+    impl EvaluateQuery for EvaluateQuery {
+        async fn evaluate(&self, evaluation: QueryEvaluation) -> Result<()>;
+    }
+
+    impl Clone for EvaluateQuery {
+        fn clone(&self) -> Self;
+    }
+}
 #[async_trait]
 impl EvaluateQuery for Box<dyn EvaluateQuery> {
     async fn evaluate(&self, evaluation: QueryEvaluation) -> Result<()> {

--- a/swiftide-indexing/src/loaders/file_loader.rs
+++ b/swiftide-indexing/src/loaders/file_loader.rs
@@ -15,6 +15,7 @@ use swiftide_core::{indexing::IndexingStream, indexing::Node, Loader};
 /// # use swiftide_indexing::loaders::FileLoader;
 /// indexing::Pipeline::from_loader(FileLoader::new(".").with_extensions(&["rs"]));
 /// ```
+#[derive(Clone, Debug)]
 pub struct FileLoader {
     pub(crate) path: PathBuf,
     pub(crate) extensions: Option<Vec<String>>,

--- a/swiftide-indexing/src/transformers/chunk_markdown.rs
+++ b/swiftide-indexing/src/transformers/chunk_markdown.rs
@@ -1,10 +1,12 @@
 //! Chunk markdown content into smaller pieces
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use derive_builder::Builder;
 use swiftide_core::{indexing::IndexingStream, indexing::Node, ChunkerTransformer};
 use text_splitter::{Characters, MarkdownSplitter};
 
-#[derive(Debug, Builder)]
+#[derive(Debug, Clone, Builder)]
 #[builder(pattern = "owned", setter(strip_option))]
 /// A transformer that chunks markdown content into smaller pieces.
 ///
@@ -15,7 +17,8 @@ use text_splitter::{Characters, MarkdownSplitter};
 ///
 /// Technically that might work with every splitter `text_splitter` provides.
 pub struct ChunkMarkdown {
-    chunker: MarkdownSplitter<Characters>,
+    #[builder(setter(into))]
+    chunker: Arc<MarkdownSplitter<Characters>>,
     #[builder(default)]
     /// The number of concurrent chunks to process.
     concurrency: Option<usize>,
@@ -30,7 +33,7 @@ impl ChunkMarkdown {
     /// Create a new transformer with a maximum number of characters per chunk.
     pub fn from_max_characters(max_characters: usize) -> Self {
         Self {
-            chunker: MarkdownSplitter::new(max_characters),
+            chunker: Arc::new(MarkdownSplitter::new(max_characters)),
             concurrency: None,
             range: None,
         }
@@ -41,7 +44,7 @@ impl ChunkMarkdown {
     /// Chunks smaller than the range will be ignored.
     pub fn from_chunk_range(range: std::ops::Range<usize>) -> Self {
         Self {
-            chunker: MarkdownSplitter::new(range.clone()),
+            chunker: Arc::new(MarkdownSplitter::new(range.clone())),
             concurrency: None,
             range: Some(range),
         }

--- a/swiftide-indexing/src/transformers/chunk_text.rs
+++ b/swiftide-indexing/src/transformers/chunk_text.rs
@@ -1,9 +1,11 @@
 //! Chunk text content into smaller pieces
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use derive_builder::Builder;
 use swiftide_core::{indexing::IndexingStream, indexing::Node, ChunkerTransformer};
 
-#[derive(Debug, Builder)]
+#[derive(Debug, Clone, Builder)]
 #[builder(pattern = "owned", setter(strip_option))]
 /// A transformer that chunks text content into smaller pieces.
 ///
@@ -15,7 +17,8 @@ use swiftide_core::{indexing::IndexingStream, indexing::Node, ChunkerTransformer
 ///
 /// Technically that might work with every splitter `text_splitter` provides.
 pub struct ChunkText {
-    chunker: text_splitter::TextSplitter<text_splitter::Characters>,
+    #[builder(setter(into))]
+    chunker: Arc<text_splitter::TextSplitter<text_splitter::Characters>>,
     #[builder(default)]
     /// The number of concurrent chunks to process.
     concurrency: Option<usize>,
@@ -30,7 +33,7 @@ impl ChunkText {
     /// Create a new transformer with a maximum number of characters per chunk.
     pub fn from_max_characters(max_characters: usize) -> Self {
         Self {
-            chunker: text_splitter::TextSplitter::new(max_characters),
+            chunker: Arc::new(text_splitter::TextSplitter::new(max_characters)),
             concurrency: None,
             range: None,
         }
@@ -41,7 +44,7 @@ impl ChunkText {
     /// Chunks smaller than the range will be ignored.
     pub fn from_chunk_range(range: std::ops::Range<usize>) -> Self {
         Self {
-            chunker: text_splitter::TextSplitter::new(range.clone()),
+            chunker: Arc::new(text_splitter::TextSplitter::new(range.clone())),
             concurrency: None,
             range: Some(range),
         }

--- a/swiftide-indexing/src/transformers/embed.rs
+++ b/swiftide-indexing/src/transformers/embed.rs
@@ -11,6 +11,7 @@ use swiftide_core::{
 /// A transformer that can generate embeddings for an `Node`
 ///
 /// This file defines the `Embed` struct and its implementation of the `BatchableTransformer` trait.
+#[derive(Clone)]
 pub struct Embed {
     embed_model: Arc<dyn EmbeddingModel>,
     concurrency: Option<usize>,

--- a/swiftide-indexing/src/transformers/sparse_embed.rs
+++ b/swiftide-indexing/src/transformers/sparse_embed.rs
@@ -11,6 +11,7 @@ use swiftide_core::{
 /// A transformer that can generate embeddings for an `Node`
 ///
 /// This file defines the `SparseEmbed` struct and its implementation of the `BatchableTransformer` trait.
+#[derive(Clone)]
 pub struct SparseEmbed {
     embed_model: Arc<dyn SparseEmbeddingModel>,
     concurrency: Option<usize>,

--- a/swiftide-integrations/src/scraping/loader.rs
+++ b/swiftide-integrations/src/scraping/loader.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use derive_builder::Builder;
 use spider::website::Website;
 use tokio::{runtime::Handle, sync::RwLock};
@@ -7,14 +9,14 @@ use swiftide_core::{
     Loader,
 };
 
-#[derive(Debug, Builder)]
+#[derive(Debug, Builder, Clone)]
 #[builder(pattern = "owned")]
 /// Scrapes a given website
 ///
 /// Under the hood uses the `spider` crate to scrape the website.
 /// For more configuration options see their documentation.
 pub struct ScrapingLoader {
-    spider_website: RwLock<Website>,
+    spider_website: Arc<RwLock<Website>>,
 }
 
 impl ScrapingLoader {
@@ -26,7 +28,7 @@ impl ScrapingLoader {
     #[allow(dead_code)]
     pub fn from_spider(spider_website: Website) -> Self {
         Self {
-            spider_website: RwLock::new(spider_website),
+            spider_website: Arc::new(RwLock::new(spider_website)),
         }
     }
 


### PR DESCRIPTION
For instance, if you have a `Box<dyn SimplePrompt>`, you can now clone into an owned copy and more effectively use the available generics. This also works for borrowed trait objects.