### PR TITLE
feat: add solidity support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ tree-sitter-ruby = "0.23"
 tree-sitter-rust = "0.23"
 tree-sitter-typescript = "0.23"
 tree-sitter-go = "0.23"
+tree-sitter-solidity = "1.2.11"
 
 
 # Testing

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -54,6 +54,8 @@ tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-java = { workspace = true, optional = true }
 tree-sitter-go = { workspace = true, optional = true }
+tree-sitter-solidity = { workspace = true, optional = true }
+
 fastembed = { workspace = true, optional = true }
 spider = { workspace = true, optional = true }
 htmd = { workspace = true, optional = true }
@@ -123,6 +125,7 @@ tree-sitter = [
   "dep:tree-sitter-javascript",
   "dep:tree-sitter-java",
   "dep:tree-sitter-go",
+  "dep:tree-sitter-solidity",
 ]
 # OpenAI for embedding and prompting
 openai = ["dep:async-openai"]

--- a/swiftide-integrations/src/treesitter/code_tree.rs
+++ b/swiftide-integrations/src/treesitter/code_tree.rs
@@ -8,7 +8,7 @@ use tree_sitter::{Parser, Query, QueryCursor, Tree};
 use anyhow::{Context as _, Result};
 use std::collections::HashSet;
 
-use crate::treesitter::queries::{solidity, go, java, javascript, python, ruby, rust, typescript};
+use crate::treesitter::queries::{go, java, javascript, python, ruby, rust, solidity, typescript};
 
 use super::SupportedLanguages;
 
@@ -107,7 +107,7 @@ impl CodeTree<'_> {
 }
 
 fn ts_queries_for_language(language: SupportedLanguages) -> (&'static str, &'static str) {
-    use SupportedLanguages::{Solidity, Go, Java, Javascript, Python, Ruby, Rust, Typescript};
+    use SupportedLanguages::{Go, Java, Javascript, Python, Ruby, Rust, Solidity, Typescript};
 
     match language {
         Rust => (rust::DEFS, rust::REFS),

--- a/swiftide-integrations/src/treesitter/outliner.rs
+++ b/swiftide-integrations/src/treesitter/outliner.rs
@@ -119,6 +119,7 @@ impl CodeOutliner {
                 _ => false,
             },
             SupportedLanguages::Go => unimplemented!(),
+            SupportedLanguages::Solidity => unimplemented!(),
         }
     }
 

--- a/swiftide-integrations/src/treesitter/queries.rs
+++ b/swiftide-integrations/src/treesitter/queries.rs
@@ -362,9 +362,8 @@ pub mod go {
 
 pub mod solidity {
     pub const DEFS: &str = r#"
-    (contract_declaration
-        (function_definition
-            name: (identifier) @name))
+    (function_definition
+    name: (identifier) @name)
 
     (source_file
         (function_definition

--- a/swiftide-integrations/src/treesitter/queries.rs
+++ b/swiftide-integrations/src/treesitter/queries.rs
@@ -359,3 +359,46 @@ pub mod go {
     (type_identifier) @name 
             "#;
 }
+
+pub mod solidity {
+    pub const DEFS: &str = r#"
+    (contract_declaration
+        (function_definition
+            name: (identifier) @name))
+
+    (source_file
+        (function_definition
+            name: (identifier) @name))
+
+    (contract_declaration
+    name: (identifier) @name) 
+
+    (interface_declaration
+    name: (identifier) @name)
+
+    (library_declaration
+    name: (identifier) @name)
+
+    (struct_declaration name: (identifier) @name)
+    (enum_declaration name: (identifier) @name)
+    (event_definition name: (identifier) @name)
+    "#;
+
+    pub const REFS: &str = r#"
+    (call_expression (expression (identifier)) @name )
+
+    (call_expression
+        (expression (member_expression
+            property: (_) @name )))
+
+    (emit_statement name: (_) @name)
+
+
+    (inheritance_specifier
+        ancestor: (user_defined_type (_) @name . ))
+
+
+    (import_directive
+    import_name: (_) @name )
+    "#;
+}

--- a/swiftide-integrations/src/treesitter/supported_languages.rs
+++ b/swiftide-integrations/src/treesitter/supported_languages.rs
@@ -10,6 +10,7 @@
 //! - Python
 //! - Ruby
 //! - Javascript
+//! - Solidity
 
 #[allow(unused_imports)]
 pub use std::str::FromStr as _;
@@ -49,6 +50,8 @@ pub enum SupportedLanguages {
     Java,
     #[serde(alias = "go")]
     Go,
+    #[serde(alias = "solidity")]
+    Solidity,
 }
 
 /// Static array of file extensions for Rust files.
@@ -72,6 +75,9 @@ static JAVA_EXTENSIONS: &[&str] = &["java"];
 /// Static array of file extensions for Go files.
 static GO_EXTENSIONS: &[&str] = &["go"];
 
+/// Static array of file extensions for Solidity files.
+static SOLIDITY_EXTENSIONS: &[&str] = &["sol"];
+
 impl SupportedLanguages {
     /// Returns the file extensions associated with the supported language.
     ///
@@ -86,6 +92,7 @@ impl SupportedLanguages {
             SupportedLanguages::Javascript => JAVASCRIPT_EXTENSIONS,
             SupportedLanguages::Java => JAVA_EXTENSIONS,
             SupportedLanguages::Go => GO_EXTENSIONS,
+            SupportedLanguages::Solidity => SOLIDITY_EXTENSIONS,
         }
     }
 }
@@ -110,6 +117,7 @@ impl From<SupportedLanguages> for tree_sitter::Language {
             SupportedLanguages::Ruby => tree_sitter_ruby::LANGUAGE,
             SupportedLanguages::Java => tree_sitter_java::LANGUAGE,
             SupportedLanguages::Go => tree_sitter_go::LANGUAGE,
+            SupportedLanguages::Solidity => tree_sitter_solidity::LANGUAGE,
         }
         .into()
     }


### PR DESCRIPTION
This pr adds solidity support. 

Notes:
* I've added queries, but have omitted outlining for now.
* The simple testcase should ensure the queries are correct ( I copied them from upstream anyways 🤷‍♂️ )


I had a quick question while writing this pr, is there any reason why the tags.scm file packaged with the parsers isn't used? or was this just easier for now.