### PR TITLE
feat(agents): By default retry failed tools with LLM up to 3 times

### DIFF
--- a/swiftide-core/src/chat_completion/errors.rs
+++ b/swiftide-core/src/chat_completion/errors.rs
@@ -5,19 +5,16 @@ use crate::CommandError;
 #[derive(Error, Debug)]
 pub enum ToolError {
     /// I.e. the llm calls the tool with the wrong arguments
-    #[error("arguments for tool failed to parse")]
+    #[error("arguments for tool failed to parse: {0:#}")]
     WrongArguments(#[from] serde_json::Error),
 
     /// Tool requires arguments but none were provided
-    #[error("no arguments provided for tool {0:#}")]
+    #[error("arguments missing for tool: {0:#}")]
     MissingArguments(String),
 
     /// Tool execution failed
     #[error("tool execution failed: {0:#}")]
     ExecutionFailed(#[from] CommandError),
-
-    #[error(transparent)]
-    Unknown(#[from] anyhow::Error),
 }
 
 #[derive(Error, Debug)]

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -46,6 +46,10 @@ pub struct ToolCall {
     name: String,
     #[builder(default)]
     args: Option<String>,
+
+    /// How often this tool call has been retried
+    #[builder(default)]
+    pub retries: usize,
 }
 
 impl std::fmt::Display for ToolCall {


### PR DESCRIPTION
Specifically meant for LLMs sending invalid JSON, these tool calls are now retried by feeding back the error into the LLM up to a limit (default 3).