### PR TITLE
fix(integration): Enable `scrape` again on spider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6668,7 +6668,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7899,7 +7899,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -7944,9 +7944,9 @@ dependencies = [
 
 [[package]]
 name = "spider"
-version = "2.27.62"
+version = "2.27.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89064a268c22a86833ce57105b03e0771447fb29870f5e6311fb198cb8c7f82"
+checksum = "163cb05e3fcc1144d0de3b404e2068934cefa857afb0a1a3f874a70adeff9d53"
 dependencies = [
  "ahash",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ dyn-clone = { version = "1.0" }
 convert_case = "0.7.1"
 
 # Integrations
-spider = { version = "2.27" }
+spider = { version = "2.27.62" }
 async-openai = { version = "0.27.1" }
 qdrant-client = { version = "1.13", default-features = false, features = [
   "serde",

--- a/swiftide-integrations/src/scraping/loader.rs
+++ b/swiftide-integrations/src/scraping/loader.rs
@@ -66,9 +66,7 @@ impl Loader for ScrapingLoader {
 
         let _scrape_thread = tokio::spawn(async move {
             tracing::info!("[Spider] Starting scrape loop");
-            // TODO: It would be much nicer if this used `scrape` instead, as it is supposedly
-            // more concurrent
-            spider_website.crawl().await;
+            spider_website.scrape().await;
             tracing::info!("[Spider] Scrape loop finished");
         });
 


### PR DESCRIPTION
Waiting on https://github.com/spider-rs/spider/issues/269

Does not work yet, log output of one of the tests:

```
[INFO  swiftide_integrations::scraping::loader] Subscribed to spider
[INFO  swiftide_integrations::scraping::loader] [Spider] Starting scrape loop
[DEBUG reqwest::connect] starting new connection: http://127.0.0.1:51487/
[DEBUG hyper_util::client::legacy::connect::http] connecting to 127.0.0.1:51487
[DEBUG hyper_util::client::legacy::connect::http] connected to 127.0.0.1:51487
[DEBUG wiremock::mock_set] Handling request.
[DEBUG hyper_util::client::legacy::pool] pooling idle connection for ("http", 127.0.0.1:51487)
[INFO  spider::utils] fetch http://127.0.0.1:51487
[INFO  spider::utils] fetch http://127.0.0.1:51487/other
[DEBUG hyper_util::client::legacy::pool] reuse idle connection for ("http", 127.0.0.1:51487)
[DEBUG wiremock::mock_set] Handling request.
[DEBUG swiftide_integrations::scraping::loader] [Spider] Received node from spider node=Ok(Node { id: 4bbb2370-2b46-3423-a5be-572a9a8b25c8, path: "http://127.0.0.1:51487", chunk: "<html><body><h1>Test Page</h1><a href=\"/other\">link</a></body></html>", metadata: {}, vectors: "", sparse_vectors: "", embed_mode: SingleWithMetadata })
[DEBUG hyper_util::client::legacy::pool] pooling idle connection for ("http", 127.0.0.1:51487)
[DEBUG swiftide_integrations::scraping::loader] [Spider] Received node from spider node=Ok(Node { id: 9d3aecea-d8f1-32f3-8479-0b4b50214d02, path: "http://127.0.0.1:51487/other", chunk: "<html><body><h1>Test Page 2</h1></body></html>", metadata: {}, vectors: "", sparse_vectors: "", embed_mode: SingleWithMetadata })
```