### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.1](https://github.com/bosun-ai/swiftide/compare/v0.15.0...v0.15.1) - 2024-12-30
+
+### New features
+
+- [52e341e](https://github.com/bosun-ai/swiftide/commit/52e341ee9777d04f9fb07054980ba087c55c033e) *(lancedb)*  Public method for opening table (#514)
+
+- [584695e](https://github.com/bosun-ai/swiftide/commit/584695e4841a3c9341e521b81e9f254270b3416e) *(query)*  Add custom SQL query generation for pgvector search (#478)
+
+````text
+Adds support for custom retrieval queries with the sqlx query builder for PGVector. Puts down the fundamentals for custom query building for any retriever.
+
+  ---------
+````
+
+- [b55bf0b](https://github.com/bosun-ai/swiftide/commit/b55bf0b318042459a6983cf725078c4da662618b) *(redb)*  Public database and table definition (#510)
+
+- [176378f](https://github.com/bosun-ai/swiftide/commit/176378f846ddecc3ddba74f6b423338b793f29b4)  Implement traits for all Arc dynamic dispatch (#513)
+
+````text
+If you use i.e. a `Persist` or a `NodeCache` outside swiftide as well, and you already have it Arc'ed, now it just works.
+````
+
+- [dc9881e](https://github.com/bosun-ai/swiftide/commit/dc9881e48da7fb5dc744ef33b1c356b4152d00d3)  Allow opt out of pipeline debug truncation
+
+### Miscellaneous
+
+- [1bbbb0e](https://github.com/bosun-ai/swiftide/commit/1bbbb0e548cafa527c34856bd9ac6f76aca2ab5f)  Clippy
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.15.0...0.15.1
+
+
+
 ## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-23
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8539,7 +8539,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8591,7 +8591,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8619,7 +8619,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8640,7 +8640,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8668,7 +8668,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.15.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.15.1" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.15.0 -> 0.15.1 (✓ API compatible changes)
* `swiftide-agents`: 0.15.0 -> 0.15.1
* `swiftide-core`: 0.15.0 -> 0.15.1 (✓ API compatible changes)
* `swiftide-macros`: 0.15.0 -> 0.15.1
* `swiftide-integrations`: 0.15.0 -> 0.15.1 (✓ API compatible changes)
* `swiftide-indexing`: 0.15.0 -> 0.15.1
* `swiftide-query`: 0.15.0 -> 0.15.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.15.1](https://github.com/bosun-ai/swiftide/compare/v0.15.0...v0.15.1) - 2024-12-30

### New features

- [52e341e](https://github.com/bosun-ai/swiftide/commit/52e341ee9777d04f9fb07054980ba087c55c033e) *(lancedb)*  Public method for opening table (#514)

- [584695e](https://github.com/bosun-ai/swiftide/commit/584695e4841a3c9341e521b81e9f254270b3416e) *(query)*  Add custom SQL query generation for pgvector search (#478)

````text
Adds support for custom retrieval queries with the sqlx query builder for PGVector. Puts down the fundamentals for custom query building for any retriever.

  ---------
````

- [b55bf0b](https://github.com/bosun-ai/swiftide/commit/b55bf0b318042459a6983cf725078c4da662618b) *(redb)*  Public database and table definition (#510)

- [176378f](https://github.com/bosun-ai/swiftide/commit/176378f846ddecc3ddba74f6b423338b793f29b4)  Implement traits for all Arc dynamic dispatch (#513)

````text
If you use i.e. a `Persist` or a `NodeCache` outside swiftide as well, and you already have it Arc'ed, now it just works.
````

- [dc9881e](https://github.com/bosun-ai/swiftide/commit/dc9881e48da7fb5dc744ef33b1c356b4152d00d3)  Allow opt out of pipeline debug truncation

### Miscellaneous

- [1bbbb0e](https://github.com/bosun-ai/swiftide/commit/1bbbb0e548cafa527c34856bd9ac6f76aca2ab5f)  Clippy


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.15.0...0.15.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).