### PR TITLE
chore: release v0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.18.2](https://github.com/bosun-ai/swiftide/compare/v0.18.1...v0.18.2) - 2025-02-11
+
+### New features
+
+- [50ffa15](https://github.com/bosun-ai/swiftide/commit/50ffa156e28bb085a61a376bab71c135bc09622f)  Anthropic support for prompts and agents (#602)
+
+### Bug fixes
+
+- [8cf70e0](https://github.com/bosun-ai/swiftide/commit/8cf70e08787d1376ba20001cc9346767d8bd84ef) *(integrations)*  Ensure anthropic tool call format is consistent with specs
+
+### Miscellaneous
+
+- [98176c6](https://github.com/bosun-ai/swiftide/commit/98176c603b61e3971ca5583f9f4346eb5b962d51)  Clippy
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.18.1...0.18.2
+
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 ## [0.18.1](https://github.com/bosun-ai/swiftide/compare/v0.18.0...v0.18.1) - 2025-02-09
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,7 +1278,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8520,7 +8520,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8548,7 +8548,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8572,7 +8572,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8600,7 +8600,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8621,7 +8621,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8649,7 +8649,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8711,7 +8711,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8733,7 +8733,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8754,7 +8754,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.18.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.18.2" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide`: 0.18.1 -> 0.18.2 (✓ API compatible changes)
* `swiftide-agents`: 0.18.1 -> 0.18.2
* `swiftide-core`: 0.18.1 -> 0.18.2
* `swiftide-macros`: 0.18.1 -> 0.18.2
* `swiftide-indexing`: 0.18.1 -> 0.18.2
* `swiftide-integrations`: 0.18.1 -> 0.18.2 (✓ API compatible changes)
* `swiftide-query`: 0.18.1 -> 0.18.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`

<blockquote>

## [0.18.2](https://github.com/bosun-ai/swiftide/compare/v0.18.1...v0.18.2) - 2025-02-11

### New features

- [50ffa15](https://github.com/bosun-ai/swiftide/commit/50ffa156e28bb085a61a376bab71c135bc09622f)  Anthropic support for prompts and agents (#602)

### Bug fixes

- [8cf70e0](https://github.com/bosun-ai/swiftide/commit/8cf70e08787d1376ba20001cc9346767d8bd84ef) *(integrations)*  Ensure anthropic tool call format is consistent with specs

### Miscellaneous

- [98176c6](https://github.com/bosun-ai/swiftide/commit/98176c603b61e3971ca5583f9f4346eb5b962d51)  Clippy


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.18.1...0.18.2
</blockquote>








</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).