### PR TITLE
feat(agents): Redrive completions manually on failure

### DIFF
--- a/swiftide-agents/src/default_context.rs
+++ b/swiftide-agents/src/default_context.rs
@@ -132,7 +132,7 @@ impl AgentContext for DefaultContext {
 
     /// Pops the last messages up until the previous completion
     ///
-    /// LLMs failing completion for various reasons is unfortunately a common occurence
+    /// LLMs failing completion for various reasons is unfortunately a common occurrence
     /// This gives a way to redrive the last completion in a generic way
     async fn redrive(&self) {
         let mut history = self.completion_history.lock().await;

--- a/swiftide-agents/src/default_context.rs
+++ b/swiftide-agents/src/default_context.rs
@@ -80,9 +80,9 @@ impl DefaultContext {
 impl AgentContext for DefaultContext {
     /// Retrieve messages for the next completion
     async fn next_completion(&self) -> Option<Vec<ChatMessage>> {
-        let current = self.completions_ptr.load(Ordering::SeqCst);
-
         let history = self.completion_history.lock().await;
+
+        let current = self.completions_ptr.load(Ordering::SeqCst);
 
         if history[current..].is_empty()
             || (self.stop_on_assistant

--- a/swiftide-core/src/agent_traits.rs
+++ b/swiftide-core/src/agent_traits.rs
@@ -124,4 +124,10 @@ pub trait AgentContext: Send + Sync {
     async fn exec_cmd(&self, cmd: &Command) -> Result<CommandOutput, CommandError>;
 
     async fn history(&self) -> Vec<ChatMessage>;
+
+    /// Pops the last messages up until the last completion
+    ///
+    /// LLMs failing completion for various reasons is unfortunately a common occurence
+    /// This gives a way to redrive the last completion in a generic way
+    async fn redrive(&self);
 }

--- a/swiftide-core/src/agent_traits.rs
+++ b/swiftide-core/src/agent_traits.rs
@@ -127,7 +127,7 @@ pub trait AgentContext: Send + Sync {
 
     /// Pops the last messages up until the last completion
     ///
-    /// LLMs failing completion for various reasons is unfortunately a common occurence
+    /// LLMs failing completion for various reasons is unfortunately a common occurrence
     /// This gives a way to redrive the last completion in a generic way
     async fn redrive(&self);
 }


### PR DESCRIPTION
Sometimes LLMs fail a completion without deterministic errors, or the user case where you just want to retry. `redrive` can now be called on a context, popping any new messages (if any), and making the messages available again to the agent.
