### PR TITLE
feat(agents): Add support for numbers, arrays and booleans in tool args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
-default-members = ["swiftide", "swiftide-*"]
+# default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]

--- a/examples/hello_agents.rs
+++ b/examples/hello_agents.rs
@@ -53,6 +53,31 @@ async fn read_file(context: &dyn AgentContext, path: &str) -> Result<ToolOutput,
     Ok(command_output.into())
 }
 
+// The macro supports strings/strs, vectors/slices, booleans and numbers.
+//
+// This is currently only supported for the attribute macro, not the derive macro.
+//
+// If you need more control or need to use full objects, we recommend to implement the `Tool` trait
+// and prove the Json spec yourself. Builders are available.
+//
+// For non-string types, the `json_type` is required to be specified.
+#[swiftide_macros::tool(
+    description = "Guess a number",
+    param(name = "number", description = "Number to guess", json_type = "number")
+)]
+async fn guess_a_number(
+    _context: &dyn AgentContext,
+    number: usize,
+) -> Result<ToolOutput, ToolError> {
+    let actual_number = 42;
+
+    if number == actual_number {
+        Ok("You guessed it!".into())
+    } else {
+        Ok("Try again!".into())
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     println!("Hello, agents!");
@@ -72,7 +97,7 @@ async fn main() -> Result<()> {
 
     agents::Agent::builder()
         .llm(&openai)
-        .tools(vec![search_code()])
+        .tools(vec![search_code(), read_file(), guess_a_number()])
         .before_all(move |_context| {
             // This is a hook that runs before any command is executed
             // No native async closures in Rust yet, so we have to use Box::pin

--- a/examples/hello_agents.rs
+++ b/examples/hello_agents.rs
@@ -115,8 +115,9 @@ async fn main() -> Result<()> {
                 Ok(())
             })
         })
+        .limit(5)
         .build()?
-        .query("In what file can I find an example of a swiftide agent?")
+        .query("In what file can I find an example of a swiftide agent? When you are done guess a number and stop")
         .await?;
 
     Ok(())

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -91,10 +91,13 @@ impl ToolCall {
 /// i.e. the json spec `OpenAI` uses to define their tools
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Default, Builder)]
 pub struct ToolSpec {
+    /// Name of the tool
     pub name: &'static str,
+    /// Description passed to the LLM for the tool
     pub description: &'static str,
 
     #[builder(default)]
+    /// Optional parameters for the tool
     pub parameters: Vec<ParamSpec>,
 }
 
@@ -104,11 +107,31 @@ impl ToolSpec {
     }
 }
 
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Default, strum_macros::IntoStaticStr)]
+#[strum(serialize_all = "camelCase")]
+pub enum ParamType {
+    #[default]
+    String,
+    Number,
+    Boolean,
+    Array,
+    // Enum
+    // Object
+    // anyOf
+}
+
+/// Parameters for tools
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Builder)]
 pub struct ParamSpec {
+    /// Name of the parameter
     pub name: &'static str,
+    /// Description of the parameter
     pub description: &'static str,
-    pub ty: &'static str,
+    /// Json spec type of the parameter
+    pub ty: ParamType,
+    /// Whether the parameter is required
+    ///
+    /// Note that macros will always generate required parameters
     #[builder(default = true)]
     pub required: bool,
 }

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -107,7 +107,7 @@ impl ToolSpec {
     }
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Default, strum_macros::IntoStaticStr)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Default, strum_macros::AsRefStr)]
 #[strum(serialize_all = "camelCase")]
 pub enum ParamType {
     #[default]
@@ -128,6 +128,7 @@ pub struct ParamSpec {
     /// Description of the parameter
     pub description: &'static str,
     /// Json spec type of the parameter
+    #[builder(default)]
     pub ty: ParamType,
     /// Whether the parameter is required
     ///

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -108,6 +108,7 @@ impl ToolSpec {
 pub struct ParamSpec {
     pub name: &'static str,
     pub description: &'static str,
+    pub ty: &'static str,
     #[builder(default = true)]
     pub required: bool,
 }

--- a/swiftide-integrations/src/anthropic/chat_completion.rs
+++ b/swiftide-integrations/src/anthropic/chat_completion.rs
@@ -405,4 +405,38 @@ mod tests {
         // Assert the result
         assert_eq!(result.message, Some("Response with system prompt".into()));
     }
+
+    #[test]
+    fn test_tools_to_anthropic() {
+        let tool_spec = ToolSpec::builder()
+            .description("Gets the weather")
+            .name("get_weather")
+            .parameters(vec![ParamSpec::builder()
+                .description("Location")
+                .name("location")
+                .required(true)
+                .build()
+                .unwrap()])
+            .build()
+            .unwrap();
+
+        let result = tools_to_anthropic(&tool_spec).unwrap();
+
+        let expected = json!({
+            "name": "get_weather",
+            "description": "Gets the weather",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "Location"
+                    }
+                },
+                "required": ["location"]
+            }
+        });
+
+        assert_eq!(result, expected.as_object().unwrap().to_owned());
+    }
 }

--- a/swiftide-integrations/src/anthropic/chat_completion.rs
+++ b/swiftide-integrations/src/anthropic/chat_completion.rs
@@ -158,7 +158,7 @@ fn tools_to_anthropic(
             param.name.to_string(),
             json!({
 
-                        "type": "string",
+                        "type": param.ty.as_ref(),
                         "description": param.description,
             }),
         );

--- a/swiftide-integrations/src/ollama/chat_completion.rs
+++ b/swiftide-integrations/src/ollama/chat_completion.rs
@@ -115,7 +115,7 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
         properties.insert(
             param.name.to_string(),
             json!({
-                "type": "string",
+                "type": param.ty.as_ref(),
                 "description": param.description,
             }),
         );

--- a/swiftide-integrations/src/open_router/chat_completion.rs
+++ b/swiftide-integrations/src/open_router/chat_completion.rs
@@ -115,7 +115,7 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
         properties.insert(
             param.name.to_string(),
             json!({
-                "type": "string",
+                "type": param.ty.as_ref(),
                 "description": param.description,
             }),
         );

--- a/swiftide-integrations/src/openai/chat_completion.rs
+++ b/swiftide-integrations/src/openai/chat_completion.rs
@@ -117,7 +117,7 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
         properties.insert(
             param.name.to_string(),
             json!({
-                "type": "string",
+                "type": param.ty.as_ref(),
                 "description": param.description,
             }),
         );

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,6 +14,8 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
+swiftide-core = { path = "../swiftide-core/" }
+
 quote = { workspace = true }
 syn = { workspace = true }
 darling = { workspace = true }
@@ -32,7 +34,6 @@ rustversion = "1.0.18"
 trybuild = "1.0"
 prettyplease = "0.2.25"
 insta.workspace = true
-swiftide-core = { path = "../swiftide-core/" }
 swiftide = { path = "../swiftide/" }
 
 [lints]

--- a/swiftide-macros/src/tool/args.rs
+++ b/swiftide-macros/src/tool/args.rs
@@ -29,7 +29,7 @@ fn as_owned_ty(ty: &syn::Type) -> TokenStream {
                 return quote!(String);
             }
 
-            // if slice return vec with recurse on sub type
+            // Does this happen?
             if p.path.is_ident("Vec") {
                 if let syn::PathArguments::AngleBracketed(args) = &p.path.segments[0].arguments {
                     if let syn::GenericArgument::Type(ty) = args.args.first().unwrap() {
@@ -191,7 +191,7 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean_args() {
+    fn test_multiple_ty_args() {
         let input: ItemFn = parse_quote! {
             pub async fn search_code(context: &dyn AgentContext, code_query: &str, include_private: bool, a_number: usize, a_slice: &[String], a_vec: Vec<String>) -> Result<ToolOutput> {
                 return Ok("hello".into())

--- a/swiftide-macros/src/tool/args.rs
+++ b/swiftide-macros/src/tool/args.rs
@@ -2,8 +2,6 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens as _};
 use syn::{parse::Result, Error, FnArg, Ident, ItemFn, PatType};
 
-use super::{ParamType, ToolArgs};
-
 pub(crate) fn args_struct_name(input: &ItemFn) -> Ident {
     let struct_name_str = input
         .sig

--- a/swiftide-macros/src/tool/args.rs
+++ b/swiftide-macros/src/tool/args.rs
@@ -2,6 +2,8 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens as _};
 use syn::{parse::Result, Error, FnArg, Ident, ItemFn, PatType};
 
+use super::{ParamType, ToolArgs};
+
 pub(crate) fn args_struct_name(input: &ItemFn) -> Ident {
     let struct_name_str = input
         .sig
@@ -49,6 +51,7 @@ fn as_owned_ty(ty: &syn::Type) -> TokenStream {
     }
 }
 
+/// Builds the parse-able arg struct
 pub(crate) fn build_tool_args(input: &ItemFn) -> Result<TokenStream> {
     validate_first_argument_is_agent_context(input)?;
 

--- a/swiftide-macros/src/tool/mod.rs
+++ b/swiftide-macros/src/tool/mod.rs
@@ -3,10 +3,8 @@
 use convert_case::{Case, Casing as _};
 use darling::{ast::NestedMeta, Error, FromDeriveInput, FromMeta};
 use proc_macro2::TokenStream;
-use quote::{quote, ToTokens, TokenStreamExt as _};
-use serde::ser::SerializeMap as _;
-use swiftide_core::chat_completion;
-use syn::{parse_quote, spanned::Spanned, DeriveInput, FnArg, ItemFn, Lifetime, Pat, PatType};
+use quote::quote;
+use syn::{DeriveInput, FnArg, ItemFn, Lifetime, Pat, PatType};
 
 mod args;
 mod tool_spec;

--- a/swiftide-macros/src/tool/mod.rs
+++ b/swiftide-macros/src/tool/mod.rs
@@ -1,9 +1,12 @@
+#![allow(clippy::used_underscore_binding)]
+
 use convert_case::{Case, Casing as _};
 use darling::{ast::NestedMeta, Error, FromDeriveInput, FromMeta};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens, TokenStreamExt as _};
 use serde::ser::SerializeMap as _;
-use syn::{spanned::Spanned, DeriveInput, FnArg, ItemFn, Lifetime, Pat, PatType};
+use swiftide_core::chat_completion;
+use syn::{parse_quote, spanned::Spanned, DeriveInput, FnArg, ItemFn, Lifetime, Pat, PatType};
 
 mod args;
 mod tool_spec;
@@ -22,7 +25,18 @@ struct ToolArgs {
 struct ParamOptions {
     name: String,
     description: String,
-    // TODO: I.e. openai also supports enums instead of strings as arg type
+
+    json_type: ParamType,
+}
+
+#[derive(Debug, FromMeta, PartialEq, Eq, Default, Clone, Copy)]
+#[darling(rename_all = "camelCase")]
+enum ParamType {
+    #[default]
+    String,
+    Number,
+    Boolean,
+    Array,
 }
 
 #[derive(Debug)]
@@ -57,29 +71,31 @@ impl FromMeta for Description {
     }
 }
 
-impl serde::Serialize for ParamOptions {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let mut map = serializer.serialize_map(Some(1))?;
-        map.serialize_entry(
-            &self.name,
-            &serde_json::json!({
-                "type": "string",
-                "description": self.description
-            }),
-        )?;
-        map.end()
-    }
-}
+// TODO: This should not be used?
+// impl serde::Serialize for ParamOptions {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: serde::Serializer,
+//     {
+//         let mut map = serializer.serialize_map(Some(1))?;
+//         map.serialize_entry(
+//             &self.name,
+//             &serde_json::json!({
+//                 "type": "string",
+//                 "description": self.description
+//             }),
+//         )?;
+//         map.end()
+//     }
+// }
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream {
-    let args = match parse_args(input_args.clone()) {
+    let input_tool_args = match parse_args(input_args.clone()) {
         Ok(args) => args,
         Err(e) => return e.write_errors(),
     };
+
     let fn_name = &input.sig.ident;
     let fn_args = &input.sig.inputs;
     let tool_name = fn_name.to_string();
@@ -90,9 +106,9 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
 
     let wrapped_fn = wrapped::wrap_tool_fn(input);
 
-    let tool_spec = tool_spec::tool_spec(&tool_name, &args);
+    let tool_spec = tool_spec::tool_spec(&tool_name, &input_tool_args);
 
-    let mut found_spec_arg_names = args
+    let mut found_spec_arg_names = input_tool_args
         .param
         .iter()
         .map(|param| param.name.clone())
@@ -101,6 +117,7 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
 
     let mut seen_arg_names = vec![];
 
+    let mut only_strings = true;
     let arg_names = fn_args
         .iter()
         .skip(1)
@@ -108,6 +125,11 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
             if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
                 if let Pat::Ident(ident) = &**pat {
                     seen_arg_names.push(ident.ident.to_string());
+                    if let syn::Type::Path(p) = &**ty {
+                        if !p.path.is_ident("str") || !p.path.is_ident("String") {
+                            only_strings = false;
+                        }
+                    }
 
                     // If the argument is a reference, we need to reference the quote as well
                     if let syn::Type::Reference(_) = &**ty {
@@ -150,11 +172,25 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
         }
 
         return syn::Error::new(
-            input_args.span(),
+            proc_macro2::Span::call_site(),
             format!(
                 "Arguments in spec and in function do not match:\n {}",
                 messages.join(", ")
             ),
+        )
+        .into_compile_error();
+    }
+
+    // Crude validation that types need to be set if non-string parameters are present
+    if !only_strings
+        && input_tool_args
+            .param
+            .iter()
+            .all(|p| matches!(p.json_type, ParamType::String))
+    {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "Params that are not strings need to have their `type` as json spec specified",
         )
         .into_compile_error();
     }

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
@@ -40,7 +40,9 @@ impl swiftide::chat_completion::Tool for HelloDerive {
             .parameters(
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("test")
-                    .description("test param").build().expect("infallible")
+                    .description("test param")
+                    .ty(::swiftide::chat_completion::ParamType::String).build()
+                    .expect("infallible")
                 ],
             )
             .build()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
@@ -40,7 +40,9 @@ impl<'a> swiftide::chat_completion::Tool for HelloDerive<'a> {
             .parameters(
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("test")
-                    .description("test param").build().expect("infallible")
+                    .description("test param")
+                    .ty(::swiftide::chat_completion::ParamType::String).build()
+                    .expect("infallible")
                 ],
             )
             .build()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
@@ -55,9 +55,13 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
             .parameters(
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("code_query")
-                    .description("my param description").build().expect("infallible"),
+                    .description("my param description")
+                    .ty(::swiftide::chat_completion::ParamType::String).build()
+                    .expect("infallible"),
                     swiftide::chat_completion::ParamSpec::builder().name("other")
-                    .description("my param description").build().expect("infallible")
+                    .description("my param description")
+                    .ty(::swiftide::chat_completion::ParamType::String).build()
+                    .expect("infallible")
                 ],
             )
             .build()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
@@ -53,7 +53,9 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
             .parameters(
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("code_query")
-                    .description("my param description").build().expect("infallible")
+                    .description("my param description")
+                    .ty(::swiftide::chat_completion::ParamType::String).build()
+                    .expect("infallible")
                 ],
             )
             .build()

--- a/swiftide-macros/src/tool/tool_spec.rs
+++ b/swiftide-macros/src/tool/tool_spec.rs
@@ -39,3 +39,34 @@ pub fn tool_spec(tool_name: &str, args: &ToolArgs) -> TokenStream {
         }
     }
 }
+
+fn classify_type_path(type_path: &syn::TypePath) -> &'static str {
+    // The last segment should hold the actual type name, e.g. "String" or "Vec".
+    // (Ignore multi-segment paths like `std::collections::HashMap` by just checking
+    // the final segment.)
+    let segment = if let Some(seg) = type_path.path.segments.last() {
+        seg
+    } else {
+        return "String";
+    };
+
+    let ident_str = segment.ident.to_string();
+
+    // If it’s an actual generic like Vec<T>, parse out the identifier and check it.
+    match ident_str.as_str() {
+        // Known string type:
+        "String" => "String",
+
+        // Common numeric primitives:
+        "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize" | "f32"
+        | "f64" => "Number",
+
+        // A generic known container: check if it’s `Vec<...>`
+        "Vec" => "Array",
+
+        // Could handle more explicitly, e.g. "HashMap" → "Object" or something else
+
+        // Fallback for any other type:
+        _ => "String",
+    }
+}

--- a/swiftide-macros/src/tool/tool_spec.rs
+++ b/swiftide-macros/src/tool/tool_spec.rs
@@ -1,5 +1,7 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, TokenStreamExt as _};
+
+use crate::tool::ParamType;
 
 use super::{Description, ToolArgs};
 
@@ -18,11 +20,13 @@ pub fn tool_spec(tool_name: &str, args: &ToolArgs) -> TokenStream {
             .map(|param| {
                 let name = &param.name;
                 let description = &param.description;
+                let ty = param_type_to_token_stream(param.json_type);
 
                 quote! {
                     swiftide::chat_completion::ParamSpec::builder()
                         .name(#name)
                         .description(#description)
+                        .ty(#ty)
                         .build().expect("infallible")
 
                 }
@@ -40,33 +44,46 @@ pub fn tool_spec(tool_name: &str, args: &ToolArgs) -> TokenStream {
     }
 }
 
-fn classify_type_path(type_path: &syn::TypePath) -> &'static str {
-    // The last segment should hold the actual type name, e.g. "String" or "Vec".
-    // (Ignore multi-segment paths like `std::collections::HashMap` by just checking
-    // the final segment.)
-    let segment = if let Some(seg) = type_path.path.segments.last() {
-        seg
-    } else {
-        return "String";
+fn param_type_to_token_stream(ty: ParamType) -> TokenStream {
+    let ty = match ty {
+        ParamType::String => "String",
+        ParamType::Number => "Number",
+        ParamType::Boolean => "Boolean",
+        ParamType::Array => "Array",
     };
 
-    let ident_str = segment.ident.to_string();
+    let ident = proc_macro2::Ident::new(&format!("{ty}"), proc_macro2::Span::call_site());
 
-    // If it’s an actual generic like Vec<T>, parse out the identifier and check it.
-    match ident_str.as_str() {
-        // Known string type:
-        "String" => "String",
-
-        // Common numeric primitives:
-        "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize" | "f32"
-        | "f64" => "Number",
-
-        // A generic known container: check if it’s `Vec<...>`
-        "Vec" => "Array",
-
-        // Could handle more explicitly, e.g. "HashMap" → "Object" or something else
-
-        // Fallback for any other type:
-        _ => "String",
-    }
+    quote! { ::swiftide::chat_completion::ParamType::#ident }
 }
+
+// fn classify_type_path(type_path: &syn::TypePath) -> &'static str {
+//     // The last segment should hold the actual type name, e.g. "String" or "Vec".
+//     // (Ignore multi-segment paths like `std::collections::HashMap` by just checking
+//     // the final segment.)
+//     let segment = if let Some(seg) = type_path.path.segments.last() {
+//         seg
+//     } else {
+//         return "String";
+//     };
+//
+//     let ident_str = segment.ident.to_string();
+//
+//     // If it’s an actual generic like Vec<T>, parse out the identifier and check it.
+//     match ident_str.as_str() {
+//         // Known string type:
+//         "String" => "String",
+//
+//         // Common numeric primitives:
+//         "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize" | "f32"
+//         | "f64" => "Number",
+//
+//         // A generic known container: check if it’s `Vec<...>`
+//         "Vec" => "Array",
+//
+//         // Could handle more explicitly, e.g. "HashMap" → "Object" or something else
+//
+//         // Fallback for any other type:
+//         _ => "String",
+//     }
+// }

--- a/swiftide-macros/src/tool/tool_spec.rs
+++ b/swiftide-macros/src/tool/tool_spec.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{quote, TokenStreamExt as _};
+use quote::quote;
 
 use crate::tool::ParamType;
 
@@ -52,38 +52,7 @@ fn param_type_to_token_stream(ty: ParamType) -> TokenStream {
         ParamType::Array => "Array",
     };
 
-    let ident = proc_macro2::Ident::new(&format!("{ty}"), proc_macro2::Span::call_site());
+    let ident = proc_macro2::Ident::new(ty, proc_macro2::Span::call_site());
 
     quote! { ::swiftide::chat_completion::ParamType::#ident }
 }
-
-// fn classify_type_path(type_path: &syn::TypePath) -> &'static str {
-//     // The last segment should hold the actual type name, e.g. "String" or "Vec".
-//     // (Ignore multi-segment paths like `std::collections::HashMap` by just checking
-//     // the final segment.)
-//     let segment = if let Some(seg) = type_path.path.segments.last() {
-//         seg
-//     } else {
-//         return "String";
-//     };
-//
-//     let ident_str = segment.ident.to_string();
-//
-//     // If it’s an actual generic like Vec<T>, parse out the identifier and check it.
-//     match ident_str.as_str() {
-//         // Known string type:
-//         "String" => "String",
-//
-//         // Common numeric primitives:
-//         "u8" | "u16" | "u32" | "u64" | "usize" | "i8" | "i16" | "i32" | "i64" | "isize" | "f32"
-//         | "f64" => "Number",
-//
-//         // A generic known container: check if it’s `Vec<...>`
-//         "Vec" => "Array",
-//
-//         // Could handle more explicitly, e.g. "HashMap" → "Object" or something else
-//
-//         // Fallback for any other type:
-//         _ => "String",
-//     }
-// }

--- a/swiftide-macros/tests/tool/tool_missing_arg_fail.rs
+++ b/swiftide-macros/tests/tool/tool_missing_arg_fail.rs
@@ -10,4 +10,20 @@ async fn basic_tool(
     Ok(format!("Hello {msg}").into())
 }
 
+#[swiftide_macros::tool(
+    description = READ_FILE,
+    param(name = "number", description = "Number to guess")
+)]
+async fn guess_a_number(
+    _context: &dyn AgentContext,
+    number: usize,
+) -> Result<ToolOutput, ToolError> {
+    let actual_number = 42;
+
+    if number == actual_number {
+        Ok("You guessed it!".into())
+    } else {
+        Ok("Try again!".into())
+    }
+}
 fn main() {}

--- a/swiftide-macros/tests/tool/tool_missing_arg_fail.stderr
+++ b/swiftide-macros/tests/tool/tool_missing_arg_fail.stderr
@@ -1,6 +1,22 @@
 error: Arguments in spec and in function do not match:
         The following parameters are missing from the spec: ["other"]
- --> tests/tool/tool_missing_arg_fail.rs:2:5
+ --> tests/tool/tool_missing_arg_fail.rs:1:1
   |
-2 |     description = "My first tool",
-  |     ^^^^^^^^^^^
+1 | / #[swiftide_macros::tool(
+2 | |     description = "My first tool",
+3 | |     param(name = "msg", description = "A message for testing")
+4 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `swiftide_macros::tool` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Params that are not strings need to have their `type` as json spec specified
+  --> tests/tool/tool_missing_arg_fail.rs:13:1
+   |
+13 | / #[swiftide_macros::tool(
+14 | |     description = READ_FILE,
+15 | |     param(name = "number", description = "Number to guess")
+16 | | )]
+   | |__^
+   |
+   = note: this error originates in the attribute macro `swiftide_macros::tool` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/swiftide-macros/tests/tool/tool_missing_parameter_fail.stderr
+++ b/swiftide-macros/tests/tool/tool_missing_parameter_fail.stderr
@@ -1,6 +1,11 @@
 error: Arguments in spec and in function do not match:
         The following parameters are missing from the function signature: ["Message"], The following parameters are missing from the spec: ["msg"]
- --> tests/tool/tool_missing_parameter_fail.rs:2:5
+ --> tests/tool/tool_missing_parameter_fail.rs:1:1
   |
-2 |     description = "My first tool",
-  |     ^^^^^^^^^^^
+1 | / #[swiftide_macros::tool(
+2 | |     description = "My first tool",
+3 | |     param(name = "Message", description = "A message for testing")
+4 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `swiftide_macros::tool` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/swiftide-macros/tests/tool/tool_single_argument_pass.rs
+++ b/swiftide-macros/tests/tool/tool_single_argument_pass.rs
@@ -9,4 +9,49 @@ async fn basic_tool(_agent_context: &dyn AgentContext, msg: &str) -> Result<Tool
     Ok(format!("Hello {msg}").into())
 }
 
+#[swiftide_macros::tool(
+    description = "My first num tool",
+    param(name = "msg", description = "A message for testing")
+)]
+async fn basic_tool_num(
+    _agent_context: &dyn AgentContext,
+    msg: i32,
+) -> Result<ToolOutput, ToolError> {
+    Ok(format!("Hello {msg}").into())
+}
+
+#[swiftide_macros::tool(
+    description = "My first array tool",
+    param(name = "msg", description = "A message for testing")
+)]
+async fn basic_tool_vec(
+    _agent_context: &dyn AgentContext,
+    msg: Vec<String>,
+) -> Result<ToolOutput, ToolError> {
+    let msg = msg.join(", ");
+    Ok(format!("Hello {msg}").into())
+}
+
+#[swiftide_macros::tool(
+    description = "My first bool tool",
+    param(name = "msg", description = "A message for testing")
+)]
+async fn basic_tool_bool(
+    _agent_context: &dyn AgentContext,
+    msg: bool,
+) -> Result<ToolOutput, ToolError> {
+    Ok(format!("Hello {msg}").into())
+}
+
+#[swiftide_macros::tool(
+    description = "My first num slice tool",
+    param(name = "msg", description = "A message for testing")
+)]
+async fn basic_tool_num_slice(
+    _agent_context: &dyn AgentContext,
+    msg: &[i32],
+) -> Result<ToolOutput, ToolError> {
+    Ok(format!("Hello {msg:?}").into())
+}
+
 fn main() {}

--- a/swiftide-macros/tests/tool/tool_single_argument_pass.rs
+++ b/swiftide-macros/tests/tool/tool_single_argument_pass.rs
@@ -11,7 +11,11 @@ async fn basic_tool(_agent_context: &dyn AgentContext, msg: &str) -> Result<Tool
 
 #[swiftide_macros::tool(
     description = "My first num tool",
-    param(name = "msg", description = "A message for testing")
+    param(
+        name = "msg",
+        description = "A message for testing",
+        json_type = "number"
+    )
 )]
 async fn basic_tool_num(
     _agent_context: &dyn AgentContext,
@@ -22,7 +26,11 @@ async fn basic_tool_num(
 
 #[swiftide_macros::tool(
     description = "My first array tool",
-    param(name = "msg", description = "A message for testing")
+    param(
+        name = "msg",
+        description = "A message for testing",
+        json_type = "array"
+    )
 )]
 async fn basic_tool_vec(
     _agent_context: &dyn AgentContext,
@@ -34,7 +42,11 @@ async fn basic_tool_vec(
 
 #[swiftide_macros::tool(
     description = "My first bool tool",
-    param(name = "msg", description = "A message for testing")
+    param(
+        name = "msg",
+        description = "A message for testing",
+        json_type = "boolean"
+    )
 )]
 async fn basic_tool_bool(
     _agent_context: &dyn AgentContext,
@@ -45,7 +57,11 @@ async fn basic_tool_bool(
 
 #[swiftide_macros::tool(
     description = "My first num slice tool",
-    param(name = "msg", description = "A message for testing")
+    param(
+        name = "msg",
+        description = "A message for testing",
+        json_type = "array"
+    )
 )]
 async fn basic_tool_num_slice(
     _agent_context: &dyn AgentContext,


### PR DESCRIPTION
Add support for numbers, arrays and boolean types in the `#[swiftide_macros::tool]` attribute macro. For enum and object a custom implementation is now properly supported as well, but not via the macro. For now, tools using Derive also still need a custom implementation.
