### PR TITLE
feat(agents): Preprocess tool calls to fix common, fixable errors

### DIFF
--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     state,
     system_prompt::SystemPrompt,
-    tools::control::Stop,
+    tools::{arg_preprocessor::ArgPreprocessor, control::Stop},
 };
 use std::{collections::HashSet, sync::Arc};
 
@@ -397,6 +397,7 @@ impl Agent {
                 tracing::info_span!("tool", "otel.name" = format!("tool.{}", tool.name()));
 
             let handle = tokio::spawn(async move {
+                    let tool_args = ArgPreprocessor::preprocess(tool_args.as_deref());
                     let output = tool.invoke(&*context, tool_args.as_deref()).await.map_err(|e| { tracing::error!(error = %e, "Failed tool call"); e })?;
 
                     tracing::debug!(output = output.to_string(), args = ?tool_args, tool_name = tool.name(), "Completed tool call");

--- a/swiftide-agents/src/tools/arg_preprocessor.rs
+++ b/swiftide-agents/src/tools/arg_preprocessor.rs
@@ -1,0 +1,80 @@
+use std::borrow::Cow;
+
+use serde_json::{Map, Value};
+
+/// Preprocesses arguments for tool calls and tries to fix common errors
+/// This must be infallible and the result is always forwarded to the tool
+pub struct ArgPreprocessor;
+
+impl ArgPreprocessor {
+    pub fn preprocess(value: Option<&str>) -> Option<Cow<'_, str>> {
+        Some(take_first_occurence_in_object(value?))
+    }
+}
+
+/// Strips duplicate keys from JSON objects
+fn take_first_occurence_in_object(value: &str) -> Cow<'_, str> {
+    let Ok(parsed) = &serde_json::from_str(value) else {
+        return Cow::Borrowed(value);
+    };
+    if let Value::Object(obj) = parsed {
+        let mut new_map = Map::with_capacity(obj.len());
+        for (k, v) in obj {
+            // Only insert if we haven't seen this key yet.
+            new_map.entry(k).or_insert(v.clone());
+        }
+        Cow::Owned(Value::Object(new_map).to_string())
+    } else {
+        // If the top-level isn't even an object, just pass it as is,
+        // or decide how you want to handle that situation.
+        Cow::Borrowed(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_preprocess_regular_json() {
+        let input = json!({
+            "key1": "value1",
+            "key2": "value2"
+        })
+        .to_string();
+        let expected = json!({
+            "key1": "value1",
+            "key2": "value2"
+        });
+        let result = ArgPreprocessor::preprocess(Some(&input));
+        assert_eq!(result.as_deref(), Some(expected.to_string().as_str()));
+    }
+
+    #[test]
+    fn test_preprocess_json_with_duplicate_keys() {
+        let input = json!({
+            "key1": "value1",
+            "key1": "value2"
+        })
+        .to_string();
+        let expected = json!({
+            "key1": "value2"
+        });
+        let result = ArgPreprocessor::preprocess(Some(&input));
+        assert_eq!(result.as_deref(), Some(expected.to_string().as_str()));
+    }
+
+    #[test]
+    fn test_no_preprocess_invalid_json() {
+        let input = "invalid json";
+        let result = ArgPreprocessor::preprocess(Some(input));
+        assert_eq!(result.as_deref(), Some(input));
+    }
+
+    #[test]
+    fn test_no_input() {
+        let result = ArgPreprocessor::preprocess(None);
+        assert_eq!(result, None);
+    }
+}

--- a/swiftide-agents/src/tools/arg_preprocessor.rs
+++ b/swiftide-agents/src/tools/arg_preprocessor.rs
@@ -8,12 +8,12 @@ pub struct ArgPreprocessor;
 
 impl ArgPreprocessor {
     pub fn preprocess(value: Option<&str>) -> Option<Cow<'_, str>> {
-        Some(take_first_occurence_in_object(value?))
+        Some(take_first_occurrence_in_object(value?))
     }
 }
 
 /// Strips duplicate keys from JSON objects
-fn take_first_occurence_in_object(value: &str) -> Cow<'_, str> {
+fn take_first_occurrence_in_object(value: &str) -> Cow<'_, str> {
     let Ok(parsed) = &serde_json::from_str(value) else {
         return Cow::Borrowed(value);
     };

--- a/swiftide-agents/src/tools/mod.rs
+++ b/swiftide-agents/src/tools/mod.rs
@@ -1,3 +1,4 @@
 //! Default tools and executor for agents
+pub mod arg_preprocessor;
 pub mod control;
 pub mod local_executor;


### PR DESCRIPTION
OpenAI has a tendency to sometimes send double keys. With this, Swiftide will now take the first key and ignore any after that.