### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
+
+
+
 ## [0.14.4](https://github.com/bosun-ai/swiftide/compare/v0.14.3...v0.14.4) - 2024-12-11
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8539,7 +8539,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8591,7 +8591,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8619,7 +8619,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8640,7 +8640,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8668,7 +8668,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.14.4"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.14.4"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.14" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.14" }
+swiftide-core = { path = "../swiftide-core", version = "0.15" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.15" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true
@@ -27,10 +27,10 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.14", features = [
+swiftide-core = { path = "../swiftide-core", version = "0.15", features = [
   "test-utils",
 ] }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.14", features = [
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.15", features = [
   "openai",
 ] }
 mockall.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.14" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.14" }
+swiftide-core = { path = "../swiftide-core", version = "0.15" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.15" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.14" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.14" }
+swiftide-core = { path = "../swiftide-core", version = "0.15" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.15" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -32,8 +32,8 @@ rustversion = "1.0.18"
 trybuild = "1.0"
 prettyplease = "0.2.25"
 insta.workspace = true
-swiftide-core = { path = "../swiftide-core/", version = "0.14" }
-swiftide = { path = "../swiftide/", version = "0.14" }
+swiftide-core = { path = "../swiftide-core/", version = "0.15" }
+swiftide = { path = "../swiftide/", version = "0.15" }
 
 [lints]
 workspace = true

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.14.4" }
+swiftide-core = { path = "../swiftide-core", version = "0.15.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.14" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.14" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.14" }
-swiftide-query = { path = "../swiftide-query", version = "0.14" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.14", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.15" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.15" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.15" }
+swiftide-query = { path = "../swiftide-query", version = "0.15" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.15", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.14.4 -> 0.15.0 (✓ API compatible changes)
* `swiftide-agents`: 0.14.4 -> 0.15.0 (✓ API compatible changes)
* `swiftide-core`: 0.14.4 -> 0.15.0 (⚠️ API breaking changes)
* `swiftide-macros`: 0.14.4 -> 0.15.0
* `swiftide-integrations`: 0.14.4 -> 0.15.0 (✓ API compatible changes)
* `swiftide-indexing`: 0.14.4 -> 0.15.0
* `swiftide-query`: 0.14.4 -> 0.15.0

### ⚠️ `swiftide-core` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_added.ron

Failed in:
  variant CommandError:NonZeroExit in /tmp/.tmptUpHfy/swiftide/swiftide-core/src/agent_traits.rs:29
  variant CommandError:NonZeroExit in /tmp/.tmptUpHfy/swiftide/swiftide-core/src/agent_traits.rs:29

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_variant_missing.ron

Failed in:
  variant CommandError::FailedWithOutput, previously in file /tmp/.tmpjw7IK2/swiftide-core/src/agent_traits.rs:29
  variant CommandError::FailedWithOutput, previously in file /tmp/.tmpjw7IK2/swiftide-core/src/agent_traits.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
</blockquote>

## `swiftide-agents`
<blockquote>

## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
</blockquote>

## `swiftide-core`
<blockquote>

## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
</blockquote>

## `swiftide-macros`
<blockquote>

## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
</blockquote>

## `swiftide-integrations`
<blockquote>

## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
</blockquote>

## `swiftide-indexing`
<blockquote>

## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
</blockquote>

## `swiftide-query`
<blockquote>

## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-17

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.14.4...0.15.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).