### PR TITLE
feat(query): Generic templates with document rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8761,6 +8761,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swiftide-core",
+ "tera",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/examples/hybrid_search.rs
+++ b/examples/hybrid_search.rs
@@ -211,7 +211,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // ### Usage of Prompts in Transformers
     //
-    // Swiftide utilizes the [`PromptTemplate`] for templating prompts, making it easy to define and manage prompts within transformers.
+    // Swiftide utilizes the [`Template`] for templating prompts, making it easy to define and manage prompts within transformers.
     //
     // ```rust
     // let template = PromptTemplate::try_compiled_from_str("hello {{world}}").await.unwrap();

--- a/swiftide-agents/src/system_prompt.rs
+++ b/swiftide-agents/src/system_prompt.rs
@@ -28,7 +28,7 @@ pub struct SystemPrompt {
 
     /// The template to use for the system prompt
     #[builder(default = default_prompt_template())]
-    template: Template<'static>,
+    template: Template,
 }
 
 impl SystemPrompt {
@@ -76,7 +76,7 @@ impl SystemPromptBuilder {
     }
 }
 
-fn default_prompt_template() -> Template<'static> {
+fn default_prompt_template() -> Template {
     include_str!("system_prompt_template.md").into()
 }
 

--- a/swiftide-agents/src/system_prompt.rs
+++ b/swiftide-agents/src/system_prompt.rs
@@ -10,7 +10,7 @@
 //! be provided on the agent level.
 
 use derive_builder::Builder;
-use swiftide_core::prompt::{Prompt, Template};
+use swiftide_core::{prompt::Prompt, template::Template};
 
 #[derive(Clone, Debug, Builder)]
 #[builder(setter(into, strip_option))]
@@ -26,7 +26,7 @@ pub struct SystemPrompt {
     #[builder(default, setter(custom))]
     constraints: Vec<String>,
 
-    /// The template to use
+    /// The template to use for the system prompt
     #[builder(default = default_prompt_template())]
     template: Template,
 }

--- a/swiftide-agents/src/system_prompt.rs
+++ b/swiftide-agents/src/system_prompt.rs
@@ -10,7 +10,7 @@
 //! be provided on the agent level.
 
 use derive_builder::Builder;
-use swiftide_core::prompt::{Prompt, PromptTemplate};
+use swiftide_core::prompt::{Prompt, Template};
 
 #[derive(Clone, Debug, Builder)]
 #[builder(setter(into, strip_option))]
@@ -28,7 +28,7 @@ pub struct SystemPrompt {
 
     /// The template to use
     #[builder(default = default_prompt_template())]
-    template: PromptTemplate,
+    template: Template,
 }
 
 impl SystemPrompt {
@@ -76,7 +76,7 @@ impl SystemPromptBuilder {
     }
 }
 
-fn default_prompt_template() -> PromptTemplate {
+fn default_prompt_template() -> Template {
     include_str!("system_prompt_template.md").into()
 }
 

--- a/swiftide-agents/src/system_prompt.rs
+++ b/swiftide-agents/src/system_prompt.rs
@@ -28,7 +28,7 @@ pub struct SystemPrompt {
 
     /// The template to use for the system prompt
     #[builder(default = default_prompt_template())]
-    template: Template,
+    template: Template<'static>,
 }
 
 impl SystemPrompt {
@@ -76,7 +76,7 @@ impl SystemPromptBuilder {
     }
 }
 
-fn default_prompt_template() -> Template {
+fn default_prompt_template() -> Template<'static> {
     include_str!("system_prompt_template.md").into()
 }
 

--- a/swiftide-core/src/lib.rs
+++ b/swiftide-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod type_aliases;
 
 pub mod document;
 pub mod prompt;
+pub mod template;
 pub use type_aliases::*;
 
 mod metadata;

--- a/swiftide-core/src/prompt.rs
+++ b/swiftide-core/src/prompt.rs
@@ -84,7 +84,11 @@ impl Prompt {
     ///
     /// See `Template::render`
     pub async fn render(&self) -> Result<String> {
-        self.template.render(&self.context).await
+        if let Some(context) = &self.context {
+            self.template.render(context).await
+        } else {
+            self.template.render(&tera::Context::default()).await
+        }
     }
 }
 

--- a/swiftide-core/src/prompt.rs
+++ b/swiftide-core/src/prompt.rs
@@ -136,14 +136,17 @@ impl PromptTemplate {
                 };
 
                 let lock = TEMPLATE_REPOSITORY.read().await;
-                let available = lock.get_template_names().collect::<Vec<_>>().join(", ");
-                tracing::debug!(id, available, "Rendering template ...");
+                tracing::debug!(
+                    id,
+                    available = ?lock.get_template_names().collect::<Vec<_>>(),
+                    "Rendering template ..."
+                );
                 let result = lock.render(id, context);
 
                 if result.is_err() {
                     tracing::error!(
                         error = result.as_ref().unwrap_err().to_string(),
-                        available,
+                        available = ?lock.get_template_names().collect::<Vec<_>>(),
                         "Error rendering template {id}"
                     );
                 }

--- a/swiftide-core/src/template.rs
+++ b/swiftide-core/src/template.rs
@@ -1,0 +1,151 @@
+use anyhow::{Context as _, Result};
+use tokio::sync::RwLock;
+
+use lazy_static::lazy_static;
+use tera::Tera;
+use uuid::Uuid;
+
+use crate::prompt::Prompt;
+
+lazy_static! {
+    /// Tera repository for templates
+    static ref TEMPLATE_REPOSITORY: RwLock<Tera> = {
+        let prefix = env!("CARGO_MANIFEST_DIR");
+        let path = format!("{prefix}/src/transformers/prompts/**/*.prompt.md");
+
+        match Tera::new(&path)
+        {
+            Ok(t) => RwLock::new(t),
+            Err(e) => {
+                tracing::error!("Parsing error(s): {e}");
+                ::std::process::exit(1);
+            }
+        }
+    };
+}
+/// A `Template` defines a template for a prompt
+#[derive(Clone, Debug)]
+pub enum Template {
+    CompiledTemplate(String),
+    String(String),
+    Static(&'static str),
+}
+
+impl Template {
+    /// Creates a reference to a template already stored in the repository
+    pub fn from_compiled_template_name(name: impl Into<String>) -> Template {
+        Template::CompiledTemplate(name.into())
+    }
+
+    pub fn from_string(template: impl Into<String>) -> Template {
+        Template::String(template.into())
+    }
+
+    /// Extends the prompt repository with a custom [`tera::Tera`] instance.
+    ///
+    /// If you have your own prompt templates or want to add other functionality, you can extend
+    /// the repository with your own [`tera::Tera`] instance.
+    ///
+    /// WARN: Do not use this inside a pipeline or any form of load, as it will lock the repository
+    ///
+    /// # Errors
+    ///
+    /// Errors if the repository could not be extended
+    pub async fn extend(tera: &Tera) -> Result<()> {
+        TEMPLATE_REPOSITORY
+            .write()
+            .await
+            .extend(tera)
+            .context("Could not extend prompt repository with custom Tera instance")
+    }
+
+    /// Compiles a template from a string and returns a `Template` with a reference to the
+    /// string.
+    ///
+    /// WARN: Do not use this inside a pipeline or any form of load, as it will lock the repository
+    ///
+    /// # Errors
+    ///
+    /// Errors if the template fails to compile
+    pub async fn try_compiled_from_str(
+        template: impl AsRef<str> + Send + 'static,
+    ) -> Result<Template> {
+        let id = Uuid::new_v4().to_string();
+        let mut lock = TEMPLATE_REPOSITORY.write().await;
+        lock.add_raw_template(&id, template.as_ref())
+            .context("Failed to add raw template")?;
+
+        Ok(Template::CompiledTemplate(id))
+    }
+
+    /// Renders a template with an optional `tera::Context`
+    ///
+    /// # Errors
+    ///
+    /// - Template cannot be found
+    /// - One-off template has errors
+    /// - Context is missing that is required by the template
+    pub async fn render(&self, context: &Option<tera::Context>) -> Result<String> {
+        use Template::{CompiledTemplate, Static, String};
+
+        let template = match self {
+            CompiledTemplate(id) => {
+                let context = match &context {
+                    Some(context) => context,
+                    None => &tera::Context::default(),
+                };
+
+                let lock = TEMPLATE_REPOSITORY.read().await;
+                tracing::debug!(
+                    id,
+                    available = ?lock.get_template_names().collect::<Vec<_>>(),
+                    "Rendering template ..."
+                );
+                let result = lock.render(id, context);
+
+                if result.is_err() {
+                    tracing::error!(
+                        error = result.as_ref().unwrap_err().to_string(),
+                        available = ?lock.get_template_names().collect::<Vec<_>>(),
+                        "Error rendering template {id}"
+                    );
+                }
+                result.with_context(|| format!("Failed to render template '{id}'"))?
+            }
+            String(template) => {
+                if let Some(context) = context {
+                    Tera::one_off(template, context, false)
+                        .context("Failed to render one-off template")?
+                } else {
+                    template.to_string()
+                }
+            }
+            Static(template) => {
+                if let Some(context) = context {
+                    Tera::one_off(template, context, false)
+                        .context("Failed to render one-off template")?
+                } else {
+                    (*template).to_string()
+                }
+            }
+        };
+        Ok(template)
+    }
+
+    /// Builds a Prompt from a template with an empty context
+    pub fn to_prompt(&self) -> Prompt {
+        self.into()
+    }
+}
+
+impl From<&'static str> for Template {
+    fn from(template: &'static str) -> Self {
+        Template::Static(template)
+    }
+}
+
+impl From<String> for Template {
+    fn from(template: String) -> Self {
+        Template::String(template)
+    }
+}

--- a/swiftide-indexing/src/transformers/mod.rs
+++ b/swiftide-indexing/src/transformers/mod.rs
@@ -6,7 +6,7 @@
 //! Transformers that prompt have a default prompt configured. Prompts can be customized
 //! and tailored, supporting Jinja style templating based on [tera](https://docs.rs/tera/latest/tera/).
 //!
-//!  See [`swiftide_core::prompt::Prompt`] and [`swiftide_core::prompt::PromptTemplate`]
+//!  See [`swiftide_core::prompt::Prompt`] and [`swiftide_core::prompt::Template`]
 
 pub mod chunk_markdown;
 pub mod chunk_text;

--- a/swiftide-indexing/src/transformers/mod.rs
+++ b/swiftide-indexing/src/transformers/mod.rs
@@ -6,7 +6,7 @@
 //! Transformers that prompt have a default prompt configured. Prompts can be customized
 //! and tailored, supporting Jinja style templating based on [tera](https://docs.rs/tera/latest/tera/).
 //!
-//!  See [`swiftide_core::prompt::Prompt`] and [`swiftide_core::prompt::Template`]
+//!  See [`swiftide_core::prompt::Prompt`] and [`swiftide_core::template::Template`]
 
 pub mod chunk_markdown;
 pub mod chunk_text;

--- a/swiftide-macros/src/indexing_transformer.rs
+++ b/swiftide-macros/src/indexing_transformer.rs
@@ -45,14 +45,14 @@ pub(crate) fn indexing_transformer_impl(args: TokenStream, input: ItemStruct) ->
     let prompt_template_struct_attr = match &args.default_prompt_file {
         Some(_file) => quote! {
             #[builder(default = "default_prompt()")]
-            prompt_template: hidden::PromptTemplate,
+            prompt_template: hidden::Template,
         },
         None => quote! {},
     };
 
     let default_prompt_fn = match &args.default_prompt_file {
         Some(file) => quote! {
-            fn default_prompt() -> hidden::PromptTemplate {
+            fn default_prompt() -> hidden::Template {
                 include_str!(#file).into()
             }
         },
@@ -90,7 +90,7 @@ pub(crate) fn indexing_transformer_impl(args: TokenStream, input: ItemStruct) ->
             pub use derive_builder::Builder;
             pub use swiftide_core::{
                 indexing::{IndexingDefaults},
-                prompt::{Prompt, PromptTemplate},
+                prompt::{Prompt, Template},
                 SimplePrompt, Transformer, WithIndexingDefaults
             };
         }
@@ -225,7 +225,7 @@ mod tests {
                 pub use derive_builder::Builder;
                 pub use swiftide_core::{
                     indexing::{IndexingDefaults},
-                    prompt::{Prompt, PromptTemplate},
+                    prompt::{Prompt, Template},
                     SimplePrompt, Transformer, WithIndexingDefaults
                 };
             }

--- a/swiftide-macros/src/indexing_transformer.rs
+++ b/swiftide-macros/src/indexing_transformer.rs
@@ -52,7 +52,7 @@ pub(crate) fn indexing_transformer_impl(args: TokenStream, input: ItemStruct) ->
 
     let default_prompt_fn = match &args.default_prompt_file {
         Some(file) => quote! {
-            fn default_prompt() -> hidden::Template {
+            fn default_prompt() -> hidden::Template<'static> {
                 include_str!(#file).into()
             }
         },

--- a/swiftide-macros/src/indexing_transformer.rs
+++ b/swiftide-macros/src/indexing_transformer.rs
@@ -165,7 +165,7 @@ pub(crate) fn indexing_transformer_impl(args: TokenStream, input: ItemStruct) ->
 
         impl #builder_name {
             pub fn client(&mut self, client: impl hidden::SimplePrompt + 'static) -> &mut Self {
-                self.client = Some(Some(hidden::Arc::new(client)));
+                self.client = Some(Some(hidden::Arc::new(client) as hidden::Arc<dyn hidden::SimplePrompt>));
                 self
             }
         }
@@ -299,7 +299,7 @@ mod tests {
 
             impl TestStructBuilder {
                 pub fn client(&mut self, client: impl hidden::SimplePrompt + 'static) -> &mut Self {
-                    self.client = Some(Some(hidden::Arc::new(client)));
+                    self.client = Some(Some(hidden::Arc::new(client) as hidden::Arc<dyn hidden::SimplePrompt>));
                     self
                 }
             }

--- a/swiftide-macros/src/indexing_transformer.rs
+++ b/swiftide-macros/src/indexing_transformer.rs
@@ -90,7 +90,8 @@ pub(crate) fn indexing_transformer_impl(args: TokenStream, input: ItemStruct) ->
             pub use derive_builder::Builder;
             pub use swiftide_core::{
                 indexing::{IndexingDefaults},
-                prompt::{Prompt, Template},
+                prompt::Prompt,
+                template::Template,
                 SimplePrompt, Transformer, WithIndexingDefaults
             };
         }
@@ -225,7 +226,8 @@ mod tests {
                 pub use derive_builder::Builder;
                 pub use swiftide_core::{
                     indexing::{IndexingDefaults},
-                    prompt::{Prompt, Template},
+                    prompt::Prompt,
+                    template::Template,
                     SimplePrompt, Transformer, WithIndexingDefaults
                 };
             }

--- a/swiftide-macros/src/indexing_transformer.rs
+++ b/swiftide-macros/src/indexing_transformer.rs
@@ -52,7 +52,7 @@ pub(crate) fn indexing_transformer_impl(args: TokenStream, input: ItemStruct) ->
 
     let default_prompt_fn = match &args.default_prompt_file {
         Some(file) => quote! {
-            fn default_prompt() -> hidden::Template<'static> {
+            fn default_prompt() -> hidden::Template {
                 include_str!(#file).into()
             }
         },

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 indoc = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tera = { workspace = true }
 
 # Internal
 swiftide-core = { path = "../swiftide-core", version = "0.15.0" }

--- a/swiftide-query/src/answers/simple.rs
+++ b/swiftide-query/src/answers/simple.rs
@@ -10,8 +10,8 @@ use swiftide_core::{
     document::Document,
     indexing::SimplePrompt,
     prelude::*,
-    prompt::Template,
     querying::{states, Query},
+    template::Template,
     Answer,
 };
 
@@ -79,16 +79,16 @@ fn default_prompt() -> Template {
 impl Answer for Simple {
     #[tracing::instrument(skip_all)]
     async fn answer(&self, query: Query<states::Retrieved>) -> Result<Query<states::Answered>> {
-        // let context = if query.current().is_empty() {
-        //     &query
-        //         .documents()
-        //         .iter()
-        //         .map(Document::content)
-        //         .collect::<Vec<_>>()
-        //         .join("\n---\n")
-        // } else {
-        //     query.current()
-        // };
+        let context = if query.current().is_empty() {
+            &query
+                .documents()
+                .iter()
+                .map(Document::content)
+                .collect::<Vec<_>>()
+                .join("\n---\n")
+        } else {
+            query.current()
+        };
 
         let answer = self
             .client
@@ -96,7 +96,7 @@ impl Answer for Simple {
                 self.prompt_template
                     .to_prompt()
                     .with_context_value("question", query.original())
-                    .with_context_value("documents", query.documents()),
+                    .with_context_value("context", context),
             )
             .await?;
 

--- a/swiftide-query/src/answers/snapshots/swiftide_query__answers__simple__test__custom_document_template.snap
+++ b/swiftide-query/src/answers/snapshots/swiftide_query__answers__simple__test__custom_document_template.snap
@@ -1,9 +1,9 @@
 ---
 source: swiftide-query/src/answers/simple.rs
-expression: prompt.render().await.unwrap()
+expression: rendered
 ---
 Answer the following question based on the context provided:
-What is love?
+original
 
 ## Constraints
 * Do not include any information that is not in the provided context.
@@ -13,5 +13,9 @@ What is love?
 ## Context
 
 ---
-My context
+some: metadata
+First document
+---
+other: metadata
+Second document
 ---

--- a/swiftide-query/src/answers/snapshots/swiftide_query__answers__simple__test__uses_current_if_present.snap
+++ b/swiftide-query/src/answers/snapshots/swiftide_query__answers__simple__test__uses_current_if_present.snap
@@ -1,9 +1,9 @@
 ---
 source: swiftide-query/src/answers/simple.rs
-expression: prompt.render().await.unwrap()
+expression: rendered
 ---
 Answer the following question based on the context provided:
-What is love?
+original
 
 ## Constraints
 * Do not include any information that is not in the provided context.
@@ -13,5 +13,5 @@ What is love?
 ## Context
 
 ---
-My context
+A fictional generated summary
 ---

--- a/swiftide-query/src/query/pipeline.rs
+++ b/swiftide-query/src/query/pipeline.rs
@@ -248,8 +248,6 @@ impl<'stream: 'static, STRATEGY: SearchStrategy> Pipeline<'stream, STRATEGY, sta
 
 impl<'stream: 'static, STRATEGY: SearchStrategy> Pipeline<'stream, STRATEGY, states::Retrieved> {
     /// Generates an answer based on previous transformations
-    ///
-    /// For a lot of use cases, `answers::Simple` should be sufficient
     #[must_use]
     pub fn then_answer<T: Answer + 'stream>(
         self,

--- a/swiftide-query/src/query/pipeline.rs
+++ b/swiftide-query/src/query/pipeline.rs
@@ -248,6 +248,8 @@ impl<'stream: 'static, STRATEGY: SearchStrategy> Pipeline<'stream, STRATEGY, sta
 
 impl<'stream: 'static, STRATEGY: SearchStrategy> Pipeline<'stream, STRATEGY, states::Retrieved> {
     /// Generates an answer based on previous transformations
+    ///
+    /// For a lot of use cases, `answers::Simple` should be sufficient
     #[must_use]
     pub fn then_answer<T: Answer + 'stream>(
         self,

--- a/swiftide-query/src/query_transformers/generate_subquestions.rs
+++ b/swiftide-query/src/query_transformers/generate_subquestions.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use swiftide_core::{
     indexing::SimplePrompt,
     prelude::*,
-    prompt::PromptTemplate,
+    prompt::Template,
     querying::{states, Query, TransformQuery},
 };
 
@@ -14,7 +14,7 @@ pub struct GenerateSubquestions {
     #[builder(setter(custom))]
     client: Arc<dyn SimplePrompt>,
     #[builder(default = "default_prompt()")]
-    prompt_template: PromptTemplate,
+    prompt_template: Template,
     #[builder(default = "5")]
     num_questions: usize,
 }
@@ -45,7 +45,7 @@ impl GenerateSubquestionsBuilder {
     }
 }
 
-fn default_prompt() -> PromptTemplate {
+fn default_prompt() -> Template {
     indoc::indoc!("
     Your job is to help a query tool find the right context.
 

--- a/swiftide-query/src/query_transformers/generate_subquestions.rs
+++ b/swiftide-query/src/query_transformers/generate_subquestions.rs
@@ -40,7 +40,7 @@ impl GenerateSubquestions {
 
 impl GenerateSubquestionsBuilder {
     pub fn client(&mut self, client: impl SimplePrompt + 'static) -> &mut Self {
-        self.client = Some(Arc::new(client));
+        self.client = Some(Arc::new(client) as Arc<dyn SimplePrompt>);
         self
     }
 }

--- a/swiftide-query/src/query_transformers/generate_subquestions.rs
+++ b/swiftide-query/src/query_transformers/generate_subquestions.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use swiftide_core::{
     indexing::SimplePrompt,
     prelude::*,
-    prompt::Template,
     querying::{states, Query, TransformQuery},
+    template::Template,
 };
 
 #[derive(Debug, Clone, Builder)]

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -8,15 +8,15 @@ use swiftide_core::{
 };
 
 #[derive(Debug, Clone, Builder)]
-pub struct Summary {
+pub struct Summary<'a> {
     #[builder(setter(custom))]
     client: Arc<dyn SimplePrompt>,
     #[builder(default = "default_prompt()")]
-    prompt_template: Template,
+    prompt_template: Template<'a>,
 }
 
-impl Summary {
-    pub fn builder() -> SummaryBuilder {
+impl Summary<'_> {
+    pub fn builder() -> SummaryBuilder<'static> {
         SummaryBuilder::default()
     }
 
@@ -28,7 +28,7 @@ impl Summary {
     /// # Panics
     ///
     /// Panics if the build failed
-    pub fn from_client(client: impl SimplePrompt + 'static) -> Summary {
+    pub fn from_client(client: impl SimplePrompt + 'static) -> Self {
         SummaryBuilder::default()
             .client(client)
             .to_owned()
@@ -37,14 +37,14 @@ impl Summary {
     }
 }
 
-impl SummaryBuilder {
+impl SummaryBuilder<'_> {
     pub fn client(&mut self, client: impl SimplePrompt + 'static) -> &mut Self {
         self.client = Some(Arc::new(client) as Arc<dyn SimplePrompt>);
         self
     }
 }
 
-fn default_prompt() -> Template {
+fn default_prompt() -> Template<'static> {
     indoc::indoc!(
         "
     Your job is to help a query tool find the right context.
@@ -69,7 +69,7 @@ fn default_prompt() -> Template {
 }
 
 #[async_trait]
-impl TransformResponse for Summary {
+impl<'a> TransformResponse for Summary<'a> {
     #[tracing::instrument(skip_all)]
     async fn transform_response(
         &self,

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -8,15 +8,15 @@ use swiftide_core::{
 };
 
 #[derive(Debug, Clone, Builder)]
-pub struct Summary<'a> {
+pub struct Summary {
     #[builder(setter(custom))]
     client: Arc<dyn SimplePrompt>,
     #[builder(default = "default_prompt()")]
-    prompt_template: Template<'a>,
+    prompt_template: Template,
 }
 
-impl Summary<'_> {
-    pub fn builder() -> SummaryBuilder<'static> {
+impl Summary {
+    pub fn builder() -> SummaryBuilder {
         SummaryBuilder::default()
     }
 
@@ -28,7 +28,7 @@ impl Summary<'_> {
     /// # Panics
     ///
     /// Panics if the build failed
-    pub fn from_client(client: impl SimplePrompt + 'static) -> Self {
+    pub fn from_client(client: impl SimplePrompt + 'static) -> Summary {
         SummaryBuilder::default()
             .client(client)
             .to_owned()
@@ -37,14 +37,14 @@ impl Summary<'_> {
     }
 }
 
-impl SummaryBuilder<'_> {
+impl SummaryBuilder {
     pub fn client(&mut self, client: impl SimplePrompt + 'static) -> &mut Self {
         self.client = Some(Arc::new(client) as Arc<dyn SimplePrompt>);
         self
     }
 }
 
-fn default_prompt() -> Template<'static> {
+fn default_prompt() -> Template {
     indoc::indoc!(
         "
     Your job is to help a query tool find the right context.
@@ -69,7 +69,7 @@ fn default_prompt() -> Template<'static> {
 }
 
 #[async_trait]
-impl<'a> TransformResponse for Summary<'a> {
+impl TransformResponse for Summary {
     #[tracing::instrument(skip_all)]
     async fn transform_response(
         &self,

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use swiftide_core::{
     indexing::SimplePrompt,
     prelude::*,
-    prompt::PromptTemplate,
+    prompt::Template,
     querying::{states, Query},
     TransformResponse,
 };
@@ -12,7 +12,7 @@ pub struct Summary {
     #[builder(setter(custom))]
     client: Arc<dyn SimplePrompt>,
     #[builder(default = "default_prompt()")]
-    prompt_template: PromptTemplate,
+    prompt_template: Template,
 }
 
 impl Summary {
@@ -44,7 +44,7 @@ impl SummaryBuilder {
     }
 }
 
-fn default_prompt() -> PromptTemplate {
+fn default_prompt() -> Template {
     indoc::indoc!(
         "
     Your job is to help a query tool find the right context.

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -39,7 +39,7 @@ impl Summary {
 
 impl SummaryBuilder {
     pub fn client(&mut self, client: impl SimplePrompt + 'static) -> &mut Self {
-        self.client = Some(Arc::new(client));
+        self.client = Some(Arc::new(client) as Arc<dyn SimplePrompt>);
         self
     }
 }

--- a/swiftide-query/src/response_transformers/summary.rs
+++ b/swiftide-query/src/response_transformers/summary.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use swiftide_core::{
     indexing::SimplePrompt,
     prelude::*,
-    prompt::Template,
     querying::{states, Query},
+    template::Template,
     TransformResponse,
 };
 


### PR DESCRIPTION
Reworks `PromptTemplate` to more a more generic `Template`, such that they can also be used elsewhere. This deprecates `PromptTemplate`.

As an example, introduces an optional `Template` in the `Simple` answer transformer, which can be used to customize the output of retrieved documents. This has excellent synergy with the metadata changes.
