### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.1](https://github.com/bosun-ai/swiftide/compare/v0.16.0...v0.16.1) - 2025-01-06
+
+### Bug fixes
+
+- [d198bb0](https://github.com/bosun-ai/swiftide/commit/d198bb0807f5d5b12a51bc76721cc945be8e65b9) *(prompts)*  Skip rendering prompts if no context and forward as is (#530)
+
+````text
+Fixes an issue if strings suddenly include jinja style values by
+  mistake. Bonus performance boost.
+````
+
+- [4e8d59f](https://github.com/bosun-ai/swiftide/commit/4e8d59fbc0fbe72dd0f8d6a95e6e335280eb88e3) *(redb)*  Log errors and return uncached instead of panicing (#531)
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.16.0...0.16.1
+
+
+
 ## [0.16.0](https://github.com/bosun-ai/swiftide/compare/v0.15.0...v0.16.0) - 2025-01-02
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8539,7 +8539,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8590,7 +8590,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8618,7 +8618,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8639,7 +8639,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8667,7 +8667,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8747,7 +8747,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.16.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.16.1" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `swiftide-agents`: 0.16.0 -> 0.16.1
* `swiftide-core`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `swiftide-macros`: 0.16.0 -> 0.16.1
* `swiftide-indexing`: 0.16.0 -> 0.16.1
* `swiftide-integrations`: 0.16.0 -> 0.16.1 (✓ API compatible changes)
* `swiftide-query`: 0.16.0 -> 0.16.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.16.1](https://github.com/bosun-ai/swiftide/compare/v0.16.0...v0.16.1) - 2025-01-06

### Bug fixes

- [d198bb0](https://github.com/bosun-ai/swiftide/commit/d198bb0807f5d5b12a51bc76721cc945be8e65b9) *(prompts)*  Skip rendering prompts if no context and forward as is (#530)

````text
Fixes an issue if strings suddenly include jinja style values by
  mistake. Bonus performance boost.
````

- [4e8d59f](https://github.com/bosun-ai/swiftide/commit/4e8d59fbc0fbe72dd0f8d6a95e6e335280eb88e3) *(redb)*  Log errors and return uncached instead of panicing (#531)


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.16.0...0.16.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).