### PR TITLE
chore: release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.2](https://github.com/bosun-ai/swiftide/compare/v0.17.1...v0.17.2) - 2025-01-21
+
+### Bug fixes
+
+- [47db5ab](https://github.com/bosun-ai/swiftide/commit/47db5ab138384a6c235a90024470e9ab96751cc8) *(agents)*  Redrive uses the correct pointer and works as intended
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.17.1...0.17.2
+
+
+
 ## [0.17.1](https://github.com/bosun-ai/swiftide/compare/v0.17.0...v0.17.1) - 2025-01-20
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8504,7 +8504,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8532,7 +8532,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8556,7 +8556,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8584,7 +8584,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8605,7 +8605,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8633,7 +8633,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8691,7 +8691,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8713,7 +8713,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8734,7 +8734,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.1"
+version = "0.17.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.17.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.17.2" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.17.1 -> 0.17.2 (✓ API compatible changes)
* `swiftide-agents`: 0.17.1 -> 0.17.2 (✓ API compatible changes)
* `swiftide-core`: 0.17.1 -> 0.17.2
* `swiftide-macros`: 0.17.1 -> 0.17.2
* `swiftide-indexing`: 0.17.1 -> 0.17.2
* `swiftide-integrations`: 0.17.1 -> 0.17.2
* `swiftide-query`: 0.17.1 -> 0.17.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.17.2](https://github.com/bosun-ai/swiftide/compare/v0.17.1...v0.17.2) - 2025-01-21

### Bug fixes

- [47db5ab](https://github.com/bosun-ai/swiftide/commit/47db5ab138384a6c235a90024470e9ab96751cc8) *(agents)*  Redrive uses the correct pointer and works as intended


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.17.1...0.17.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).