### PR TITLE
chore: release v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,6 @@ All notable changes to this project will be documented in this file.
 
 - [de46656](https://github.com/bosun-ai/swiftide/commit/de46656f80c5cf68cc192d21b5f34eb3e0667a14) *(agents)*  Add `on_start` hook (#586)
 
-````text
-- **feat(agents)!: Yield agent in hooks instead of context**
-  - **Clippy**
-  - **feat(agents): Add `on_start` hook for agents**
-````
-
 - [c551f1b](https://github.com/bosun-ai/swiftide/commit/c551f1becfd1750ce480a00221a34908db61e42f) *(integrations)*  OpenRouter support (#589)
 
 ````text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.18.0](https://github.com/bosun-ai/swiftide/compare/v0.17.5...v0.18.0) - 2025-02-01
+
+### New features
+
+- [de46656](https://github.com/bosun-ai/swiftide/commit/de46656f80c5cf68cc192d21b5f34eb3e0667a14) *(agents)*  Add `on_start` hook (#586)
+
+````text
+- **feat(agents)!: Yield agent in hooks instead of context**
+  - **Clippy**
+  - **feat(agents): Add `on_start` hook for agents**
+````
+
+- [c551f1b](https://github.com/bosun-ai/swiftide/commit/c551f1becfd1750ce480a00221a34908db61e42f) *(integrations)*  OpenRouter support (#589)
+
+````text
+Adds OpenRouter support. OpenRouter allows you to use any LLM via their
+  own api (with a minor upsell).
+````
+
+### Bug fixes
+
+- [3ea5839](https://github.com/bosun-ai/swiftide/commit/3ea583971c0d2cc5ef0594eaf764ea149bacd1d8) *(redb)*  Disable per-node tracing
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.lock dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.17.5...0.18.0
+
+
+
 ## [0.17.5](https://github.com/bosun-ai/swiftide/compare/v0.17.4...v0.17.5) - 2025-01-27
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8495,7 +8495,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8547,7 +8547,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8575,7 +8575,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8624,7 +8624,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8683,7 +8683,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8705,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8726,7 +8726,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.17.5"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.5"
+version = "0.18.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.17" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.17" }
+swiftide-core = { path = "../swiftide-core", version = "0.18" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.18" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.17" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.17" }
+swiftide-core = { path = "../swiftide-core", version = "0.18" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.18" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.17" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.17" }
+swiftide-core = { path = "../swiftide-core", version = "0.18" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.18" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.17.5" }
+swiftide-core = { path = "../swiftide-core", version = "0.18.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.17" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.17" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.17" }
-swiftide-query = { path = "../swiftide-query", version = "0.17" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.17", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.18" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.18" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.18" }
+swiftide-query = { path = "../swiftide-query", version = "0.18" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.18", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION
## 🤖 New release
* `swiftide`: 0.17.5 -> 0.18.0 (✓ API compatible changes)
* `swiftide-agents`: 0.17.5 -> 0.18.0 (⚠️ API breaking changes)
* `swiftide-core`: 0.17.5 -> 0.18.0 (✓ API compatible changes)
* `swiftide-macros`: 0.17.5 -> 0.18.0
* `swiftide-indexing`: 0.17.5 -> 0.18.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.17.5 -> 0.18.0 (✓ API compatible changes)
* `swiftide-query`: 0.17.5 -> 0.18.0 (✓ API compatible changes)

### ⚠️ `swiftide-agents` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant HookTypes:OnStart in /tmp/.tmpArEE27/swiftide/swiftide-agents/src/hooks.rs:172
  variant Hook:OnStart in /tmp/.tmpArEE27/swiftide/swiftide-agents/src/hooks.rs:172
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`
<blockquote>

## [0.18.0](https://github.com/bosun-ai/swiftide/compare/v0.17.5...v0.18.0) - 2025-02-01

### New features

- [de46656](https://github.com/bosun-ai/swiftide/commit/de46656f80c5cf68cc192d21b5f34eb3e0667a14) *(agents)*  Add `on_start` hook (#586)

````text
- **feat(agents)!: Yield agent in hooks instead of context**
  - **Clippy**
  - **feat(agents): Add `on_start` hook for agents**
````

- [c551f1b](https://github.com/bosun-ai/swiftide/commit/c551f1becfd1750ce480a00221a34908db61e42f) *(integrations)*  OpenRouter support (#589)

````text
Adds OpenRouter support. OpenRouter allows you to use any LLM via their
  own api (with a minor upsell).
````

### Bug fixes

- [3ea5839](https://github.com/bosun-ai/swiftide/commit/3ea583971c0d2cc5ef0594eaf764ea149bacd1d8) *(redb)*  Disable per-node tracing

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.lock dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.17.5...0.18.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).