### PR TITLE
chore: release v0.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.2](https://github.com/bosun-ai/swiftide/compare/v0.13.1...v0.13.2) - 2024-10-05
+
+### New features
+
+- [4b13aa7](https://github.com/bosun-ai/swiftide/commit/4b13aa7d76dfc7270870682e2f757f066a99ba4e) *(core)*  Add support for cloning all trait objects ([#355](https://github.com/bosun-ai/swiftide/pull/355))
+
+````text
+For instance, if you have a `Box<dyn SimplePrompt>`, you can now clone
+  into an owned copy and more effectively use the available generics. This
+  also works for borrowed trait objects.
+````
+
+- [ed3da52](https://github.com/bosun-ai/swiftide/commit/ed3da52cf89b2384ec6f07c610c591b3eda2fa28) *(indexing)*  Support Redb as embedable nodecache ([#346](https://github.com/bosun-ai/swiftide/pull/346))
+
+````text
+Adds support for Redb as an embeddable node cache, allowing full local
+  app development without needing external services.
+````
+
+### Bug fixes
+
+- [06f8336](https://github.com/bosun-ai/swiftide/commit/06f83361c52010a451e8b775ce9c5d67057edbc5) *(indexing)*  Ensure `name()` returns concrete name on trait objects ([#351](https://github.com/bosun-ai/swiftide/pull/351))
+
+### Miscellaneous
+
+- [8237c28](https://github.com/bosun-ai/swiftide/commit/8237c2890df681c48117188e80cbad914b91e0fd) *(core)*  Mock traits for testing should not have their docs hidden
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.13.1...0.13.2
+
+
+
 ## [0.13.1](https://github.com/bosun-ai/swiftide/compare/v0.13.0...v0.13.1) - 2024-10-02
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2718,7 +2718,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "fluvio",
  "qdrant-client",
@@ -7485,7 +7485,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7511,7 +7511,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7537,7 +7537,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7565,7 +7565,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7621,7 +7621,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7657,7 +7657,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.13.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.13.2" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.13.1 -> 0.13.2 (✓ API compatible changes)
* `swiftide-core`: 0.13.1 -> 0.13.2 (✓ API compatible changes)
* `swiftide-indexing`: 0.13.1 -> 0.13.2 (✓ API compatible changes)
* `swiftide-macros`: 0.13.1 -> 0.13.2
* `swiftide-integrations`: 0.13.1 -> 0.13.2 (✓ API compatible changes)
* `swiftide-query`: 0.13.1 -> 0.13.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.13.2](https://github.com/bosun-ai/swiftide/compare/v0.13.1...v0.13.2) - 2024-10-05

### New features

- [4b13aa7](https://github.com/bosun-ai/swiftide/commit/4b13aa7d76dfc7270870682e2f757f066a99ba4e) *(core)*  Add support for cloning all trait objects ([#355](https://github.com/bosun-ai/swiftide/pull/355))

````text
For instance, if you have a `Box<dyn SimplePrompt>`, you can now clone
  into an owned copy and more effectively use the available generics. This
  also works for borrowed trait objects.
````

- [ed3da52](https://github.com/bosun-ai/swiftide/commit/ed3da52cf89b2384ec6f07c610c591b3eda2fa28) *(indexing)*  Support Redb as embedable nodecache ([#346](https://github.com/bosun-ai/swiftide/pull/346))

````text
Adds support for Redb as an embeddable node cache, allowing full local
  app development without needing external services.
````

### Bug fixes

- [06f8336](https://github.com/bosun-ai/swiftide/commit/06f83361c52010a451e8b775ce9c5d67057edbc5) *(indexing)*  Ensure `name()` returns concrete name on trait objects ([#351](https://github.com/bosun-ai/swiftide/pull/351))

### Miscellaneous

- [8237c28](https://github.com/bosun-ai/swiftide/commit/8237c2890df681c48117188e80cbad914b91e0fd) *(core)*  Mock traits for testing should not have their docs hidden

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.13.1...0.13.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).