### PR TITLE
feat(agents)!: Yield agent in hooks instead of context

### DIFF
--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -260,7 +260,7 @@ impl Agent {
                         "otel.name" = format!("hook.{}", HookTypes::AfterTool)
                     );
                     tracing::info!("Calling {} hook", HookTypes::AfterTool);
-                    hook(&*self.context).instrument(span.or_current()).await?;
+                    hook(self).instrument(span.or_current()).await?;
                 }
             }
         }
@@ -315,7 +315,7 @@ impl Agent {
                     "otel.name" = format!("hook.{}", HookTypes::BeforeCompletion)
                 );
                 tracing::info!("Calling {} hook", HookTypes::BeforeCompletion);
-                hook(&*self.context, &mut chat_completion_request)
+                hook(&*self, &mut chat_completion_request)
                     .instrument(span.or_current())
                     .await?;
             }
@@ -341,7 +341,7 @@ impl Agent {
                     "otel.name" = format!("hook.{}", HookTypes::AfterCompletion)
                 );
                 tracing::info!("Calling {} hook", HookTypes::AfterCompletion);
-                hook(&*self.context, &mut response)
+                hook(&*self, &mut response)
                     .instrument(span.or_current())
                     .await?;
             }
@@ -363,7 +363,7 @@ impl Agent {
                     "otel.name" = format!("hook.{}", HookTypes::AfterEach)
                 );
                 tracing::info!("Calling {} hook", HookTypes::AfterEach);
-                hook(&*self.context).instrument(span.or_current()).await?;
+                hook(&*self).instrument(span.or_current()).await?;
             }
         }
 
@@ -391,7 +391,7 @@ impl Agent {
                         "otel.name" = format!("hook.{}", HookTypes::BeforeTool)
                     );
                     tracing::info!("Calling {} hook", HookTypes::BeforeTool);
-                    hook(&*self.context, &tool_call)
+                    hook(&*self, &tool_call)
                         .instrument(span.or_current())
                         .await?;
                 }
@@ -423,7 +423,7 @@ impl Agent {
                         "otel.name" = format!("hook.{}", HookTypes::AfterTool)
                     );
                     tracing::info!("Calling {} hook", HookTypes::AfterTool);
-                    hook(&*self.context, &tool_call, &mut output)
+                    hook(&*self, &tool_call, &mut output)
                         .instrument(span.or_current())
                         .await?;
                 }
@@ -468,10 +468,7 @@ impl Agent {
                     "hook",
                     "otel.name" = format!("hook.{}", HookTypes::OnNewMessage)
                 );
-                if let Err(err) = hook(&*self.context, &mut message)
-                    .instrument(span.or_current())
-                    .await
-                {
+                if let Err(err) = hook(self, &mut message).instrument(span.or_current()).await {
                     tracing::error!(
                         "Error in {hooktype} hook: {err}",
                         hooktype = HookTypes::OnNewMessage,
@@ -491,6 +488,21 @@ impl Agent {
     /// Access the agent's context
     pub fn context(&self) -> &dyn AgentContext {
         &self.context
+    }
+
+    /// The agent is still running
+    pub fn is_running(&self) -> bool {
+        self.state.is_running()
+    }
+
+    /// The agent stopped
+    pub fn is_stopped(&self) -> bool {
+        self.state.is_stopped()
+    }
+
+    /// The agent has not (ever) started
+    pub fn is_pending(&self) -> bool {
+        self.state.is_pending()
     }
 }
 

--- a/swiftide-agents/src/hooks.rs
+++ b/swiftide-agents/src/hooks.rs
@@ -47,12 +47,9 @@ use anyhow::Result;
 use std::{future::Future, pin::Pin};
 
 use dyn_clone::DynClone;
-use swiftide_core::{
-    chat_completion::{
-        errors::ToolError, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ToolCall,
-        ToolOutput,
-    },
-    AgentContext,
+use swiftide_core::chat_completion::{
+    errors::ToolError, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ToolCall,
+    ToolOutput,
 };
 
 use crate::Agent;

--- a/swiftide-agents/src/test_utils.rs
+++ b/swiftide-agents/src/test_utils.rs
@@ -8,6 +8,7 @@ use swiftide_core::AgentContext;
 use crate::hooks::{
     AfterCompletionFn, AfterToolFn, BeforeAllFn, BeforeCompletionFn, BeforeToolFn, MessageHookFn,
 };
+use crate::Agent;
 
 #[macro_export]
 macro_rules! chat_request {
@@ -157,7 +158,7 @@ impl Tool for MockTool {
 
 impl From<MockTool> for Box<dyn Tool> {
     fn from(val: MockTool) -> Self {
-        Box::new(val)
+        Box::new(val) as Box<dyn Tool>
     }
 }
 
@@ -206,7 +207,7 @@ impl MockHook {
 
     pub fn hook_fn(&self) -> impl BeforeAllFn {
         let called = Arc::clone(&self.called);
-        move |_: &dyn AgentContext| {
+        move |_: &Agent| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -218,7 +219,7 @@ impl MockHook {
 
     pub fn before_completion_fn(&self) -> impl BeforeCompletionFn {
         let called = Arc::clone(&self.called);
-        move |_: &dyn AgentContext, _| {
+        move |_: &Agent, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -230,7 +231,7 @@ impl MockHook {
 
     pub fn after_completion_fn(&self) -> impl AfterCompletionFn {
         let called = Arc::clone(&self.called);
-        move |_: &dyn AgentContext, _| {
+        move |_: &Agent, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -242,7 +243,7 @@ impl MockHook {
 
     pub fn after_tool_fn(&self) -> impl AfterToolFn {
         let called = Arc::clone(&self.called);
-        move |_: &dyn AgentContext, _, _| {
+        move |_: &Agent, _, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -254,7 +255,7 @@ impl MockHook {
 
     pub fn before_tool_fn(&self) -> impl BeforeToolFn {
         let called = Arc::clone(&self.called);
-        move |_: &dyn AgentContext, _| {
+        move |_: &Agent, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -266,7 +267,7 @@ impl MockHook {
 
     pub fn message_hook_fn(&self) -> impl MessageHookFn {
         let called = Arc::clone(&self.called);
-        move |_: &dyn AgentContext, _| {
+        move |_: &Agent, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();


### PR DESCRIPTION
Enables a lot more customizability than yielding just the agent. The
context can still be accessed through agent#context.
