### PR TITLE
chore: Improve workspace configuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,7 @@ jobs:
           tool: cargo-llvm-cov
       - name: Generate code coverage
         run: |
-          cargo +nightly llvm-cov --workspace --all-features --lcov --output-path lcov.info
+          cargo +nightly llvm-cov --tests --all-features --lcov --output-path lcov.info
 
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Lint dependencies
         uses: EmbarkStudios/cargo-deny-action@v2
       - name: clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features --workspace
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,5 @@
 [workspace]
-members = [
-  "swiftide",
-  "swiftide-core",
-  "swiftide-integrations",
-  "swiftide-indexing",
-
-  "examples",
-  "benchmarks",
-  "swiftide-test-utils",
-  "swiftide-macros",
-]
+members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
+default-members = ["swiftide", "swiftide-*"]
+
 resolver = "2"
 
 [workspace.package]


### PR DESCRIPTION
Ensure swiftide\* crates are always included. Additionally, these are the default members, excluding examples and benches.
