### PR TITLE
chore: release v0.17.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.17.5](https://github.com/bosun-ai/swiftide/compare/v0.17.4...v0.17.5) - 2025-01-27
+
+### New features
+
+- [825a52e](https://github.com/bosun-ai/swiftide/commit/825a52e70a74e4621d370485346a78d61bf5d7a9) *(agents)*  Tool description now also accepts paths (i.e. a const) (#580)
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.lock dependencies
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.17.4...0.17.5
+
+
+
 ## [0.17.4](https://github.com/bosun-ai/swiftide/compare/v0.17.3...v0.17.4) - 2025-01-24
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8494,7 +8494,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8522,7 +8522,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8574,7 +8574,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8595,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8623,7 +8623,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8682,7 +8682,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8704,7 +8704,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8725,7 +8725,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.17.4"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.4"
+version = "0.17.5"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.17.4" }
+swiftide-core = { path = "../swiftide-core", version = "0.17.5" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.17.4 -> 0.17.5 (✓ API compatible changes)
* `swiftide-agents`: 0.17.4 -> 0.17.5 (✓ API compatible changes)
* `swiftide-core`: 0.17.4 -> 0.17.5
* `swiftide-macros`: 0.17.4 -> 0.17.5
* `swiftide-indexing`: 0.17.4 -> 0.17.5 (✓ API compatible changes)
* `swiftide-integrations`: 0.17.4 -> 0.17.5 (✓ API compatible changes)
* `swiftide-query`: 0.17.4 -> 0.17.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.17.5](https://github.com/bosun-ai/swiftide/compare/v0.17.4...v0.17.5) - 2025-01-27

### New features

- [825a52e](https://github.com/bosun-ai/swiftide/commit/825a52e70a74e4621d370485346a78d61bf5d7a9) *(agents)*  Tool description now also accepts paths (i.e. a const) (#580)

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.lock dependencies

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.17.4...0.17.5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).