### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0](https://github.com/bosun-ai/swiftide/compare/v0.13.4...v0.14.0) - 2024-10-27
+
+### New features
+
+- [a866d38](https://github.com/bosun-ai/swiftide/commit/a866d38b2cbaf7154ace957472c75b99f1c9c070) *(integrations)*  Support in process hugging face models via mistralrs ([#386](https://github.com/bosun-ai/swiftide/pull/386))
+
+### Bug fixes
+
+- [551a9cb](https://github.com/bosun-ai/swiftide/commit/551a9cb769293e42e15bae5dca3ab677be0ee8ea) *(indexing)*  [**breaking**] Node ID no longer memoized ([#414](https://github.com/bosun-ai/swiftide/pull/414))
+
+````text
+As @shamb0 pointed out in [#392](https://github.com/bosun-ai/swiftide/pull/392), there is a potential issue where Node
+  ids are get cached before chunking or other transformations, breaking
+  upserts and potentially resulting in data loss.
+````
+
+**BREAKING CHANGE**: This PR reworks Nodes with a builder API and a private
+id. Hence, manually creating nodes no longer works. In the future, all
+the fields are likely to follow the same pattern, so that we can
+decouple the inner fields from the Node's implementation.
+
+- [c091ffa](https://github.com/bosun-ai/swiftide/commit/c091ffa6be792b0bd7bb03d604e26e40b2adfda8) *(indexing)*  Use atomics for key generation in memory storage ([#415](https://github.com/bosun-ai/swiftide/pull/415))
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.13.4...0.14.0
+
+
+
 ## [0.13.4](https://github.com/bosun-ai/swiftide/compare/v0.13.3...v0.13.4) - 2024-10-21
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8304,7 +8304,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -8329,7 +8329,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8355,7 +8355,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "fluvio",
  "qdrant-client",
@@ -8369,7 +8369,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8397,7 +8397,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8454,7 +8454,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -8464,7 +8464,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8490,7 +8490,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.4"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.13" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.13" }
+swiftide-core = { path = "../swiftide-core", version = "0.14" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.14" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.13" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.13" }
+swiftide-core = { path = "../swiftide-core", version = "0.14" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.14" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.13.4" }
+swiftide-core = { path = "../swiftide-core", version = "0.14.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,10 +16,10 @@ homepage.workspace = true
 document-features = "0.2.10"
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.13" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.13" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.13" }
-swiftide-query = { path = "../swiftide-query", version = "0.13" }
+swiftide-core = { path = "../swiftide-core", version = "0.14" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.14" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.14" }
+swiftide-query = { path = "../swiftide-query", version = "0.14" }
 
 [features]
 default = []


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.13.4 -> 0.14.0 (✓ API compatible changes)
* `swiftide-core`: 0.13.4 -> 0.14.0 (⚠️ API breaking changes)
* `swiftide-indexing`: 0.13.4 -> 0.14.0 (✓ API compatible changes)
* `swiftide-macros`: 0.13.4 -> 0.14.0
* `swiftide-integrations`: 0.13.4 -> 0.14.0 (✓ API compatible changes)
* `swiftide-query`: 0.13.4 -> 0.14.0 (✓ API compatible changes)

### ⚠️ `swiftide-core` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  Node::update_id, previously in file /tmp/.tmpp9ZuUf/swiftide-core/src/node.rs:204

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field id of struct Node, previously in file /tmp/.tmpp9ZuUf/swiftide-core/src/node.rs:41
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.14.0](https://github.com/bosun-ai/swiftide/compare/v0.13.4...v0.14.0) - 2024-10-27

### New features

- [a866d38](https://github.com/bosun-ai/swiftide/commit/a866d38b2cbaf7154ace957472c75b99f1c9c070) *(integrations)*  Support in process hugging face models via mistralrs ([#386](https://github.com/bosun-ai/swiftide/pull/386))

### Bug fixes

- [551a9cb](https://github.com/bosun-ai/swiftide/commit/551a9cb769293e42e15bae5dca3ab677be0ee8ea) *(indexing)*  [**breaking**] Node ID no longer memoized ([#414](https://github.com/bosun-ai/swiftide/pull/414))

````text
As @shamb0 pointed out in [#392](https://github.com/bosun-ai/swiftide/pull/392), there is a potential issue where Node
  ids are get cached before chunking or other transformations, breaking
  upserts and potentially resulting in data loss.
````

**BREAKING CHANGE**: This PR reworks Nodes with a builder API and a private
id. Hence, manually creating nodes no longer works. In the future, all
the fields are likely to follow the same pattern, so that we can
decouple the inner fields from the Node's implementation.

- [c091ffa](https://github.com/bosun-ai/swiftide/commit/c091ffa6be792b0bd7bb03d604e26e40b2adfda8) *(indexing)*  Use atomics for key generation in memory storage ([#415](https://github.com/bosun-ai/swiftide/pull/415))

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.13.4...0.14.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).