### PR TITLE
feat(agents): Rename `CommandError::FailedWithOutput` to `CommandError::NonZeroExit`

### DIFF
--- a/swiftide-agents/src/tools/local_executor.rs
+++ b/swiftide-agents/src/tools/local_executor.rs
@@ -49,7 +49,7 @@ impl LocalExecutor {
         if output.status.success() {
             Ok(merged_output.into())
         } else {
-            Err(CommandError::FailedWithOutput(merged_output.into()))
+            Err(CommandError::NonZeroExit(merged_output.into()))
         }
     }
 

--- a/swiftide-core/src/agent_traits.rs
+++ b/swiftide-core/src/agent_traits.rs
@@ -25,8 +25,8 @@ pub enum CommandError {
     ExecutorError(#[from] anyhow::Error),
 
     /// The command failed, i.e. failing tests with stderr. This error might be handled
-    #[error("command failed: {0}")]
-    FailedWithOutput(CommandOutput),
+    #[error("command failed with NonZeroExit: {0}")]
+    NonZeroExit(CommandOutput),
 }
 
 /// Commands that can be executed by the executor


### PR DESCRIPTION
Better describes what is going on. I.e. `rg` exits with 1 if nothing is
found, tests generally do the same if they fail.
