### PR TITLE
feat(tree-sitter): Add golang support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8689,6 +8689,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tree-sitter",
+ "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-python",
@@ -9667,6 +9668,16 @@ dependencies = [
  "cc",
  "regex",
  "regex-syntax 0.8.5",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ tree-sitter-python = "0.23"
 tree-sitter-ruby = "0.23"
 tree-sitter-rust = "0.23"
 tree-sitter-typescript = "0.23"
+tree-sitter-go = "0.23"
 
 
 # Testing

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -53,6 +53,7 @@ tree-sitter-ruby = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-java = { workspace = true, optional = true }
+tree-sitter-go = { workspace = true, optional = true }
 fastembed = { workspace = true, optional = true }
 spider = { workspace = true, optional = true }
 htmd = { workspace = true, optional = true }
@@ -121,6 +122,7 @@ tree-sitter = [
   "dep:tree-sitter-typescript",
   "dep:tree-sitter-javascript",
   "dep:tree-sitter-java",
+  "dep:tree-sitter-go",
 ]
 # OpenAI for embedding and prompting
 openai = ["dep:async-openai"]
@@ -145,6 +147,7 @@ fluvio = ["dep:fluvio"]
 parquet = ["dep:arrow-array", "dep:parquet", "dep:arrow"]
 # Redb as an embeddable node cache
 redb = ["dep:redb"]
+
 
 [lints]
 workspace = true

--- a/swiftide-integrations/src/treesitter/code_tree.rs
+++ b/swiftide-integrations/src/treesitter/code_tree.rs
@@ -8,7 +8,7 @@ use tree_sitter::{Parser, Query, QueryCursor, Tree};
 use anyhow::{Context as _, Result};
 use std::collections::HashSet;
 
-use crate::treesitter::queries::{java, javascript, python, ruby, rust, typescript};
+use crate::treesitter::queries::{go, java, javascript, python, ruby, rust, typescript};
 
 use super::SupportedLanguages;
 
@@ -107,7 +107,7 @@ impl CodeTree<'_> {
 }
 
 fn ts_queries_for_language(language: SupportedLanguages) -> (&'static str, &'static str) {
-    use SupportedLanguages::{Java, Javascript, Python, Ruby, Rust, Typescript};
+    use SupportedLanguages::{Go, Java, Javascript, Python, Ruby, Rust, Typescript};
 
     match language {
         Rust => (rust::DEFS, rust::REFS),
@@ -117,6 +117,7 @@ fn ts_queries_for_language(language: SupportedLanguages) -> (&'static str, &'sta
         Javascript => (javascript::DEFS, javascript::REFS),
         Ruby => (ruby::DEFS, ruby::REFS),
         Java => (java::DEFS, java::REFS),
+        Go => (go::DEFS, go::REFS),
     }
 }
 
@@ -279,5 +280,29 @@ mod tests {
         let result = tree.references_and_definitions().unwrap();
         assert_eq!(result.definitions, vec!["Material", "Person", "getName"]);
         assert!(result.references.is_empty());
+    }
+
+    #[test]
+    fn test_parsing_go() {
+        let parser = CodeParser::from_language(SupportedLanguages::Go);
+        // hello world go with struct
+        let code = r"
+        package main
+
+        type Person struct {
+            name string
+            age int
+        }
+
+        func main() {
+            p := Person{name: 'John', age: 30}
+            fmt.Println(p)
+        }
+        ";
+
+        let tree = parser.parse(code).unwrap();
+        let result = tree.references_and_definitions().unwrap();
+        assert_eq!(result.references, vec!["Println", "int", "string"]);
+        assert_eq!(result.definitions, vec!["Person", "main"]);
     }
 }

--- a/swiftide-integrations/src/treesitter/outliner.rs
+++ b/swiftide-integrations/src/treesitter/outliner.rs
@@ -118,6 +118,7 @@ impl CodeOutliner {
                 }
                 _ => false,
             },
+            SupportedLanguages::Go => unimplemented!(),
         }
     }
 

--- a/swiftide-integrations/src/treesitter/queries.rs
+++ b/swiftide-integrations/src/treesitter/queries.rs
@@ -322,3 +322,40 @@ pub mod java {
             (object_creation_expression
                 type: (type_identifier) @name)";
 }
+
+pub mod go {
+    pub const DEFS: &str = r"
+    (function_declaration
+    name: (identifier) @name)
+
+    (method_declaration
+    name: (field_identifier) @name)
+
+    (type_declaration (type_spec name: (type_identifier) @name type: (interface_type)))
+
+    (type_declaration (type_spec name: (type_identifier) @name type: (struct_type)))
+
+    (import_declaration (import_spec) @name)
+
+    (var_declaration (var_spec name: (identifier) @name))
+
+    (const_declaration (const_spec name: (identifier) @name))
+
+            ";
+
+    pub const REFS: &str = r#"
+    (call_expression
+    function: [
+        (identifier) @name
+        (parenthesized_expression (identifier) @name)
+        (selector_expression field: (field_identifier) @name)
+        (parenthesized_expression (selector_expression field: (field_identifier) @name))
+    ])
+
+    (type_spec
+    name: (type_identifier) @name) 
+
+    (package_clause "package" (package_identifier) @name)
+    (type_identifier) @name 
+            "#;
+}

--- a/swiftide-integrations/src/treesitter/supported_languages.rs
+++ b/swiftide-integrations/src/treesitter/supported_languages.rs
@@ -47,6 +47,8 @@ pub enum SupportedLanguages {
     Javascript,
     #[serde(alias = "java")]
     Java,
+    #[serde(alias = "go")]
+    Go,
 }
 
 /// Static array of file extensions for Rust files.
@@ -67,6 +69,9 @@ static JAVASCRIPT_EXTENSIONS: &[&str] = &["js", "jsx"];
 /// Static array of file extensions for Java files.
 static JAVA_EXTENSIONS: &[&str] = &["java"];
 
+/// Static array of file extensions for Go files.
+static GO_EXTENSIONS: &[&str] = &["go"];
+
 impl SupportedLanguages {
     /// Returns the file extensions associated with the supported language.
     ///
@@ -80,6 +85,7 @@ impl SupportedLanguages {
             SupportedLanguages::Ruby => RUBY_EXTENSIONS,
             SupportedLanguages::Javascript => JAVASCRIPT_EXTENSIONS,
             SupportedLanguages::Java => JAVA_EXTENSIONS,
+            SupportedLanguages::Go => GO_EXTENSIONS,
         }
     }
 }
@@ -103,6 +109,7 @@ impl From<SupportedLanguages> for tree_sitter::Language {
             SupportedLanguages::Javascript => tree_sitter_javascript::LANGUAGE,
             SupportedLanguages::Ruby => tree_sitter_ruby::LANGUAGE,
             SupportedLanguages::Java => tree_sitter_java::LANGUAGE,
+            SupportedLanguages::Go => tree_sitter_go::LANGUAGE,
         }
         .into()
     }


### PR DESCRIPTION
Seems someone conveniently forgot to add Golang support for the splitter (me). Implemented for splitter and refs/defs tools, not for outline yet.