### PR TITLE
feat: Continue Agent on Tool Failure

### DIFF
--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -105,7 +105,7 @@ pub struct Agent {
     pub(crate) tool_retries_counter: HashMap<u64, usize>,
 
     /// If true, the agent will continue to run even if a tool call fails after all retries
-    #[builder(default = true)]
+    #[builder(default = false)]
     pub(crate) continue_on_tool_total_failure: bool,
 }
 

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -486,33 +486,28 @@ impl Agent {
             }
 
             if let Err(error) = output {
-                if self.tool_calls_over_limit(&tool_call) {
+                let stop = self.tool_calls_over_limit(&tool_call);
+                if stop {
                     tracing::error!(
                         "Tool call failed, retry limit reached, stopping agent: {err}",
                         err = error
                     );
-                    // required for graceful stop which can be recovered from
-                    self.add_message(ChatMessage::ToolOutput(
-                        tool_call,
-                        ToolOutput::Text(
-                            "Tool call could not be executed successfully, stopping agent"
-                                .to_string(),
-                        ),
-                    ))
-                    .await?;
-                    self.stop();
-                    return Err(error.into());
+                } else {
+                    tracing::warn!(
+                        error = error.to_string(),
+                        tool_call = ?tool_call,
+                        "Tool call failed, retrying",
+                    );
                 }
-                tracing::warn!(
-                    error = error.to_string(),
-                    tool_call = ?tool_call,
-                    "Tool call failed, retrying",
-                );
                 self.add_message(ChatMessage::ToolOutput(
                     tool_call,
                     ToolOutput::Fail(error.to_string()),
                 ))
                 .await?;
+                if stop {
+                    self.stop();
+                    return Err(error.into());
+                }
                 continue;
             }
 

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -491,23 +491,23 @@ impl Agent {
 
             if let Err(error) = output {
                 if self.tool_calls_over_limit(&tool_call) {
-                    //if !self.continue_on_tool_total_failure {
-                    //    tracing::error!(
-                    //        "Tool call failed, retry limit reached, stopping agent: {err}",
-                    //        err = error
-                    //    );
-                    //    // required for graceful stop which can be recovered from
-                    //    self.add_message(ChatMessage::ToolOutput(
-                    //        tool_call,
-                    //        ToolOutput::Text(
-                    //            "Tool call could not be executed successfully, stopping agent"
-                    //                .to_string(),
-                    //        ),
-                    //    ))
-                    //    .await?;
-                    //    self.stop();
-                    //    return Err(error.into());
-                    //}
+                    if !self.continue_on_tool_total_failure {
+                        tracing::error!(
+                            "Tool call failed, retry limit reached, stopping agent: {err}",
+                            err = error
+                        );
+                        // required for graceful stop which can be recovered from
+                        self.add_message(ChatMessage::ToolOutput(
+                            tool_call,
+                            ToolOutput::Text(
+                                "Tool call could not be executed successfully, stopping agent"
+                                    .to_string(),
+                            ),
+                        ))
+                        .await?;
+                        self.stop();
+                        return Err(error.into());
+                    }
 
                     tracing::error!(
                         "Tool call failed, retry limit reached, continuing agent, but ignoring this tool call: {err}",

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -103,6 +103,10 @@ pub struct Agent {
     /// the name and args of the tool.
     #[builder(private, default)]
     pub(crate) tool_retries_counter: HashMap<u64, usize>,
+
+    /// If true, the agent will continue to run even if a tool call fails after all retries
+    #[builder(default = true)]
+    pub(crate) continue_on_tool_total_failure: bool,
 }
 
 impl std::fmt::Debug for Agent {
@@ -487,24 +491,42 @@ impl Agent {
 
             if let Err(error) = output {
                 if self.tool_calls_over_limit(&tool_call) {
+                    if !self.continue_on_tool_total_failure {
+                        tracing::error!(
+                            "Tool call failed, retry limit reached, stopping agent: {err}",
+                            err = error
+                        );
+                        // required for graceful stop which can be recovered from
+                        self.add_message(ChatMessage::ToolOutput(
+                            tool_call,
+                            ToolOutput::Text(
+                                "Tool call could not be executed successfully, stopping agent"
+                                    .to_string(),
+                            ),
+                        ))
+                        .await?;
+                        self.stop();
+                        return Err(error.into());
+                    }
+
                     tracing::error!(
-                        "Tool call failed, retry limit reached, stopping agent: {err}",
+                        "Tool call failed, retry limit reached, continuing agent, but ignoring this tool call: {err}",
                         err = error
                     );
-                    self.stop();
-                    return Err(error.into());
+                    output = Ok(ToolOutput::Text("Tool call could not be executed successfully, please try a different approach".to_string()));
+                } else {
+                    tracing::warn!(
+                        error = error.to_string(),
+                        tool_call = ?tool_call,
+                        "Tool call failed, retrying",
+                    );
+                    self.add_message(ChatMessage::ToolOutput(
+                        tool_call,
+                        ToolOutput::Fail(error.to_string()),
+                    ))
+                    .await?;
+                    continue;
                 }
-                tracing::warn!(
-                    error = error.to_string(),
-                    tool_call = ?tool_call,
-                    "Tool call failed, retrying",
-                );
-                self.add_message(ChatMessage::ToolOutput(
-                    tool_call,
-                    ToolOutput::Fail(error.to_string()),
-                ))
-                .await?;
-                continue;
             }
 
             let output = output?;

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -491,23 +491,23 @@ impl Agent {
 
             if let Err(error) = output {
                 if self.tool_calls_over_limit(&tool_call) {
-                    if !self.continue_on_tool_total_failure {
-                        tracing::error!(
-                            "Tool call failed, retry limit reached, stopping agent: {err}",
-                            err = error
-                        );
-                        // required for graceful stop which can be recovered from
-                        self.add_message(ChatMessage::ToolOutput(
-                            tool_call,
-                            ToolOutput::Text(
-                                "Tool call could not be executed successfully, stopping agent"
-                                    .to_string(),
-                            ),
-                        ))
-                        .await?;
-                        self.stop();
-                        return Err(error.into());
-                    }
+                    //if !self.continue_on_tool_total_failure {
+                    //    tracing::error!(
+                    //        "Tool call failed, retry limit reached, stopping agent: {err}",
+                    //        err = error
+                    //    );
+                    //    // required for graceful stop which can be recovered from
+                    //    self.add_message(ChatMessage::ToolOutput(
+                    //        tool_call,
+                    //        ToolOutput::Text(
+                    //            "Tool call could not be executed successfully, stopping agent"
+                    //                .to_string(),
+                    //        ),
+                    //    ))
+                    //    .await?;
+                    //    self.stop();
+                    //    return Err(error.into());
+                    //}
 
                     tracing::error!(
                         "Tool call failed, retry limit reached, continuing agent, but ignoring this tool call: {err}",


### PR DESCRIPTION
Continues the agent on tool failure, related to https://github.com/bosun-ai/kwaak/issues/313