### PR TITLE
fix(indexing)!: Node ID no longer memoized

### DIFF
--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -37,7 +37,7 @@ use crate::{metadata::Metadata, util::debug_long_utf8, Embedding, SparseEmbeddin
 /// in the indexing pipeline. It includes fields for an identifier, file path, data chunk, optional
 /// vector representation, and metadata.
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq, Builder)]
-#[builder(setter(into, strip_option), build_fn(error = "anyhow::Error"))]
+#[builder(setter(into), build_fn(error = "anyhow::Error"))]
 pub struct Node {
     /// File path associated with the node.
     #[builder(default)]
@@ -110,8 +110,8 @@ impl Node {
             .path(node.path.clone())
             .chunk(node.chunk.clone())
             .metadata(node.metadata.clone())
-            .vectors(node.vectors.clone().unwrap_or_default())
-            .sparse_vectors(node.sparse_vectors.clone().unwrap_or_default())
+            .vectors(node.vectors.clone())
+            .sparse_vectors(node.sparse_vectors.clone())
             .embed_mode(node.embed_mode)
             .original_size(node.original_size)
             .offset(node.offset)

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -23,7 +23,6 @@ use std::{
     hash::{Hash, Hasher},
     os::unix::ffi::OsStrExt,
     path::PathBuf,
-    sync::OnceLock,
 };
 
 use derive_builder::Builder;

--- a/swiftide-indexing/src/loaders/file_loader.rs
+++ b/swiftide-indexing/src/loaders/file_loader.rs
@@ -72,12 +72,12 @@ impl FileLoader {
                 tracing::debug!("Reading file: {:?}", entry);
                 let content = std::fs::read_to_string(&entry).unwrap();
                 let original_size = content.len();
-                Node {
-                    path: entry,
-                    chunk: content,
-                    original_size,
-                    ..Default::default()
-                }
+                Node::builder()
+                    .path(entry)
+                    .chunk(content)
+                    .original_size(original_size)
+                    .build()
+                    .expect("Failed to build node")
             })
             .collect()
     }
@@ -113,12 +113,12 @@ impl Loader for FileLoader {
                 let content =
                     std::fs::read_to_string(entry.path()).context("Failed to read file")?;
                 let original_size = content.len();
-                Ok(Node {
-                    path: entry.path().into(),
-                    chunk: content,
-                    original_size,
-                    ..Default::default()
-                })
+
+                Node::builder()
+                    .path(entry.path())
+                    .chunk(content)
+                    .original_size(original_size)
+                    .build()
             });
 
         IndexingStream::iter(files)

--- a/swiftide-indexing/src/persist/memory_storage.rs
+++ b/swiftide-indexing/src/persist/memory_storage.rs
@@ -27,7 +27,7 @@ pub struct MemoryStorage {
 }
 
 impl MemoryStorage {
-    async fn key(&self, node: &Node) -> String {
+    async fn key(&self) -> String {
         self.node_count.read().await.to_string()
     }
 
@@ -62,7 +62,7 @@ impl Persist for MemoryStorage {
     ///
     /// If the node does not have an id, a simple counter is used as the key.
     async fn store(&self, node: Node) -> Result<Node> {
-        let key = self.key(&node).await;
+        let key = self.key().await;
         self.data.write().await.insert(key, node.clone());
 
         (*self.node_count.write().await) += 1;

--- a/swiftide-indexing/src/persist/memory_storage.rs
+++ b/swiftide-indexing/src/persist/memory_storage.rs
@@ -16,7 +16,7 @@ use swiftide_core::{
 ///
 /// Great for experimentation and testing.
 ///
-/// By default the storage will use a zero indexed, incremental counter as the key for each node if the node id
+/// The storage will use a zero indexed, incremental counter as the key for each node if the node id
 /// is not set.
 pub struct MemoryStorage {
     data: Arc<RwLock<HashMap<String, Node>>>,
@@ -28,10 +28,7 @@ pub struct MemoryStorage {
 
 impl MemoryStorage {
     async fn key(&self, node: &Node) -> String {
-        match node.id {
-            Some(id) => id.to_string(),
-            None => (*self.node_count.read().await).to_string(),
-        }
+        self.node_count.read().await.to_string()
     }
 
     /// Retrieve a node by its key
@@ -68,9 +65,7 @@ impl Persist for MemoryStorage {
         let key = self.key(&node).await;
         self.data.write().await.insert(key, node.clone());
 
-        if node.id.is_none() {
-            *self.node_count.write().await += 1;
-        }
+        (*self.node_count.write().await) += 1;
         Ok(node)
     }
 

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -777,10 +777,7 @@ mod tests {
             .returning(|| {
                 vec![
                     Ok(Node::default()),
-                    Ok(Node {
-                        chunk: "skip".to_string(),
-                        ..Node::default()
-                    }),
+                    Ok(Node::new("skip")),
                     Ok(Node::default()),
                 ]
                 .into()
@@ -808,10 +805,7 @@ mod tests {
             .returning(|| {
                 vec![
                     Ok(Node::default()),
-                    Ok(Node {
-                        chunk: "will go left".to_string(),
-                        ..Node::default()
-                    }),
+                    Ok(Node::new("will go left")),
                     Ok(Node::default()),
                 ]
                 .into()

--- a/swiftide-indexing/src/transformers/chunk_markdown.rs
+++ b/swiftide-indexing/src/transformers/chunk_markdown.rs
@@ -128,12 +128,11 @@ impl ChunkerTransformer for ChunkMarkdown {
             })
             .collect::<Vec<String>>();
 
-        IndexingStream::iter(chunks.into_iter().map(move |chunk| {
-            Ok(Node {
-                chunk,
-                ..node.clone()
-            })
-        }))
+        IndexingStream::iter(
+            chunks
+                .into_iter()
+                .map(move |chunk| Node::build_from_other(&node).chunk(chunk).build()),
+        )
     }
 
     fn concurrency(&self) -> Option<usize> {
@@ -164,10 +163,7 @@ mod test {
     async fn test_transforming_with_max_characters_and_trimming() {
         let chunker = ChunkMarkdown::from_max_characters(40);
 
-        let node = Node {
-            chunk: MARKDOWN.to_string(),
-            ..Node::default()
-        };
+        let node = Node::new(MARKDOWN.to_string());
 
         let nodes: Vec<Node> = chunker
             .transform_node(node)
@@ -192,10 +188,7 @@ mod test {
         let ranges = vec![(10..15), (20..25), (30..35), (40..45), (50..55)];
         for range in ranges {
             let chunker = ChunkMarkdown::from_chunk_range(range.clone());
-            let node = Node {
-                chunk: MARKDOWN.to_string(),
-                ..Node::default()
-            };
+            let node = Node::new(MARKDOWN.to_string());
             let nodes: Vec<Node> = chunker
                 .transform_node(node)
                 .await

--- a/swiftide-indexing/src/transformers/chunk_text.rs
+++ b/swiftide-indexing/src/transformers/chunk_text.rs
@@ -121,12 +121,11 @@ impl ChunkerTransformer for ChunkText {
             })
             .collect::<Vec<String>>();
 
-        IndexingStream::iter(chunks.into_iter().map(move |chunk| {
-            Ok(Node {
-                chunk,
-                ..node.clone()
-            })
-        }))
+        IndexingStream::iter(
+            chunks
+                .into_iter()
+                .map(move |chunk| Node::build_from_other(&node).chunk(chunk).build()),
+        )
     }
 
     fn concurrency(&self) -> Option<usize> {
@@ -151,10 +150,7 @@ mod test {
     async fn test_transforming_with_max_characters_and_trimming() {
         let chunker = ChunkText::from_max_characters(40);
 
-        let node = Node {
-            chunk: TEXT.to_string(),
-            ..Node::default()
-        };
+        let node = Node::new(TEXT.to_string());
 
         let nodes: Vec<Node> = chunker
             .transform_node(node)
@@ -175,10 +171,7 @@ mod test {
         let ranges = vec![(10..15), (20..25), (30..35), (40..45), (50..55)];
         for range in ranges {
             let chunker = ChunkText::from_chunk_range(range.clone());
-            let node = Node {
-                chunk: TEXT.to_string(),
-                ..Node::default()
-            };
+            let node = Node::new(TEXT.to_string());
             let nodes: Vec<Node> = chunker
                 .transform_node(node)
                 .await

--- a/swiftide-indexing/src/transformers/embed.rs
+++ b/swiftide-indexing/src/transformers/embed.rs
@@ -254,11 +254,13 @@ mod tests {
     async fn batch_transform(test_data: Vec<TestData<'_>>) {
         let test_nodes: Vec<Node> = test_data
             .iter()
-            .map(|data| Node {
-                chunk: data.chunk.into(),
-                metadata: data.metadata.clone(),
-                embed_mode: data.embed_mode,
-                ..Default::default()
+            .map(|data| {
+                Node::builder()
+                    .chunk(data.chunk)
+                    .metadata(data.metadata.clone())
+                    .embed_mode(data.embed_mode)
+                    .build()
+                    .unwrap()
             })
             .collect();
 

--- a/swiftide-indexing/src/transformers/sparse_embed.rs
+++ b/swiftide-indexing/src/transformers/sparse_embed.rs
@@ -255,11 +255,13 @@ mod tests {
     async fn batch_transform(test_data: Vec<TestData<'_>>) {
         let test_nodes: Vec<Node> = test_data
             .iter()
-            .map(|data| Node {
-                chunk: data.chunk.into(),
-                metadata: data.metadata.clone(),
-                embed_mode: data.embed_mode,
-                ..Default::default()
+            .map(|data| {
+                Node::builder()
+                    .chunk(data.chunk)
+                    .metadata(data.metadata.clone())
+                    .embed_mode(data.embed_mode)
+                    .build()
+                    .unwrap()
             })
             .collect();
 

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -116,7 +116,7 @@ mod tests {
     use qdrant_client::qdrant::{
         vectors::VectorsOptions, NamedVectors, PointId, PointStruct, Value, Vector, Vectors,
     };
-    use swiftide_core::indexing::{EmbeddedField, Metadata, Node};
+    use swiftide_core::indexing::{EmbeddedField, Node};
     use test_case::test_case;
 
     use crate::qdrant::indexing_node::NodeWithVectors;

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -124,14 +124,14 @@ mod tests {
     static EXPECTED_UUID: &str = "d42d252d-671d-37ef-a157-8e85d0710610";
 
     #[test_case(
-        Node { id: None, path: "/path".into(), chunk: "data".into(),
-            vectors: Some(HashMap::from([(EmbeddedField::Chunk, vec![1.0])])),
-            original_size: 4,
-            offset: 0,
-            metadata: Metadata::from([("m1", "mv1")]),
-            embed_mode: swiftide_core::indexing::EmbedMode::SingleWithMetadata,
-            ..Default::default()
-        },
+        Node::builder()
+            .path("/path")
+            .chunk("data")
+            .vectors([(EmbeddedField::Chunk, vec![1.0])])
+            .metadata([("m1", "mv1")])
+            .embed_mode(swiftide_core::indexing::EmbedMode::SingleWithMetadata)
+            .build().unwrap()
+        ,
         HashSet::from([EmbeddedField::Combined]),
         PointStruct { id: Some(PointId::from(EXPECTED_UUID)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
@@ -142,17 +142,16 @@ mod tests {
         "Node with single vector creates struct with unnamed vector"
     )]
     #[test_case(
-        Node { id: None, path: "/path".into(), chunk: "data".into(),
-            vectors: Some(HashMap::from([
+        Node::builder()
+            .path("/path")
+            .chunk("data")
+            .vectors([
                 (EmbeddedField::Chunk, vec![1.0]),
                 (EmbeddedField::Metadata("m1".into()), vec![2.0])
-            ])),
-            metadata: Metadata::from([("m1", "mv1")]),
-            embed_mode: swiftide_core::indexing::EmbedMode::PerField,
-            original_size: 4,
-            offset: 0,
-            ..Default::default()
-        },
+            ])
+            .metadata([("m1", "mv1")])
+            .embed_mode(swiftide_core::indexing::EmbedMode::PerField)
+            .build().unwrap(),
         HashSet::from([EmbeddedField::Chunk, EmbeddedField::Metadata("m1".into())]),
         PointStruct { id: Some(PointId::from(EXPECTED_UUID)), payload: HashMap::from([
             ("content".into(), Value::from("data")),
@@ -170,19 +169,18 @@ mod tests {
         "Node with multiple vectors creates struct with named vectors"
     )]
     #[test_case(
-        Node { id: None, path: "/path".into(), chunk: "data".into(),
-            vectors: Some(HashMap::from([
+        Node::builder()
+            .path("/path")
+            .chunk("data")
+            .vectors([
                 (EmbeddedField::Chunk, vec![1.0]),
                 (EmbeddedField::Combined, vec![1.0]),
                 (EmbeddedField::Metadata("m1".into()), vec![1.0]),
                 (EmbeddedField::Metadata("m2".into()), vec![2.0])
-            ])),
-            metadata: Metadata::from([("m1", "mv1"), ("m2", "mv2")]),
-            embed_mode: swiftide_core::indexing::EmbedMode::Both,
-            original_size: 4,
-            offset: 0,
-            ..Default::default()
-        },
+            ])
+            .metadata([("m1", "mv1"), ("m2", "mv2")])
+            .embed_mode(swiftide_core::indexing::EmbedMode::Both)
+            .build().unwrap(),
         HashSet::from([EmbeddedField::Combined]),
         PointStruct { id: Some(PointId::from(EXPECTED_UUID)), payload: HashMap::from([
             ("content".into(), Value::from("data")),

--- a/swiftide-integrations/src/qdrant/mod.rs
+++ b/swiftide-integrations/src/qdrant/mod.rs
@@ -118,7 +118,7 @@ impl Qdrant {
             tracing::debug!(?sparse_vectors_config, "Adding sparse vectors config");
             collection = collection.sparse_vectors_config(sparse_vectors_config);
         }
-        tracing::warn!("Creating collection");
+        tracing::warn!("Creating collection {}", &self.collection_name);
 
         self.client.create_collection(collection).await?;
         Ok(())

--- a/swiftide-integrations/src/redis/node_cache.rs
+++ b/swiftide-integrations/src/redis/node_cache.rs
@@ -118,12 +118,7 @@ mod tests {
             .expect("Could not build redis client");
         cache.reset_cache().await;
 
-        let node = Node {
-            id: None,
-            path: "test".into(),
-            chunk: "chunk".into(),
-            ..Default::default()
-        };
+        let node = Node::new("chunk");
 
         let before_cache = cache.get(&node).await;
         assert!(!before_cache);

--- a/swiftide-integrations/src/redis/persist.rs
+++ b/swiftide-integrations/src/redis/persist.rs
@@ -108,12 +108,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let node = Node {
-            id: None,
-            path: "test".into(),
-            chunk: "chunk".into(),
-            ..Default::default()
-        };
+        let node = Node::new("chunk");
 
         redis.store(node.clone()).await.unwrap();
         let stored_node = serde_json::from_str(&redis.get_node(&node).await.unwrap().unwrap());
@@ -132,18 +127,7 @@ mod tests {
             .batch_size(20)
             .build()
             .unwrap();
-        let nodes = vec![
-            Node {
-                id: None,
-                path: "test".into(),
-                ..Default::default()
-            },
-            Node {
-                id: None,
-                path: "other".into(),
-                ..Default::default()
-            },
-        ];
+        let nodes = vec![Node::new("test"), Node::new("other")];
 
         let stream = redis.batch_store(nodes).await;
         let streamed_nodes: Vec<Node> = stream.try_collect().await.unwrap();
@@ -167,10 +151,7 @@ mod tests {
             .persist_value_fn(|_node| Ok("hello world".to_string()))
             .build()
             .unwrap();
-        let node = Node {
-            id: None,
-            ..Default::default()
-        };
+        let node = Node::default();
 
         redis.store(node.clone()).await.unwrap();
         let stored_node = redis.get_node(&node).await.unwrap();

--- a/swiftide-integrations/src/scraping/html_to_markdown_transformer.rs
+++ b/swiftide-integrations/src/scraping/html_to_markdown_transformer.rs
@@ -44,11 +44,9 @@ impl Transformer for HtmlToMarkdownTransformer {
     /// Will Err the node if the conversion fails.
     #[tracing::instrument(skip_all, name = "transformer.html_to_markdown")]
     async fn transform_node(&self, node: Node) -> Result<Node> {
-        let chunk = self.htmd.convert(&node.chunk);
-        Ok(Node {
-            chunk: chunk?,
-            ..node
-        })
+        let chunk = self.htmd.convert(&node.chunk)?;
+
+        Node::build_from_other(&node).chunk(chunk).build()
     }
 
     fn concurrency(&self) -> Option<usize> {

--- a/swiftide-integrations/src/scraping/loader.rs
+++ b/swiftide-integrations/src/scraping/loader.rs
@@ -55,15 +55,14 @@ impl Loader for ScrapingLoader {
             while let Ok(res) = spider_rx.recv().await {
                 let html = res.get_html();
                 let original_size = html.len();
-                let node = Node {
-                    chunk: html,
-                    original_size,
-                    // TODO: Probably not the best way to represent this
-                    // and will fail. Can we add more metadata too?
-                    path: res.get_url().into(),
-                    ..Default::default()
-                };
-                if tx.send(Ok(node)).is_err() {
+
+                let node = Node::builder()
+                    .chunk(html)
+                    .original_size(original_size)
+                    .path(res.get_url())
+                    .build();
+
+                if tx.send(node).is_err() {
                     break;
                 }
             }

--- a/swiftide-integrations/src/treesitter/chunk_code.rs
+++ b/swiftide-integrations/src/treesitter/chunk_code.rs
@@ -109,13 +109,15 @@ impl ChunkerTransformer for ChunkCode {
 
             IndexingStream::iter(split.into_iter().map(move |chunk| {
                 let chunk_size = chunk.len();
-                let mut node = Node {
-                    chunk,
-                    ..node.clone()
-                };
-                node.offset = offset;
+
+                let node = Node::build_from_other(&node)
+                    .chunk(chunk)
+                    .offset(offset)
+                    .build();
+
                 offset += chunk_size;
-                Ok(node)
+
+                node
             }))
         } else {
             // Send the error downstream

--- a/swiftide-test-utils/src/test_utils.rs
+++ b/swiftide-test-utils/src/test_utils.rs
@@ -33,7 +33,7 @@ pub fn openai_client(
 /// Setup Qdrant container.
 /// Returns container server and `server_url`.
 pub async fn start_qdrant() -> (ContainerAsync<GenericImage>, String) {
-    let qdrant = testcontainers::GenericImage::new("qdrant/qdrant", "v1.11.3")
+    let qdrant = testcontainers::GenericImage::new("qdrant/qdrant", "v1.12.1")
         .with_exposed_port(6334.into())
         .with_exposed_port(6333.into())
         .with_wait_for(testcontainers::core::WaitFor::http(


### PR DESCRIPTION
As @shamb0 pointed out in #392, there is a potential issue where Node ids are get cached before chunking or other transformations, breaking upserts and potentially resulting in data loss.

BREAKING CHANGE: This PR reworks Nodes with a builder API and a private id. Hence, manually creating nodes no longer works. In the future, all the fields are likely to follow the same pattern, so that we can decouple the inner fields from the Node's implementation.
