### PR TITLE
chore: release v0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.2](https://github.com/bosun-ai/swiftide/compare/v0.20.1...v0.20.2) - 2025-02-23
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.20.1...0.20.2
+
+
+
 ## [0.20.1](https://github.com/bosun-ai/swiftide/compare/v0.20.0...v0.20.1) - 2025-02-21
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8395,7 +8395,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8447,7 +8447,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8475,7 +8475,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8588,7 +8588,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.20.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.20.1" }
+swiftide-core = { path = "../swiftide-core/", version = "0.20.2" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.20.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.20.2" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide`: 0.20.1 -> 0.20.2 (✓ API compatible changes)
* `swiftide-agents`: 0.20.1 -> 0.20.2
* `swiftide-core`: 0.20.1 -> 0.20.2 (✓ API compatible changes)
* `swiftide-macros`: 0.20.1 -> 0.20.2
* `swiftide-indexing`: 0.20.1 -> 0.20.2
* `swiftide-integrations`: 0.20.1 -> 0.20.2 (✓ API compatible changes)
* `swiftide-query`: 0.20.1 -> 0.20.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`

<blockquote>

## [0.20.2](https://github.com/bosun-ai/swiftide/compare/v0.20.1...v0.20.2) - 2025-02-23

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.20.1...0.20.2
</blockquote>








</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).