### PR TITLE
fix(openai): Enable strict mode for tool calls

### DIFF
--- a/swiftide-integrations/src/openai/chat_completion.rs
+++ b/swiftide-integrations/src/openai/chat_completion.rs
@@ -126,6 +126,7 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
         .function(FunctionObjectArgs::default()
             .name(spec.name)
             .description(spec.description)
+            .strict(true)
             .parameters(json!({
                 "type": "object",
                 "properties": properties,


### PR DESCRIPTION
Ensures openai sticks much better to the schema and avoids accidental
mistakes.
