### PR TITLE
chore: release v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.1](https://github.com/bosun-ai/swiftide/compare/v0.14.0...v0.14.1) - 2024-10-27
+
+### Bug fixes
+
+- [5bbcd55](https://github.com/bosun-ai/swiftide/commit/5bbcd55de65d73d7908e91c96f120928edb6b388)  Revert 0.14 release as mistralrs is unpublished ([#417](https://github.com/bosun-ai/swiftide/pull/417))
+
+````text
+Revert the 0.14 release as `mistralrs` is unpublished and unfortunately
+  cannot be released.
+````
+
+### Miscellaneous
+
+- [07c2661](https://github.com/bosun-ai/swiftide/commit/07c2661b7a7cdf75cdba12fab0ca91866793f727)  Re-release 0.14 without mistralrs ([#419](https://github.com/bosun-ai/swiftide/pull/419))
+
+````text
+- **Revert "fix: Revert 0.14 release as mistralrs is unpublished
+  ([#417](https://github.com/bosun-ai/swiftide/pull/417))"**
+  - **Fix changelog**
+````
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.0...0.14.1
+
+
+
 ## [0.14.0](https://github.com/bosun-ai/swiftide/compare/v0.13.4...v0.14.0) - 2024-10-27
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "benchmarks"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -7578,7 +7578,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7605,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7631,7 +7631,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "fluvio",
  "qdrant-client",
@@ -7645,7 +7645,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7673,7 +7673,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -7729,7 +7729,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7739,7 +7739,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7765,7 +7765,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.14.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.14.1" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `swiftide-core`: 0.14.0 -> 0.14.1
* `swiftide-indexing`: 0.14.0 -> 0.14.1 (✓ API compatible changes)
* `swiftide-macros`: 0.14.0 -> 0.14.1
* `swiftide-integrations`: 0.14.0 -> 0.14.1
* `swiftide-query`: 0.14.0 -> 0.14.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.14.1](https://github.com/bosun-ai/swiftide/compare/v0.14.0...v0.14.1) - 2024-10-27

### Bug fixes

- [5bbcd55](https://github.com/bosun-ai/swiftide/commit/5bbcd55de65d73d7908e91c96f120928edb6b388)  Revert 0.14 release as mistralrs is unpublished ([#417](https://github.com/bosun-ai/swiftide/pull/417))

````text
Revert the 0.14 release as `mistralrs` is unpublished and unfortunately
  cannot be released.
````

### Miscellaneous

- [07c2661](https://github.com/bosun-ai/swiftide/commit/07c2661b7a7cdf75cdba12fab0ca91866793f727)  Re-release 0.14 without mistralrs ([#419](https://github.com/bosun-ai/swiftide/pull/419))

````text
- **Revert "fix: Revert 0.14 release as mistralrs is unpublished
  ([#417](https://github.com/bosun-ai/swiftide/pull/417))"**
  - **Fix changelog**
````


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.0...0.14.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).