### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.19.0](https://github.com/bosun-ai/swiftide/compare/v0.18.2...v0.19.0) - 2025-02-13
+
+### New features
+
+- [fa5112c](https://github.com/bosun-ai/swiftide/commit/fa5112c9224fdf5984d26db669f04dedc8ebb561) *(agents)*  By default retry failed tools with LLM up to 3 times (#609)
+
+````text
+Specifically meant for LLMs sending invalid JSON, these tool calls are
+  now retried by feeding back the error into the LLM up to a limit
+  (default 3).
+````
+
+- [14f4778](https://github.com/bosun-ai/swiftide/commit/14f47780b4294be3a9fa3670aa18a952ad7e9d6e) *(integrations)*  Parallel tool calling in OpenAI is now configurable (#611)
+
+````text
+Adds support reasoning models in agents and for chat completions.
+````
+
+- [37a1a2c](https://github.com/bosun-ai/swiftide/commit/37a1a2c7bfd152db56ed929e0ea1ab99080e640d) *(integrations)*  Add system prompts as `system` instead of message in Anthropic requests
+
+### Bug fixes
+
+- [ab27c75](https://github.com/bosun-ai/swiftide/commit/ab27c75b8f4a971cb61e88b26d94231afd35c871) *(agents)*  Add back anyhow catch all for failed tools
+
+- [2388f18](https://github.com/bosun-ai/swiftide/commit/2388f187966d996ede4ff42c71521238b63d129c) *(agents)*  Use name/arg hash on tool retries (#612)
+
+- [da55664](https://github.com/bosun-ai/swiftide/commit/da5566473e3f8874fce427ceb48a15d002737d07) *(integrations)*  Scraper should stop when finished (#614)
+
+### Miscellaneous
+
+- [990a8ea](https://github.com/bosun-ai/swiftide/commit/990a8eaeffdbd447bb05a0b01aa65a39a7c9cacf) *(deps)*  Update tree-sitter (#616)
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.18.2...0.19.0
+
+
+
 ## [0.18.2](https://github.com/bosun-ai/swiftide/compare/v0.18.1...v0.18.2) - 2025-02-11
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,7 +1249,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8358,7 +8358,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8386,7 +8386,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8410,7 +8410,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8438,7 +8438,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8459,7 +8459,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8487,7 +8487,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8549,7 +8549,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8571,7 +8571,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8592,7 +8592,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.18.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.2"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.18" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.18" }
+swiftide-core = { path = "../swiftide-core", version = "0.19" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.19" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.18" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.18" }
+swiftide-core = { path = "../swiftide-core", version = "0.19" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.19" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.18" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.18" }
+swiftide-core = { path = "../swiftide-core", version = "0.19" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.19" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.18.2" }
+swiftide-core = { path = "../swiftide-core", version = "0.19.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.18" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.18" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.18" }
-swiftide-query = { path = "../swiftide-query", version = "0.18" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.18", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.19" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.19" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.19" }
+swiftide-query = { path = "../swiftide-query", version = "0.19" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.19", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide`: 0.18.2 -> 0.19.0 (✓ API compatible changes)
* `swiftide-agents`: 0.18.2 -> 0.19.0 (✓ API compatible changes)
* `swiftide-core`: 0.18.2 -> 0.19.0 (✓ API compatible changes)
* `swiftide-macros`: 0.18.2 -> 0.19.0
* `swiftide-indexing`: 0.18.2 -> 0.19.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.18.2 -> 0.19.0 (⚠ API breaking changes)
* `swiftide-query`: 0.18.2 -> 0.19.0

### ⚠ `swiftide-integrations` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Options.parallel_tool_calls in /tmp/.tmpykErkE/swiftide/swiftide-integrations/src/openai/mod.rs:70
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`

<blockquote>

## [0.19.0](https://github.com/bosun-ai/swiftide/compare/v0.18.2...v0.19.0) - 2025-02-13

### New features

- [fa5112c](https://github.com/bosun-ai/swiftide/commit/fa5112c9224fdf5984d26db669f04dedc8ebb561) *(agents)*  By default retry failed tools with LLM up to 3 times (#609)

````text
Specifically meant for LLMs sending invalid JSON, these tool calls are
  now retried by feeding back the error into the LLM up to a limit
  (default 3).
````

- [14f4778](https://github.com/bosun-ai/swiftide/commit/14f47780b4294be3a9fa3670aa18a952ad7e9d6e) *(integrations)*  Parallel tool calling in OpenAI is now configurable (#611)

````text
Adds support reasoning models in agents and for chat completions.
````

- [37a1a2c](https://github.com/bosun-ai/swiftide/commit/37a1a2c7bfd152db56ed929e0ea1ab99080e640d) *(integrations)*  Add system prompts as `system` instead of message in Anthropic requests

### Bug fixes

- [ab27c75](https://github.com/bosun-ai/swiftide/commit/ab27c75b8f4a971cb61e88b26d94231afd35c871) *(agents)*  Add back anyhow catch all for failed tools

- [2388f18](https://github.com/bosun-ai/swiftide/commit/2388f187966d996ede4ff42c71521238b63d129c) *(agents)*  Use name/arg hash on tool retries (#612)

- [da55664](https://github.com/bosun-ai/swiftide/commit/da5566473e3f8874fce427ceb48a15d002737d07) *(integrations)*  Scraper should stop when finished (#614)

### Miscellaneous

- [990a8ea](https://github.com/bosun-ai/swiftide/commit/990a8eaeffdbd447bb05a0b01aa65a39a7c9cacf) *(deps)*  Update tree-sitter (#616)

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.18.2...0.19.0
</blockquote>








</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).