### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0](https://github.com/bosun-ai/swiftide/compare/v0.15.0...v0.16.0) - 2025-01-02
+
+### New features
+
+- [52e341e](https://github.com/bosun-ai/swiftide/commit/52e341ee9777d04f9fb07054980ba087c55c033e) *(lancedb)*  Public method for opening table (#514)
+
+- [3254bd3](https://github.com/bosun-ai/swiftide/commit/3254bd34d0eeb038c8aa6ea56ac2940b3ca81960) *(query)*  Generic templates with document rendering (#520)
+
+````text
+Reworks `PromptTemplate` to a more generic `Template`, such that they
+  can also be used elsewhere. This deprecates `PromptTemplate`.
+
+  As an example, an optional `Template` in the `Simple` answer
+  transformer, which can be used to customize the output of retrieved
+  documents. This has excellent synergy with the metadata changes in #504.
+````
+
+- [235780b](https://github.com/bosun-ai/swiftide/commit/235780b941a0805b69541f0f4c55c3404091baa8) *(query)*  Documents as first class citizens (#504)
+
+````text
+For simple RAG, just adding the content of a retrieved document might be
+  enough. However, in more complex use cases, you might want to add
+  metadata as well, as is or for conditional formatting.
+
+  For instance, when dealing with large amounts of chunked code, providing
+  the path goes a long way. If generated metadata is good enough, could be
+  useful as well.
+
+  With this retrieved Documents are treated as first class citizens,
+  including any metadata as well. Additionally, this also paves the way
+  for multi retrieval (and multi modal).
+````
+
+- [584695e](https://github.com/bosun-ai/swiftide/commit/584695e4841a3c9341e521b81e9f254270b3416e) *(query)*  Add custom SQL query generation for pgvector search (#478)
+
+````text
+Adds support for custom retrieval queries with the sqlx query builder for PGVector. Puts down the fundamentals for custom query building for any retriever.
+
+  ---------
+````
+
+- [b55bf0b](https://github.com/bosun-ai/swiftide/commit/b55bf0b318042459a6983cf725078c4da662618b) *(redb)*  Public database and table definition (#510)
+
+- [176378f](https://github.com/bosun-ai/swiftide/commit/176378f846ddecc3ddba74f6b423338b793f29b4)  Implement traits for all Arc dynamic dispatch (#513)
+
+````text
+If you use i.e. a `Persist` or a `NodeCache` outside swiftide as well, and you already have it Arc'ed, now it just works.
+````
+
+- [dc9881e](https://github.com/bosun-ai/swiftide/commit/dc9881e48da7fb5dc744ef33b1c356b4152d00d3)  Allow opt out of pipeline debug truncation
+
+### Bug fixes
+
+- [2831101](https://github.com/bosun-ai/swiftide/commit/2831101daa2928b5507116d9eb907d98fb77bf50) *(lancedb)*  Metadata should be nullable in lancedb (#515)
+
+- [c35df55](https://github.com/bosun-ai/swiftide/commit/c35df5525d4d88cfb9ada89a060e1ab512b471af) *(macros)*  Explicit box dyn cast fixing Rust Analyzer troubles (#523)
+
+### Miscellaneous
+
+- [1bbbb0e](https://github.com/bosun-ai/swiftide/commit/1bbbb0e548cafa527c34856bd9ac6f76aca2ab5f)  Clippy
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.15.0...0.16.0
+
+
+
 ## [0.15.0](https://github.com/bosun-ai/swiftide/compare/v0.14.4...v0.15.0) - 2024-12-23
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8539,7 +8539,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8591,7 +8591,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8619,7 +8619,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8640,7 +8640,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8668,7 +8668,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8748,7 +8748,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8769,7 +8769,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.15" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.15" }
+swiftide-core = { path = "../swiftide-core", version = "0.16" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.16" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true
@@ -27,10 +27,10 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.15", features = [
+swiftide-core = { path = "../swiftide-core", version = "0.16", features = [
   "test-utils",
 ] }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.15", features = [
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.16", features = [
   "openai",
 ] }
 mockall.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.15" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.15" }
+swiftide-core = { path = "../swiftide-core", version = "0.16" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.16" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.15" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.15" }
+swiftide-core = { path = "../swiftide-core", version = "0.16" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.16" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -32,8 +32,8 @@ rustversion = "1.0.18"
 trybuild = "1.0"
 prettyplease = "0.2.25"
 insta.workspace = true
-swiftide-core = { path = "../swiftide-core/", version = "0.15" }
-swiftide = { path = "../swiftide/", version = "0.15" }
+swiftide-core = { path = "../swiftide-core/", version = "0.16" }
+swiftide = { path = "../swiftide/", version = "0.16" }
 
 [lints]
 workspace = true

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.15.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.16.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.15" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.15" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.15" }
-swiftide-query = { path = "../swiftide-query", version = "0.15" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.15", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.16" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.16" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.16" }
+swiftide-query = { path = "../swiftide-query", version = "0.16" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.16", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.15.0 -> 0.16.0 (✓ API compatible changes)
* `swiftide-agents`: 0.15.0 -> 0.16.0 (✓ API compatible changes)
* `swiftide-core`: 0.15.0 -> 0.16.0 (⚠️ API breaking changes)
* `swiftide-macros`: 0.15.0 -> 0.16.0
* `swiftide-integrations`: 0.15.0 -> 0.16.0 (✓ API compatible changes)
* `swiftide-indexing`: 0.15.0 -> 0.16.0 (✓ API compatible changes)
* `swiftide-query`: 0.15.0 -> 0.16.0 (✓ API compatible changes)

### ⚠️ `swiftide-core` breaking changes

```
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_missing.ron

Failed in:
  enum swiftide_core::querying::states::AnsweredBuilderError, previously in file /tmp/.tmpfXNg04/swiftide-core/src/query.rs:202
  enum swiftide_core::querying::states::RetrievedBuilderError, previously in file /tmp/.tmpfXNg04/swiftide-core/src/query.rs:179

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct swiftide_core::querying::states::RetrievedBuilder, previously in file /tmp/.tmpfXNg04/swiftide-core/src/query.rs:179
  struct swiftide_core::querying::states::AnsweredBuilder, previously in file /tmp/.tmpfXNg04/swiftide-core/src/query.rs:202

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait swiftide_core::querying::QueryState gained Default in file /tmp/.tmp5vx3MP/swiftide/swiftide-core/src/query.rs:178

--- failure trait_no_longer_object_safe: trait no longer object safe ---

Description:
Trait is no longer object safe, which breaks `dyn Trait` usage.
        ref: https://doc.rust-lang.org/stable/reference/items/traits.html#object-safety
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_no_longer_object_safe.ron

Failed in:
  trait QueryState in file /tmp/.tmp5vx3MP/swiftide/swiftide-core/src/query.rs:178
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.16.0](https://github.com/bosun-ai/swiftide/compare/v0.15.0...v0.16.0) - 2025-01-02

### New features

- [52e341e](https://github.com/bosun-ai/swiftide/commit/52e341ee9777d04f9fb07054980ba087c55c033e) *(lancedb)*  Public method for opening table (#514)

- [3254bd3](https://github.com/bosun-ai/swiftide/commit/3254bd34d0eeb038c8aa6ea56ac2940b3ca81960) *(query)*  Generic templates with document rendering (#520)

````text
Reworks `PromptTemplate` to a more generic `Template`, such that they
  can also be used elsewhere. This deprecates `PromptTemplate`.

  As an example, an optional `Template` in the `Simple` answer
  transformer, which can be used to customize the output of retrieved
  documents. This has excellent synergy with the metadata changes in #504.
````

- [235780b](https://github.com/bosun-ai/swiftide/commit/235780b941a0805b69541f0f4c55c3404091baa8) *(query)*  Documents as first class citizens (#504)

````text
For simple RAG, just adding the content of a retrieved document might be
  enough. However, in more complex use cases, you might want to add
  metadata as well, as is or for conditional formatting.

  For instance, when dealing with large amounts of chunked code, providing
  the path goes a long way. If generated metadata is good enough, could be
  useful as well.

  With this retrieved Documents are treated as first class citizens,
  including any metadata as well. Additionally, this also paves the way
  for multi retrieval (and multi modal).
````

- [584695e](https://github.com/bosun-ai/swiftide/commit/584695e4841a3c9341e521b81e9f254270b3416e) *(query)*  Add custom SQL query generation for pgvector search (#478)

````text
Adds support for custom retrieval queries with the sqlx query builder for PGVector. Puts down the fundamentals for custom query building for any retriever.

  ---------
````

- [b55bf0b](https://github.com/bosun-ai/swiftide/commit/b55bf0b318042459a6983cf725078c4da662618b) *(redb)*  Public database and table definition (#510)

- [176378f](https://github.com/bosun-ai/swiftide/commit/176378f846ddecc3ddba74f6b423338b793f29b4)  Implement traits for all Arc dynamic dispatch (#513)

````text
If you use i.e. a `Persist` or a `NodeCache` outside swiftide as well, and you already have it Arc'ed, now it just works.
````

- [dc9881e](https://github.com/bosun-ai/swiftide/commit/dc9881e48da7fb5dc744ef33b1c356b4152d00d3)  Allow opt out of pipeline debug truncation

### Bug fixes

- [2831101](https://github.com/bosun-ai/swiftide/commit/2831101daa2928b5507116d9eb907d98fb77bf50) *(lancedb)*  Metadata should be nullable in lancedb (#515)

- [c35df55](https://github.com/bosun-ai/swiftide/commit/c35df5525d4d88cfb9ada89a060e1ab512b471af) *(macros)*  Explicit box dyn cast fixing Rust Analyzer troubles (#523)

### Miscellaneous

- [1bbbb0e](https://github.com/bosun-ai/swiftide/commit/1bbbb0e548cafa527c34856bd9ac6f76aca2ab5f)  Clippy


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.15.0...0.16.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).