### PR TITLE
chore: release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.0](https://github.com/bosun-ai/swiftide/compare/v0.16.4...v0.17.0) - 2025-01-16
+
+### New features
+
+- [835c35e](https://github.com/bosun-ai/swiftide/commit/835c35e7d74811daa90f7ca747054d1919633058) *(agents)*  Redrive completions manually on failure (#551)
+
+````text
+Sometimes LLMs fail a completion without deterministic errors, or the
+  user case where you just want to retry. `redrive` can now be called on a
+  context, popping any new messages (if any), and making the messages
+  available again to the agent.
+````
+
+- [f83f3f0](https://github.com/bosun-ai/swiftide/commit/f83f3f03bbf6a9591b54521dde91bf1a5ed19c5c) *(agents)*  Implement ToolExecutor for common dyn pointers (#549)
+
+- [7f85735](https://github.com/bosun-ai/swiftide/commit/7f857358e46e825494ba927dffb33c3afa0d762e) *(query)*  Add custom lancedb query generation for lancedb search (#518)
+
+- [ce4e34b](https://github.com/bosun-ai/swiftide/commit/ce4e34be42ce1a0ab69770d03695bd67f99a8739) *(tree-sitter)*  Add golang support (#552)
+
+````text
+Seems someone conveniently forgot to add Golang support for the
+  splitter.
+````
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.lock dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.16.4...0.17.0
+
+
+
 ## [0.16.4](https://github.com/bosun-ai/swiftide/compare/v0.16.3...v0.16.4) - 2025-01-12
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8542,7 +8542,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8566,7 +8566,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8594,7 +8594,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8615,7 +8615,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8643,7 +8643,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8723,7 +8723,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8744,7 +8744,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.16.4"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.16.4"
+version = "0.17.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.16" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.16" }
+swiftide-core = { path = "../swiftide-core", version = "0.17" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.17" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true
@@ -27,7 +27,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 [dev-dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.16", features = [
+swiftide-core = { path = "../swiftide-core", version = "0.17", features = [
   "test-utils",
 ] }
 mockall.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.16" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.16" }
+swiftide-core = { path = "../swiftide-core", version = "0.17" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.17" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.16" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.16" }
+swiftide-core = { path = "../swiftide-core", version = "0.17" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.17" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -32,8 +32,8 @@ rustversion = "1.0.18"
 trybuild = "1.0"
 prettyplease = "0.2.25"
 insta.workspace = true
-swiftide-core = { path = "../swiftide-core/", version = "0.16" }
-swiftide = { path = "../swiftide/", version = "0.16" }
+swiftide-core = { path = "../swiftide-core/", version = "0.17" }
+swiftide = { path = "../swiftide/", version = "0.17" }
 
 [lints]
 workspace = true

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.16.4" }
+swiftide-core = { path = "../swiftide-core", version = "0.17.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.16" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.16" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.16" }
-swiftide-query = { path = "../swiftide-query", version = "0.16" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.16", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.17" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.17" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.17" }
+swiftide-query = { path = "../swiftide-query", version = "0.17" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.17", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.16.4 -> 0.17.0 (✓ API compatible changes)
* `swiftide-agents`: 0.16.4 -> 0.17.0 (✓ API compatible changes)
* `swiftide-core`: 0.16.4 -> 0.17.0 (⚠️ API breaking changes)
* `swiftide-macros`: 0.16.4 -> 0.17.0
* `swiftide-indexing`: 0.16.4 -> 0.17.0
* `swiftide-integrations`: 0.16.4 -> 0.17.0 (✓ API compatible changes)
* `swiftide-query`: 0.16.4 -> 0.17.0

### ⚠️ `swiftide-core` breaking changes

```
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_method_added.ron

Failed in:
  trait method swiftide_core::agent_traits::AgentContext::redrive in file /tmp/.tmps520nh/swiftide/swiftide-core/src/agent_traits.rs:153
  trait method swiftide_core::AgentContext::redrive in file /tmp/.tmps520nh/swiftide/swiftide-core/src/agent_traits.rs:153
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.17.0](https://github.com/bosun-ai/swiftide/compare/v0.16.4...v0.17.0) - 2025-01-16

### New features

- [835c35e](https://github.com/bosun-ai/swiftide/commit/835c35e7d74811daa90f7ca747054d1919633058) *(agents)*  Redrive completions manually on failure (#551)

````text
Sometimes LLMs fail a completion without deterministic errors, or the
  user case where you just want to retry. `redrive` can now be called on a
  context, popping any new messages (if any), and making the messages
  available again to the agent.
````

- [f83f3f0](https://github.com/bosun-ai/swiftide/commit/f83f3f03bbf6a9591b54521dde91bf1a5ed19c5c) *(agents)*  Implement ToolExecutor for common dyn pointers (#549)

- [7f85735](https://github.com/bosun-ai/swiftide/commit/7f857358e46e825494ba927dffb33c3afa0d762e) *(query)*  Add custom lancedb query generation for lancedb search (#518)

- [ce4e34b](https://github.com/bosun-ai/swiftide/commit/ce4e34be42ce1a0ab69770d03695bd67f99a8739) *(tree-sitter)*  Add golang support (#552)

````text
Seems someone conveniently forgot to add Golang support for the
  splitter.
````

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.lock dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.16.4...0.17.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).