### PR TITLE
feat: Documents as first class citizens

### DIFF
--- a/swiftide-core/src/document.rs
+++ b/swiftide-core/src/document.rs
@@ -1,11 +1,14 @@
 use std::fmt;
 
+use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 use crate::{metadata::Metadata, util::debug_long_utf8};
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Builder)]
+#[builder(setter(into))]
 pub struct Document {
+    #[builder(default)]
     metadata: Metadata,
     content: String,
 }
@@ -61,6 +64,10 @@ impl Document {
             metadata: metadata.unwrap_or_default(),
             content: content.into(),
         }
+    }
+
+    pub fn builder() -> DocumentBuilder {
+        DocumentBuilder::default()
     }
 
     pub fn content(&self) -> &str {

--- a/swiftide-core/src/document.rs
+++ b/swiftide-core/src/document.rs
@@ -1,7 +1,6 @@
-use std::{borrow::Cow, fmt};
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
-use tracing::field::Visit;
 
 use crate::{metadata::Metadata, util::debug_long_utf8};
 

--- a/swiftide-core/src/document.rs
+++ b/swiftide-core/src/document.rs
@@ -1,0 +1,74 @@
+use std::{borrow::Cow, fmt};
+
+use serde::{Deserialize, Serialize};
+use tracing::field::Visit;
+
+use crate::{metadata::Metadata, util::debug_long_utf8};
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Document {
+    metadata: Option<Metadata>,
+    content: String,
+}
+
+impl From<Document> for serde_json::Value {
+    fn from(document: Document) -> Self {
+        serde_json::json!({
+            "metadata": document.metadata,
+            "content": document.content,
+        })
+    }
+}
+
+impl From<&Document> for serde_json::Value {
+    fn from(document: &Document) -> Self {
+        serde_json::json!({
+            "metadata": document.metadata,
+            "content": document.content,
+        })
+    }
+}
+
+impl PartialOrd for Document {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.content.cmp(&other.content))
+    }
+}
+
+impl Ord for Document {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.content.cmp(&other.content)
+    }
+}
+
+impl fmt::Debug for Document {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Document")
+            .field("metadata", &self.metadata)
+            .field("content", &debug_long_utf8(&self.content, 100))
+            .finish()
+    }
+}
+
+impl<T: AsRef<str>> From<T> for Document {
+    fn from(value: T) -> Self {
+        Document::new(value.as_ref(), None)
+    }
+}
+
+impl Document {
+    pub fn new(content: impl Into<String>, metadata: Option<Metadata>) -> Self {
+        Self {
+            metadata,
+            content: content.into(),
+        }
+    }
+
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    pub fn metadata(&self) -> Option<&Metadata> {
+        self.metadata.as_ref()
+    }
+}

--- a/swiftide-core/src/document.rs
+++ b/swiftide-core/src/document.rs
@@ -6,7 +6,7 @@ use crate::{metadata::Metadata, util::debug_long_utf8};
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Document {
-    metadata: Option<Metadata>,
+    metadata: Metadata,
     content: String,
 }
 
@@ -58,7 +58,7 @@ impl<T: AsRef<str>> From<T> for Document {
 impl Document {
     pub fn new(content: impl Into<String>, metadata: Option<Metadata>) -> Self {
         Self {
-            metadata,
+            metadata: metadata.unwrap_or_default(),
             content: content.into(),
         }
     }
@@ -67,7 +67,7 @@ impl Document {
         &self.content
     }
 
-    pub fn metadata(&self) -> Option<&Metadata> {
-        self.metadata.as_ref()
+    pub fn metadata(&self) -> &Metadata {
+        &self.metadata
     }
 }

--- a/swiftide-core/src/document.rs
+++ b/swiftide-core/src/document.rs
@@ -1,3 +1,7 @@
+//! Documents are the main data structure that is retrieved via the query pipeline
+//!
+//! Retrievers are expected to eagerly set any configured metadata on the document, with the same
+//! field name used during indexing if applicable.
 use std::fmt;
 
 use derive_builder::Builder;
@@ -5,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{metadata::Metadata, util::debug_long_utf8};
 
+/// A document represents a single unit of retrieved text
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Builder)]
 #[builder(setter(into))]
 pub struct Document {

--- a/swiftide-core/src/document.rs
+++ b/swiftide-core/src/document.rs
@@ -71,3 +71,86 @@ impl Document {
         &self.metadata
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::Metadata;
+
+    #[test]
+    fn test_document_creation() {
+        let content = "Test content";
+        let metadata = Metadata::from([("some", "metadata")]);
+        let document = Document::new(content, Some(metadata.clone()));
+
+        assert_eq!(document.content(), content);
+        assert_eq!(document.metadata(), &metadata);
+    }
+
+    #[test]
+    fn test_document_default_metadata() {
+        let content = "Test content";
+        let document = Document::new(content, None);
+
+        assert_eq!(document.content(), content);
+        assert_eq!(document.metadata(), &Metadata::default());
+    }
+
+    #[test]
+    fn test_document_from_str() {
+        let content = "Test content";
+        let document: Document = content.into();
+
+        assert_eq!(document.content(), content);
+        assert_eq!(document.metadata(), &Metadata::default());
+    }
+
+    #[test]
+    fn test_document_partial_ord() {
+        let doc1 = Document::new("A", None);
+        let doc2 = Document::new("B", None);
+
+        assert!(doc1 < doc2);
+    }
+
+    #[test]
+    fn test_document_ord() {
+        let doc1 = Document::new("A", None);
+        let doc2 = Document::new("B", None);
+
+        assert!(doc1.cmp(&doc2) == std::cmp::Ordering::Less);
+    }
+
+    #[test]
+    fn test_document_debug() {
+        let content = "Test content";
+        let document = Document::new(content, None);
+        let debug_str = format!("{document:?}");
+
+        assert!(debug_str.contains("Document"));
+        assert!(debug_str.contains("metadata"));
+        assert!(debug_str.contains("content"));
+    }
+
+    #[test]
+    fn test_document_to_json() {
+        let content = "Test content";
+        let metadata = Metadata::from([("some", "metadata")]);
+        let document = Document::new(content, Some(metadata.clone()));
+        let json_value: serde_json::Value = document.into();
+
+        assert_eq!(json_value["content"], content);
+        assert_eq!(json_value["metadata"], serde_json::json!(metadata));
+    }
+
+    #[test]
+    fn test_document_ref_to_json() {
+        let content = "Test content";
+        let metadata = Metadata::from([("some", "metadata")]);
+        let document = Document::new(content, Some(metadata.clone()));
+        let json_value: serde_json::Value = (&document).into();
+
+        assert_eq!(json_value["content"], content);
+        assert_eq!(json_value["metadata"], serde_json::json!(metadata));
+    }
+}

--- a/swiftide-core/src/lib.rs
+++ b/swiftide-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod query_traits;
 mod search_strategies;
 pub mod type_aliases;
 
+pub mod document;
 pub mod prompt;
 pub use type_aliases::*;
 

--- a/swiftide-core/src/metadata.rs
+++ b/swiftide-core/src/metadata.rs
@@ -9,7 +9,7 @@ use serde::Deserializer;
 
 use crate::util::debug_long_utf8;
 
-#[derive(Clone, Default, PartialEq)]
+#[derive(Clone, Default, PartialEq, Eq)]
 pub struct Metadata {
     inner: BTreeMap<String, serde_json::Value>,
 }
@@ -52,6 +52,10 @@ impl Metadata {
 
     pub fn into_values(self) -> IntoValues<String, serde_json::Value> {
         self.inner.into_values()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 }
 

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -8,7 +8,7 @@
 use derive_builder::Builder;
 
 use crate::{
-    document::Document, metadata::Metadata, util::debug_long_utf8, Embedding, SparseEmbedding,
+    document::Document, util::debug_long_utf8, Embedding, SparseEmbedding,
 };
 
 /// A query is the main object going through a query pipeline

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -89,6 +89,11 @@ impl<STATE: Clone + QueryState> Query<STATE> {
     pub fn documents(&self) -> &[Document] {
         &self.documents
     }
+
+    /// Returns the current documents as mutable
+    pub fn documents_mut(&mut self) -> &mut Vec<Document> {
+        &mut self.documents
+    }
 }
 
 impl<STATE: Clone + CanRetrieve> Query<STATE> {

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -7,9 +7,7 @@
 //! `states::Answered`: The query has been answered
 use derive_builder::Builder;
 
-use crate::{
-    document::Document, util::debug_long_utf8, Embedding, SparseEmbedding,
-};
+use crate::{document::Document, util::debug_long_utf8, Embedding, SparseEmbedding};
 
 /// A query is the main object going through a query pipeline
 ///

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -7,9 +7,9 @@
 //! `states::Answered`: The query has been answered
 use derive_builder::Builder;
 
-use crate::{util::debug_long_utf8, Embedding, SparseEmbedding};
-
-type Document = String;
+use crate::{
+    document::Document, metadata::Metadata, util::debug_long_utf8, Embedding, SparseEmbedding,
+};
 
 /// A query is the main object going through a query pipeline
 ///
@@ -34,6 +34,12 @@ pub struct Query<STATE: QueryState> {
 
     #[builder(default)]
     pub sparse_embedding: Option<SparseEmbedding>,
+
+    /// Documents the query will operate on
+    ///
+    /// A query can retrieve multiple times, accumulating documents
+    #[builder(default)]
+    documents: Vec<Document>,
 }
 
 impl<STATE: std::fmt::Debug + QueryState> std::fmt::Debug for Query<STATE> {
@@ -71,12 +77,36 @@ impl<STATE: Clone + QueryState> Query<STATE> {
             transformation_history: self.transformation_history,
             embedding: self.embedding,
             sparse_embedding: self.sparse_embedding,
+            documents: self.documents,
         }
     }
 
     #[allow(dead_code)]
     pub fn history(&self) -> &Vec<TransformationEvent> {
         &self.transformation_history
+    }
+
+    /// Returns the current documents that will be used as context for answer generation
+    pub fn documents(&self) -> &[Document] {
+        &self.documents
+    }
+}
+
+impl<STATE: Clone + CanRetrieve> Query<STATE> {
+    /// Add retrieved documents and transition to `states::Retrieved`
+    pub fn retrieved_documents(mut self, documents: Vec<Document>) -> Query<states::Retrieved> {
+        self.documents.extend(documents.clone());
+        self.transformation_history
+            .push(TransformationEvent::Retrieved {
+                before: self.current.clone(),
+                after: String::new(),
+                documents,
+            });
+
+        let state = states::Retrieved;
+
+        self.current.clear();
+        self.transition_to(state)
     }
 }
 
@@ -100,21 +130,6 @@ impl Query<states::Pending> {
 
         self.current = new_query;
     }
-
-    /// Add retrieved documents and transition to `states::Retrieved`
-    pub fn retrieved_documents(mut self, documents: Vec<Document>) -> Query<states::Retrieved> {
-        self.transformation_history
-            .push(TransformationEvent::Retrieved {
-                before: self.current.clone(),
-                after: String::new(),
-                documents: documents.clone(),
-            });
-
-        let state = states::Retrieved { documents };
-
-        self.current.clear();
-        self.transition_to(state)
-    }
 }
 
 impl Query<states::Retrieved> {
@@ -135,17 +150,11 @@ impl Query<states::Retrieved> {
         self.current = new_response;
     }
 
-    /// Returns the last retrieved documents
-    pub fn documents(&self) -> &[Document] {
-        &self.state.documents
-    }
-
     /// Transition the query to `states::Answered`
     #[must_use]
-    pub fn answered(self, answer: impl Into<String>) -> Query<states::Answered> {
-        let state = states::Answered {
-            answer: answer.into(),
-        };
+    pub fn answered(mut self, answer: impl Into<String>) -> Query<states::Answered> {
+        self.current = answer.into();
+        let state = states::Answered;
         self.transition_to(state)
     }
 }
@@ -157,66 +166,37 @@ impl Query<states::Answered> {
 
     /// Returns the answer of the query
     pub fn answer(&self) -> &str {
-        &self.state.answer
+        &self.current
     }
 }
 
 /// Marker trait for query states
 pub trait QueryState: Send + Sync {}
+/// Marker trait for query states that can still retrieve
+pub trait CanRetrieve: QueryState {}
 
 /// States of a query
 pub mod states {
-    use crate::util::debug_long_utf8;
+    use super::{CanRetrieve, QueryState};
 
-    use super::Builder;
-    use super::Document;
-    use super::QueryState;
-
-    #[derive(Debug, Default, Clone)]
+    #[derive(Debug, Default, Clone, PartialEq)]
     /// The query is pending and has not been used
     pub struct Pending;
 
-    #[derive(Default, Clone, Builder, PartialEq)]
-    #[builder(setter(into))]
+    #[derive(Debug, Default, Clone, PartialEq)]
     /// Documents have been retrieved
-    pub struct Retrieved {
-        pub(crate) documents: Vec<Document>,
-    }
+    pub struct Retrieved;
 
-    impl std::fmt::Debug for Retrieved {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("Retrieved")
-                .field("num_documents", &self.documents.len())
-                .field(
-                    "documents",
-                    &self
-                        .documents
-                        .iter()
-                        .map(|d| debug_long_utf8(d, 100))
-                        .collect::<Vec<_>>(),
-                )
-                .finish()
-        }
-    }
-
-    #[derive(Default, Clone, Builder, PartialEq)]
-    #[builder(setter(into))]
+    #[derive(Debug, Default, Clone, PartialEq)]
     /// The query has been answered
-    pub struct Answered {
-        pub(crate) answer: String,
-    }
-
-    impl std::fmt::Debug for Answered {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.debug_struct("Answered")
-                .field("answer", &debug_long_utf8(&self.answer, 100))
-                .finish()
-        }
-    }
+    pub struct Answered;
 
     impl QueryState for Pending {}
     impl QueryState for Retrieved {}
     impl QueryState for Answered {}
+
+    impl CanRetrieve for Pending {}
+    impl CanRetrieve for Retrieved {}
 }
 
 impl<T: AsRef<str>> From<T> for Query<states::Pending> {
@@ -301,7 +281,7 @@ mod tests {
     #[test]
     fn test_query_retrieved_documents() {
         let query = Query::<states::Pending>::from("test query");
-        let documents = vec!["doc1".to_string(), "doc2".to_string()];
+        let documents: Vec<Document> = vec!["doc1".into(), "doc2".into()];
         let query = query.retrieved_documents(documents.clone());
         assert_eq!(query.documents(), &documents);
         assert_eq!(query.history().len(), 1);
@@ -323,7 +303,7 @@ mod tests {
     #[test]
     fn test_query_transformed_response() {
         let query = Query::<states::Pending>::from("test query");
-        let documents = vec!["doc1".to_string(), "doc2".to_string()];
+        let documents = vec!["doc1".into(), "doc2".into()];
         let mut query = query.retrieved_documents(documents.clone());
         query.transformed_response("new response");
 
@@ -342,7 +322,7 @@ mod tests {
     #[test]
     fn test_query_answered() {
         let query = Query::<states::Pending>::from("test query");
-        let documents = vec!["doc1".to_string(), "doc2".to_string()];
+        let documents = vec!["doc1".into(), "doc2".into()];
         let query = query.retrieved_documents(documents);
         let query = query.answered("the answer");
 

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -22,6 +22,7 @@ pub struct Query<STATE: QueryState> {
     original: String,
     #[builder(default = "self.original.clone().unwrap_or_default()")]
     current: String,
+    #[builder(default = STATE::default())]
     state: STATE,
     #[builder(default)]
     transformation_history: Vec<TransformationEvent>,
@@ -169,7 +170,7 @@ impl Query<states::Answered> {
 }
 
 /// Marker trait for query states
-pub trait QueryState: Send + Sync {}
+pub trait QueryState: Send + Sync + Default {}
 /// Marker trait for query states that can still retrieve
 pub trait CanRetrieve: QueryState {}
 

--- a/swiftide-integrations/src/lancedb/mod.rs
+++ b/swiftide-integrations/src/lancedb/mod.rs
@@ -21,6 +21,8 @@ See examples for more information.
 
 Implements `Persist` and `Retrieve`.
 
+If you want to store / retrieve metadata in Lance, the columns can be defined with `with_metadata`.
+
 Note: For querying large tables you manually need to create an index. You can get an
 active connection via `get_connection`.
 

--- a/swiftide-integrations/src/lancedb/retrieve.rs
+++ b/swiftide-integrations/src/lancedb/retrieve.rs
@@ -1,10 +1,13 @@
 use anyhow::{Context as _, Result};
+use arrow::datatypes::SchemaRef;
 use arrow_array::StringArray;
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
 use itertools::Itertools;
 use lancedb::query::{ExecutableQuery, QueryBase};
 use swiftide_core::{
+    document::Document,
+    indexing::Metadata,
     querying::{search_strategies::SimilaritySingleEmbedding, states, Query},
     Retrieve,
 };
@@ -57,24 +60,49 @@ impl Retrieve<SimilaritySingleEmbedding<String>> for LanceDB {
             query_builder = query_builder.only_if(filter);
         }
 
-        let result = query_builder
+        let batches = query_builder
             .execute()
             .await?
             .try_collect::<Vec<_>>()
             .await?;
 
-        let Some(recordbatch) = result.first() else {
-            return Ok(query.retrieved_documents(vec![]));
-        };
+        let mut documents = vec![];
 
-        let documents: Vec<String> = recordbatch
-            .column_by_name("chunk")
-            .and_then(|raw_array| raw_array.as_any().downcast_ref::<StringArray>())
-            .context("Could not cast documents to strings")?
-            .into_iter()
-            .flatten()
-            .map_into()
-            .collect();
+        for batch in batches {
+            let schema: SchemaRef = batch.schema();
+
+            for row_idx in 0..batch.num_rows() {
+                let mut metadata = Metadata::default();
+                let mut content = String::new();
+
+                for (col_idx, field) in schema.fields().iter().enumerate() {
+                    let column = batch.column(col_idx);
+
+                    if let Some(array) = column.as_any().downcast_ref::<StringArray>() {
+                        if field.name() == "chunk" {
+                            // Extract the "content" field
+                            content = array.value(row_idx).to_string();
+                        } else {
+                            // Assume other fields are part of the metadata
+                            let value = array.value(row_idx).to_string();
+                            metadata.insert(field.name().clone(), value);
+                        }
+                    } else {
+                        // Handle other array types as necessary
+                        // TODO: Can't we just downcast to serde::Value or fail?
+                    }
+                }
+
+                documents.push(Document::new(
+                    content,
+                    if metadata.is_empty() {
+                        None
+                    } else {
+                        Some(metadata)
+                    },
+                ));
+            }
+        }
 
         Ok(query.retrieved_documents(documents))
     }

--- a/swiftide-integrations/src/lancedb/retrieve.rs
+++ b/swiftide-integrations/src/lancedb/retrieve.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use arrow::datatypes::SchemaRef;
 use arrow_array::StringArray;
 use async_trait::async_trait;

--- a/swiftide-integrations/src/pgvector/mod.rs
+++ b/swiftide-integrations/src/pgvector/mod.rs
@@ -193,6 +193,7 @@ mod tests {
     use futures_util::TryStreamExt;
     use std::collections::HashSet;
     use swiftide_core::{
+        document::Document,
         indexing::{self, EmbedMode, EmbeddedField},
         querying::{search_strategies::SimilaritySingleEmbedding, states, Query},
         Persist, Retrieve,
@@ -248,8 +249,13 @@ mod tests {
 
         assert_eq!(result.documents().len(), 2);
 
-        assert!(result.documents().contains(&"content1".into()));
-        assert!(result.documents().contains(&"content2".into()));
+        let contents = result
+            .documents()
+            .iter()
+            .map(Document::content)
+            .collect::<Vec<_>>();
+        assert!(contents.contains(&"content1"));
+        assert!(contents.contains(&"content2"));
 
         // Additional test with priority filter
         let search_strategy =
@@ -261,8 +267,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.documents().len(), 2);
-        assert!(result.documents().contains(&"content1".into()));
-        assert!(result.documents().contains(&"content3".into()));
+        let contents = result
+            .documents()
+            .iter()
+            .map(Document::content)
+            .collect::<Vec<_>>();
+        assert!(contents.contains(&"content1"));
+        assert!(contents.contains(&"content3"));
     }
 
     #[test_log::test(tokio::test)]
@@ -318,8 +329,13 @@ mod tests {
 
         // Verify that similar vectors are retrieved first
         assert_eq!(result.documents().len(), 2);
-        assert!(result.documents().contains(&"base_content".into()));
-        assert!(result.documents().contains(&"similar_content".into()));
+        let contents = result
+            .documents()
+            .iter()
+            .map(Document::content)
+            .collect::<Vec<_>>();
+        assert!(contents.contains(&"base_content"));
+        assert!(contents.contains(&"similar_content"));
     }
 
     #[test_case(
@@ -444,7 +460,12 @@ mod tests {
 
                 if test_case.expected_in_results {
                     assert!(
-                        result.documents().contains(&test_case.chunk.into()),
+                        result
+                            .documents()
+                            .iter()
+                            .map(Document::content)
+                            .collect::<Vec<_>>()
+                            .contains(&test_case.chunk),
                         "Document should be found in results for field {field}",
                     );
                 }

--- a/swiftide-integrations/src/pgvector/mod.rs
+++ b/swiftide-integrations/src/pgvector/mod.rs
@@ -243,8 +243,8 @@ mod tests {
 
         assert_eq!(result.documents().len(), 2);
 
-        assert!(result.documents().contains(&"content1".to_string()));
-        assert!(result.documents().contains(&"content2".to_string()));
+        assert!(result.documents().contains(&"content1".into()));
+        assert!(result.documents().contains(&"content2".into()));
 
         // Additional test with priority filter
         let search_strategy =
@@ -256,8 +256,8 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.documents().len(), 2);
-        assert!(result.documents().contains(&"content1".to_string()));
-        assert!(result.documents().contains(&"content3".to_string()));
+        assert!(result.documents().contains(&"content1".into()));
+        assert!(result.documents().contains(&"content3".into()));
     }
 
     #[test_log::test(tokio::test)]
@@ -313,8 +313,8 @@ mod tests {
 
         // Verify that similar vectors are retrieved first
         assert_eq!(result.documents().len(), 2);
-        assert!(result.documents().contains(&"base_content".to_string()));
-        assert!(result.documents().contains(&"similar_content".to_string()));
+        assert!(result.documents().contains(&"base_content".into()));
+        assert!(result.documents().contains(&"similar_content".into()));
     }
 
     #[test_case(
@@ -439,7 +439,7 @@ mod tests {
 
                 if test_case.expected_in_results {
                     assert!(
-                        result.documents().contains(&test_case.chunk.to_string()),
+                        result.documents().contains(&test_case.chunk.into()),
                         "Document should be found in results for field {field}",
                     );
                 }

--- a/swiftide-integrations/src/pgvector/mod.rs
+++ b/swiftide-integrations/src/pgvector/mod.rs
@@ -6,6 +6,7 @@
 //! - Efficient vector storage and indexing
 //! - Connection pooling with automatic retries
 //! - Batch operations for optimized performance
+//! - Metadata included in retrieval
 //!
 //! The functionality is primarily used through the [`PgVector`] client, which implements
 //! the [`Persist`] trait for seamless integration with indexing and query pipelines.

--- a/swiftide-integrations/src/pgvector/persist.rs
+++ b/swiftide-integrations/src/pgvector/persist.rs
@@ -5,6 +5,8 @@
 //! - Single-node storage operations
 //! - Optimized batch storage with configurable batch sizes
 //!
+//! NOTE: Persisting and retrieving metadata is not supported at the moment.
+//!
 //! The implementation ensures thread-safe concurrent access and handles
 //! connection management automatically.
 use crate::pgvector::PgVector;

--- a/swiftide-integrations/src/pgvector/retrieve.rs
+++ b/swiftide-integrations/src/pgvector/retrieve.rs
@@ -132,7 +132,7 @@ impl Retrieve<CustomStrategy<sqlx::QueryBuilder<'static, sqlx::Postgres>>> for P
             .map_err(|e| anyhow!("Failed to execute search query: {}", e))?;
 
         // Transform results into documents
-        let documents = results.into_iter().map(|r| r.chunk).collect();
+        let documents = results.into_iter().map(|r| r.chunk.into()).collect();
 
         // Update query state with retrieved documents
         Ok(query.retrieved_documents(documents))

--- a/swiftide-integrations/src/pgvector/retrieve.rs
+++ b/swiftide-integrations/src/pgvector/retrieve.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use pgvector::Vector;
 use sqlx::{prelude::FromRow, types::Uuid};
 use swiftide_core::{
-    document::Document,
     querying::{search_strategies::SimilaritySingleEmbedding, states, Query},
     Retrieve,
 };

--- a/swiftide-integrations/src/pgvector/retrieve.rs
+++ b/swiftide-integrations/src/pgvector/retrieve.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use pgvector::Vector;
 use sqlx::{prelude::FromRow, types::Uuid};
 use swiftide_core::{
+    document::Document,
     querying::{search_strategies::SimilaritySingleEmbedding, states, Query},
     Retrieve,
 };
@@ -86,7 +87,7 @@ impl Retrieve<SimilaritySingleEmbedding<String>> for PgVector {
             .fetch_all(pool)
             .await?;
 
-        let docs = data.into_iter().map(|r| r.chunk).collect();
+        let docs = data.into_iter().map(|r| r.chunk.into()).collect();
 
         Ok(query_state.retrieved_documents(docs))
     }

--- a/swiftide-integrations/src/pgvector/retrieve.rs
+++ b/swiftide-integrations/src/pgvector/retrieve.rs
@@ -1,9 +1,11 @@
-use crate::pgvector::{PgVector, PgVectorBuilder};
+use crate::pgvector::{FieldConfig, PgVector, PgVectorBuilder};
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use pgvector::Vector;
-use sqlx::{prelude::FromRow, types::Uuid};
+use sqlx::{prelude::FromRow, types::Uuid, Column, Row};
 use swiftide_core::{
+    document::Document,
+    indexing::Metadata,
     querying::{
         search_strategies::{CustomStrategy, SimilaritySingleEmbedding},
         states, Query,
@@ -12,10 +14,47 @@ use swiftide_core::{
 };
 
 #[allow(dead_code)]
-#[derive(Debug, Clone, FromRow)]
+#[derive(Debug, Clone)]
 struct VectorSearchResult {
     id: Uuid,
     chunk: String,
+    metadata: Metadata,
+}
+
+impl From<VectorSearchResult> for Document {
+    fn from(val: VectorSearchResult) -> Self {
+        Document::new(val.chunk, Some(val.metadata))
+    }
+}
+
+impl FromRow<'_, sqlx::postgres::PgRow> for VectorSearchResult {
+    fn from_row(row: &sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
+        dbg!(&row);
+        let mut metadata = Metadata::default();
+
+        // Metadata fields are stored each as prefixed meta_ fields. Perhaps we should add a single
+        // metadata field instead of multiple fields.
+        for column in row.columns() {
+            if column.name().starts_with("meta_") {
+                row.try_get::<serde_json::Value, _>(column.name())?
+                    .as_object()
+                    .and_then(|object| {
+                        object.keys().collect::<Vec<_>>().first().map(|key| {
+                            metadata.insert(
+                                key.to_owned(),
+                                object.get(key.as_str()).expect("infallible").clone(),
+                            );
+                        })
+                    });
+            }
+        }
+
+        Ok(VectorSearchResult {
+            id: row.try_get("id")?,
+            chunk: row.try_get("chunk")?,
+            metadata,
+        })
+    }
 }
 
 #[allow(clippy::redundant_closure_for_method_calls)]
@@ -40,6 +79,12 @@ impl Retrieve<SimilaritySingleEmbedding<String>> for PgVector {
         let default_columns: Vec<_> = PgVectorBuilder::default_fields()
             .iter()
             .map(|f| f.field_name().to_string())
+            .chain(
+                self.fields
+                    .iter()
+                    .filter(|f| matches!(f, FieldConfig::Metadata(_)))
+                    .map(|f| f.field_name().to_string()),
+            )
             .collect();
 
         // Start building the SQL query
@@ -89,7 +134,7 @@ impl Retrieve<SimilaritySingleEmbedding<String>> for PgVector {
             .fetch_all(pool)
             .await?;
 
-        let docs = data.into_iter().map(|r| r.chunk.into()).collect();
+        let docs = data.into_iter().map(Into::into).collect();
 
         Ok(query_state.retrieved_documents(docs))
     }
@@ -132,7 +177,7 @@ impl Retrieve<CustomStrategy<sqlx::QueryBuilder<'static, sqlx::Postgres>>> for P
             .map_err(|e| anyhow!("Failed to execute search query: {}", e))?;
 
         // Transform results into documents
-        let documents = results.into_iter().map(|r| r.chunk.into()).collect();
+        let documents = results.into_iter().map(Into::into).collect();
 
         // Update query state with retrieved documents
         Ok(query.retrieved_documents(documents))
@@ -211,5 +256,53 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.documents().len(), 0);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_retrieve_docs_with_metadata() {
+        let test_context = TestContext::setup_with_cfg(
+            vec!["other", "text"].into(),
+            HashSet::from([EmbeddedField::Combined]),
+        )
+        .await
+        .expect("Test setup failed");
+
+        let nodes = vec![indexing::Node::new("test_query1")
+            .with_metadata([
+                ("other", serde_json::Value::from(10)),
+                ("text", serde_json::Value::from("some text")),
+            ])
+            .with_vectors([(EmbeddedField::Combined, vec![1.0; 384])])
+            .to_owned()];
+
+        test_context
+            .pgv_storage
+            .batch_store(nodes)
+            .await
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let mut query = Query::<states::Pending>::new("test_query");
+        query.embedding = Some(vec![1.0; 384]);
+
+        let search_strategy = SimilaritySingleEmbedding::<()>::default();
+        let result = test_context
+            .pgv_storage
+            .retrieve(&search_strategy, query.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(result.documents().len(), 1);
+
+        let doc = result.documents().first().unwrap();
+        assert_eq!(
+            doc.metadata().get("other"),
+            Some(&serde_json::Value::from(10))
+        );
+        assert_eq!(
+            doc.metadata().get("text"),
+            Some(&serde_json::Value::from("some text"))
+        );
     }
 }

--- a/swiftide-integrations/src/pgvector/retrieve.rs
+++ b/swiftide-integrations/src/pgvector/retrieve.rs
@@ -29,7 +29,6 @@ impl From<VectorSearchResult> for Document {
 
 impl FromRow<'_, sqlx::postgres::PgRow> for VectorSearchResult {
     fn from_row(row: &sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        dbg!(&row);
         let mut metadata = Metadata::default();
 
         // Metadata fields are stored each as prefixed meta_ fields. Perhaps we should add a single

--- a/swiftide-integrations/src/qdrant/retrieve.rs
+++ b/swiftide-integrations/src/qdrant/retrieve.rs
@@ -223,7 +223,7 @@ mod tests {
         assert_eq!(
             result
                 .documents()
-                .into_iter()
+                .iter()
                 .sorted()
                 .map(ToOwned::to_owned)
                 .collect::<Vec<Document>>(),
@@ -247,7 +247,7 @@ mod tests {
         assert_eq!(
             result
                 .documents()
-                .into_iter()
+                .iter()
                 .sorted()
                 .map(ToOwned::to_owned)
                 .collect::<Vec<Document>>(),

--- a/swiftide-integrations/src/qdrant/retrieve.rs
+++ b/swiftide-integrations/src/qdrant/retrieve.rs
@@ -225,15 +225,14 @@ mod tests {
                 .documents()
                 .iter()
                 .sorted()
-                .map(ToOwned::to_owned)
-                .collect::<Vec<Document>>(),
+                .map(Document::content)
+                .collect_vec(),
             // FIXME: The extra quotes should be removed by serde (via qdrant::Value), but they are
             // not
             ["\"test_query1\"", "\"test_query2\"", "\"test_query3\""]
                 .into_iter()
                 .sorted()
-                .map(Into::into)
-                .collect::<Vec<Document>>()
+                .collect_vec()
         );
 
         let search_strategy = SimilaritySingleEmbedding::from_filter(qdrant::Filter::must([
@@ -249,12 +248,11 @@ mod tests {
                 .documents()
                 .iter()
                 .sorted()
-                .map(ToOwned::to_owned)
-                .collect::<Vec<Document>>(),
+                .map(Document::content)
+                .collect_vec(),
             ["\"test_query1\"", "\"test_query2\""]
                 .into_iter()
                 .sorted()
-                .map(Into::into)
                 .collect_vec()
         );
 

--- a/swiftide-query/src/answers/simple.rs
+++ b/swiftide-query/src/answers/simple.rs
@@ -7,6 +7,7 @@
 //! as context instead.
 use std::sync::Arc;
 use swiftide_core::{
+    document::Document,
     indexing::SimplePrompt,
     prelude::*,
     prompt::PromptTemplate,
@@ -77,7 +78,12 @@ impl Answer for Simple {
     #[tracing::instrument(skip_all)]
     async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>> {
         let context = if query.current().is_empty() {
-            &query.documents().join("\n---\n")
+            &query
+                .documents()
+                .into_iter()
+                .map(Document::content)
+                .collect::<Vec<_>>()
+                .join("\n---\n")
         } else {
             query.current()
         };

--- a/swiftide-query/src/answers/simple.rs
+++ b/swiftide-query/src/answers/simple.rs
@@ -80,7 +80,7 @@ impl Answer for Simple {
         let context = if query.current().is_empty() {
             &query
                 .documents()
-                .into_iter()
+                .iter()
                 .map(Document::content)
                 .collect::<Vec<_>>()
                 .join("\n---\n")

--- a/swiftide-query/src/evaluators/ragas.rs
+++ b/swiftide-query/src/evaluators/ragas.rs
@@ -42,7 +42,6 @@ use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tokio::sync::RwLock;
 
 use swiftide_core::{
-    document::Document,
     querying::{states, Query, QueryEvaluation},
     EvaluateQuery,
 };
@@ -123,7 +122,7 @@ impl EvaluationDataSet {
 
         data.contexts = query
             .documents()
-            .into_iter()
+            .iter()
             .map(|d| d.content().to_string())
             .collect::<Vec<_>>();
         Ok(())
@@ -241,7 +240,7 @@ impl FromStr for EvaluationDataSet {
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use swiftide_core::querying::{states, Query, QueryEvaluation};
+    use swiftide_core::querying::{Query, QueryEvaluation};
     use tokio::sync::RwLock;
 
     #[tokio::test]

--- a/swiftide-query/src/evaluators/ragas.rs
+++ b/swiftide-query/src/evaluators/ragas.rs
@@ -42,6 +42,7 @@ use std::{collections::HashMap, str::FromStr, sync::Arc};
 use tokio::sync::RwLock;
 
 use swiftide_core::{
+    document::Document,
     querying::{states, Query, QueryEvaluation},
     EvaluateQuery,
 };
@@ -120,7 +121,11 @@ impl EvaluationDataSet {
             .get_mut(question)
             .ok_or_else(|| anyhow::anyhow!("Question not found"))?;
 
-        data.contexts = query.documents().to_vec();
+        data.contexts = query
+            .documents()
+            .into_iter()
+            .map(|d| d.content().to_string())
+            .collect::<Vec<_>>();
         Ok(())
     }
 
@@ -299,12 +304,7 @@ mod tests {
 
         let query = Query::builder()
             .original("What is Rust?")
-            .state(
-                states::RetrievedBuilder::default()
-                    .documents(vec!["Rust is a language".to_string()])
-                    .build()
-                    .unwrap(),
-            )
+            .documents(vec!["Rust is a language".into()])
             .build()
             .unwrap();
         let evaluation = QueryEvaluation::RetrieveDocuments(query.clone());
@@ -325,12 +325,7 @@ mod tests {
 
         let query = Query::builder()
             .original("What is Rust?")
-            .state(
-                states::AnsweredBuilder::default()
-                    .answer("A systems programming language")
-                    .build()
-                    .unwrap(),
-            )
+            .current("A systems programming language")
             .build()
             .unwrap();
         let evaluation = QueryEvaluation::AnswerQuery(query.clone());
@@ -372,12 +367,7 @@ mod tests {
 
         let query = Query::builder()
             .original("What is Rust?")
-            .state(
-                states::RetrievedBuilder::default()
-                    .documents(vec!["Rust is a language".to_string()])
-                    .build()
-                    .unwrap(),
-            )
+            .documents(vec!["Rust is a language".into()])
             .build()
             .unwrap();
         dataset
@@ -394,12 +384,7 @@ mod tests {
 
         let query = Query::builder()
             .original("What is Rust?")
-            .state(
-                states::AnsweredBuilder::default()
-                    .answer("A systems programming language")
-                    .build()
-                    .unwrap(),
-            )
+            .current("A systems programming language")
             .build()
             .unwrap();
         dataset

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -91,7 +91,9 @@ impl TransformResponse for Summary {
 
 #[cfg(test)]
 mod test {
+    use swiftide_core::document::Document;
+
     use super::*;
 
-    assert_default_prompt_snapshot!("documents" => vec!["First document", "Second Document"]);
+    assert_default_prompt_snapshot!("documents" => vec![Document::from("First document"), Document::from("Second Document")]);
 }

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -60,7 +60,7 @@ fn default_prompt() -> PromptTemplate {
 
     {% for document in documents -%}
     ---
-    {{ document }}
+    {{ document.content }}
     ---
     {% endfor -%}
     "

--- a/swiftide/tests/lancedb.rs
+++ b/swiftide/tests/lancedb.rs
@@ -3,7 +3,7 @@ use swiftide::indexing::{
     transformers::{metadata_qa_code::NAME as METADATA_QA_CODE_NAME, ChunkCode, MetadataQACode},
     EmbeddedField,
 };
-use swiftide::query::{self, states, Query, TransformationEvent};
+use swiftide::query::{self, states, Query};
 use swiftide_indexing::{loaders, transformers, Pipeline};
 use swiftide_integrations::{fastembed::FastEmbed, lancedb::LanceDB};
 use swiftide_query::{answers, query_transformers, response_transformers};

--- a/swiftide/tests/lancedb.rs
+++ b/swiftide/tests/lancedb.rs
@@ -75,17 +75,8 @@ async fn test_lancedb() {
         result.answer(),
         "\n\nHello there, how may I assist you today?"
     );
-    let TransformationEvent::Retrieved { documents, .. } = result
-        .history()
-        .iter()
-        .find(|e| matches!(e, TransformationEvent::Retrieved { .. }))
-        .unwrap()
-    else {
-        panic!("No documents found")
-    };
-
     assert_eq!(
-        documents.first().unwrap(),
-        "fn main() { println!(\"Hello, World!\"); }"
+        result.documents().first().unwrap(),
+        &"fn main() { println!(\"Hello, World!\"); }".into()
     );
 }

--- a/swiftide/tests/pgvector.rs
+++ b/swiftide/tests/pgvector.rs
@@ -22,7 +22,6 @@ use swiftide::{
     },
     query::{
         self, answers, query_transformers, response_transformers, states, Query,
-        TransformationEvent,
     },
 };
 use swiftide_test_utils::{mock_chat_completions, openai_client};

--- a/swiftide/tests/pgvector.rs
+++ b/swiftide/tests/pgvector.rs
@@ -227,6 +227,6 @@ async fn test_pgvector_retrieve() {
 
     assert_eq!(
         documents.first().unwrap(),
-        "fn main() { println!(\"Hello, World!\"); }"
+        &"fn main() { println!(\"Hello, World!\"); }".into()
     );
 }

--- a/swiftide/tests/pgvector.rs
+++ b/swiftide/tests/pgvector.rs
@@ -20,9 +20,7 @@ use swiftide::{
         self,
         pgvector::{FieldConfig, PgVector, PgVectorBuilder, VectorConfig},
     },
-    query::{
-        self, answers, query_transformers, response_transformers, states, Query,
-    },
+    query::{self, answers, query_transformers, response_transformers, states, Query},
 };
 use swiftide_test_utils::{mock_chat_completions, openai_client};
 use wiremock::MockServer;


### PR DESCRIPTION
For simple RAG, just adding the content of a retrieved document might be enough. However, in more complex use cases, you might want to add metadata as well, as is or for conditional formatting.

For instance, when dealing with large amounts of chunked code, providing the path goes a long way. If generated metadata is good enough, could be useful as well.

With this retrieved Documents are treated as first class citizens. Additionally, this also paves the way for multi retrieval (and multi modal).

Documents can be formatted with `tera` in the answering step.
