### PR TITLE
chore: release v0.16.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.4](https://github.com/bosun-ai/swiftide/compare/v0.16.3...v0.16.4) - 2025-01-12
+
+### New features
+
+- [c919484](https://github.com/bosun-ai/swiftide/commit/c9194845faa12b8a0fcecdd65f8ec9d3d221ba08)  Ollama via async-openai with chatcompletion support (#545)
+
+````text
+Adds support for chatcompletions (agents) for ollama. SimplePrompt and embeddings now use async-openai underneath.
+
+  Copy pasted as I expect some differences in the future.
+````
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.16.3...0.16.4
+
+
+
 ## [0.16.3](https://github.com/bosun-ai/swiftide/compare/v0.16.2...v0.16.3) - 2025-01-10
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8541,7 +8541,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8565,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8593,7 +8593,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8614,7 +8614,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8642,7 +8642,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8699,7 +8699,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8721,7 +8721,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8742,7 +8742,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.3"
+version = "0.16.4"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.16.3" }
+swiftide-core = { path = "../swiftide-core", version = "0.16.4" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.16.3 -> 0.16.4 (✓ API compatible changes)
* `swiftide-agents`: 0.16.3 -> 0.16.4 (✓ API compatible changes)
* `swiftide-core`: 0.16.3 -> 0.16.4 (✓ API compatible changes)
* `swiftide-macros`: 0.16.3 -> 0.16.4
* `swiftide-indexing`: 0.16.3 -> 0.16.4 (✓ API compatible changes)
* `swiftide-integrations`: 0.16.3 -> 0.16.4 (✓ API compatible changes)
* `swiftide-query`: 0.16.3 -> 0.16.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.16.4](https://github.com/bosun-ai/swiftide/compare/v0.16.3...v0.16.4) - 2025-01-12

### New features

- [c919484](https://github.com/bosun-ai/swiftide/commit/c9194845faa12b8a0fcecdd65f8ec9d3d221ba08)  Ollama via async-openai with chatcompletion support (#545)

````text
Adds support for chatcompletions (agents) for ollama. SimplePrompt and embeddings now use async-openai underneath.

  Copy pasted as I expect some differences in the future.
````

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.16.3...0.16.4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).