### PR TITLE
chore: release v0.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 ## [0.13.3](https://github.com/bosun-ai/swiftide/compare/v0.13.2...v0.13.3) - 2024-10-11
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2777,7 +2777,7 @@ dependencies = [
 
 [[package]]
 name = "examples"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "fluvio",
  "qdrant-client",
@@ -7557,7 +7557,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7584,7 +7584,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7610,7 +7610,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7638,7 +7638,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7694,7 +7694,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7704,7 +7704,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7730,7 +7730,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.13.3"
+version = "0.13.4"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.13.3" }
+swiftide-core = { path = "../swiftide-core", version = "0.13.4" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.13.3 -> 0.13.4 (✓ API compatible changes)
* `swiftide-core`: 0.13.3 -> 0.13.4
* `swiftide-indexing`: 0.13.3 -> 0.13.4
* `swiftide-macros`: 0.13.3 -> 0.13.4
* `swiftide-integrations`: 0.13.3 -> 0.13.4
* `swiftide-query`: 0.13.3 -> 0.13.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.13.3](https://github.com/bosun-ai/swiftide/compare/v0.13.2...v0.13.3) - 2024-10-11

### Bug fixes

- [2647f16](https://github.com/bosun-ai/swiftide/commit/2647f16dc164eb5230d8f7c6d71e31663000cb0d) *(deps)*  Update rust crate text-splitter to 0.17 ([#366](https://github.com/bosun-ai/swiftide/pull/366))

- [d74d85b](https://github.com/bosun-ai/swiftide/commit/d74d85be3bd98706349eff373c16443b9c45c4f0) *(indexing)*  Add missing `Embed::batch_size` implementation ([#378](https://github.com/bosun-ai/swiftide/pull/378))

- [95f78d3](https://github.com/bosun-ai/swiftide/commit/95f78d3412951c099df33149c57817338a76553d) *(tree-sitter)*  Compile regex only once ([#371](https://github.com/bosun-ai/swiftide/pull/371))

````text
Regex compilation is not cheap, use a static with a oncelock instead.
````

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.13.2...0.13.3
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).