### PR TITLE
feat(agents): Improve flexibility for tool generation

### DIFF
--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -452,13 +452,13 @@ impl Agent {
             }
 
             let tool_span =
-                tracing::info_span!("tool", "otel.name" = format!("tool.{}", tool.name()));
+                tracing::info_span!("tool", "otel.name" = format!("tool.{}", tool.name().as_ref()));
 
             let handle = tokio::spawn(async move {
                     let tool_args = ArgPreprocessor::preprocess(tool_args.as_deref());
                     let output = tool.invoke(&*context, tool_args.as_deref()).await.map_err(|e| { tracing::error!(error = %e, "Failed tool call"); e })?;
 
-                    tracing::debug!(output = output.to_string(), args = ?tool_args, tool_name = tool.name(), "Completed tool call");
+                    tracing::debug!(output = output.to_string(), args = ?tool_args, tool_name = tool.name().as_ref(), "Completed tool call");
 
                     Ok(output)
                 }.instrument(tool_span.or_current()));

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -451,8 +451,10 @@ impl Agent {
                 }
             }
 
-            let tool_span =
-                tracing::info_span!("tool", "otel.name" = format!("tool.{}", tool.name().as_ref()));
+            let tool_span = tracing::info_span!(
+                "tool",
+                "otel.name" = format!("tool.{}", tool.name().as_ref())
+            );
 
             let handle = tokio::spawn(async move {
                     let tool_args = ArgPreprocessor::preprocess(tool_args.as_deref());

--- a/swiftide-agents/src/test_utils.rs
+++ b/swiftide-agents/src/test_utils.rs
@@ -1,4 +1,5 @@
 use std::sync::{Arc, Mutex};
+use std::borrow::Cow;
 
 use async_trait::async_trait;
 use swiftide_core::chat_completion::{errors::ToolError, Tool, ToolOutput, ToolSpec};
@@ -175,13 +176,13 @@ impl Tool for MockTool {
         expectation.0
     }
 
-    fn name(&self) -> &'static str {
-        self.name
+    fn name<'tool>(&'tool self) -> Cow<'tool, str> {
+        self.name.into()
     }
 
     fn tool_spec(&self) -> ToolSpec {
         ToolSpec::builder()
-            .name(self.name())
+            .name(self.name().as_ref())
             .description("A fake tool for testing purposes")
             .build()
             .unwrap()

--- a/swiftide-agents/src/test_utils.rs
+++ b/swiftide-agents/src/test_utils.rs
@@ -1,5 +1,5 @@
-use std::sync::{Arc, Mutex};
 use std::borrow::Cow;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use swiftide_core::chat_completion::{errors::ToolError, Tool, ToolOutput, ToolSpec};
@@ -176,7 +176,7 @@ impl Tool for MockTool {
         expectation.0
     }
 
-    fn name<'tool>(&'tool self) -> Cow<'tool, str> {
+    fn name(&self) -> Cow<'_, str> {
         self.name.into()
     }
 

--- a/swiftide-agents/src/tools/control.rs
+++ b/swiftide-agents/src/tools/control.rs
@@ -1,11 +1,11 @@
 //! Control tools manage control flow during agent's lifecycle.
 use anyhow::Result;
 use async_trait::async_trait;
+use std::borrow::Cow;
 use swiftide_core::{
     chat_completion::{errors::ToolError, Tool, ToolOutput, ToolSpec},
     AgentContext,
 };
-use std::borrow::Cow;
 
 // TODO: Cannot use macros in our own crates because of import shenanigans
 #[derive(Clone, Debug, Default)]
@@ -21,7 +21,7 @@ impl Tool for Stop {
         Ok(ToolOutput::Stop)
     }
 
-    fn name<'tool>(&'tool self) -> Cow<'tool, str> {
+    fn name(&self) -> Cow<'_, str> {
         "stop".into()
     }
 

--- a/swiftide-agents/src/tools/control.rs
+++ b/swiftide-agents/src/tools/control.rs
@@ -5,6 +5,7 @@ use swiftide_core::{
     chat_completion::{errors::ToolError, Tool, ToolOutput, ToolSpec},
     AgentContext,
 };
+use std::borrow::Cow;
 
 // TODO: Cannot use macros in our own crates because of import shenanigans
 #[derive(Clone, Debug, Default)]
@@ -20,8 +21,8 @@ impl Tool for Stop {
         Ok(ToolOutput::Stop)
     }
 
-    fn name(&self) -> &'static str {
-        "stop"
+    fn name<'tool>(&'tool self) -> Cow<'tool, str> {
+        "stop".into()
     }
 
     fn tool_spec(&self) -> ToolSpec {

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -90,11 +90,12 @@ impl ToolCall {
 ///
 /// i.e. the json spec `OpenAI` uses to define their tools
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Default, Builder)]
+#[builder(setter(into))]
 pub struct ToolSpec {
     /// Name of the tool
-    pub name: &'static str,
+    pub name: String,
     /// Description passed to the LLM for the tool
-    pub description: &'static str,
+    pub description: String,
 
     #[builder(default)]
     /// Optional parameters for the tool
@@ -122,11 +123,12 @@ pub enum ParamType {
 
 /// Parameters for tools
 #[derive(Clone, Debug, Hash, Eq, PartialEq, Builder)]
+#[builder(setter(into))]
 pub struct ParamSpec {
     /// Name of the parameter
-    pub name: &'static str,
+    pub name: String,
     /// Description of the parameter
-    pub description: &'static str,
+    pub description: String,
     /// Json spec type of the parameter
     #[builder(default)]
     pub ty: ParamType,

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -78,7 +78,7 @@ pub trait Tool: Send + Sync + DynClone {
         raw_args: Option<&str>,
     ) -> Result<ToolOutput, ToolError>;
 
-    fn name<'a>(&'a self) -> Cow<'a, str>;
+    fn name(&self) -> Cow<'_, str>;
 
     fn tool_spec(&self) -> ToolSpec;
 
@@ -99,7 +99,7 @@ impl Tool for Box<dyn Tool> {
     ) -> Result<ToolOutput, ToolError> {
         (**self).invoke(agent_context, raw_args).await
     }
-    fn name<'a>(&'a self) -> Cow<'a, str> {
+    fn name(&self) -> Cow<'_, str> {
         (**self).name()
     }
     fn tool_spec(&self) -> ToolSpec {

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -69,6 +69,14 @@ impl From<CommandOutput> for ToolOutput {
     }
 }
 
+/// The `Tool` trait is the main interface for chat completion and agent tools.
+///
+/// `swiftide-macros` provides a set of macros to generate implementations of this trait. If you
+/// need more control over the implementation, you can implement the trait manually.
+///
+/// The `ToolSpec` is what will end up with the LLM. A builder is provided. The `name` is expected
+/// to be unique, and is used to identify the tool. It should be the same as the name in the
+/// `ToolSpec`.
 #[async_trait]
 pub trait Tool: Send + Sync + DynClone {
     // tbd
@@ -108,16 +116,6 @@ impl Tool for Box<dyn Tool> {
 }
 
 dyn_clone::clone_trait_object!(Tool);
-
-// impl<T> From<T> for Box<dyn Tool + '_>
-// where
-//     for<'b> T: Tool + 'b,
-// {
-//     fn from(value: T) -> Self {
-//         // dyn_clone::clone_box(&value)
-//         Box::new(value)
-//     }
-// }
 
 /// Tools are identified and unique by name
 /// These allow comparison and lookups

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use dyn_clone::DynClone;
+use std::borrow::Cow;
 
 use crate::{AgentContext, CommandOutput};
 
@@ -77,7 +78,7 @@ pub trait Tool: Send + Sync + DynClone {
         raw_args: Option<&str>,
     ) -> Result<ToolOutput, ToolError>;
 
-    fn name(&self) -> &'static str;
+    fn name<'a>(&'a self) -> Cow<'a, str>;
 
     fn tool_spec(&self) -> ToolSpec;
 
@@ -98,7 +99,7 @@ impl Tool for Box<dyn Tool> {
     ) -> Result<ToolOutput, ToolError> {
         (**self).invoke(agent_context, raw_args).await
     }
-    fn name(&self) -> &'static str {
+    fn name<'a>(&'a self) -> Cow<'a, str> {
         (**self).name()
     }
     fn tool_spec(&self) -> ToolSpec {

--- a/swiftide-integrations/src/anthropic/chat_completion.rs
+++ b/swiftide-integrations/src/anthropic/chat_completion.rs
@@ -159,13 +159,13 @@ fn tools_to_anthropic(
             json!({
 
                         "type": param.ty.as_ref(),
-                        "description": param.description,
+                        "description": &param.description,
             }),
         );
     }
     let mut map = json!({
-        "name": spec.name,
-        "description": spec.description,
+        "name": &spec.name,
+        "description": &spec.description,
     })
     .as_object_mut()
     .context("Failed to build tool")?
@@ -175,7 +175,7 @@ fn tools_to_anthropic(
         .parameters
         .iter()
         .filter(|param| param.required)
-        .map(|param| param.name)
+        .map(|param| &param.name)
         .collect::<Vec<_>>();
 
     map.insert(
@@ -220,8 +220,8 @@ mod tests {
             todo!()
         }
 
-        fn name(&self) -> &'static str {
-            "get_weather"
+        fn name<'tool>(&'tool self) -> std::borrow::Cow<'tool, str> {
+            "get_weather".into()
         }
 
         fn tool_spec(&self) -> ToolSpec {

--- a/swiftide-integrations/src/anthropic/chat_completion.rs
+++ b/swiftide-integrations/src/anthropic/chat_completion.rs
@@ -220,7 +220,7 @@ mod tests {
             todo!()
         }
 
-        fn name<'tool>(&'tool self) -> std::borrow::Cow<'tool, str> {
+        fn name(&self) -> std::borrow::Cow<'_, str> {
             "get_weather".into()
         }
 

--- a/swiftide-integrations/src/ollama/chat_completion.rs
+++ b/swiftide-integrations/src/ollama/chat_completion.rs
@@ -116,7 +116,7 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
             param.name.to_string(),
             json!({
                 "type": param.ty.as_ref(),
-                "description": param.description,
+                "description": &param.description,
             }),
         );
     }
@@ -124,12 +124,12 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
     ChatCompletionToolArgs::default()
         .r#type(ChatCompletionToolType::Function)
         .function(FunctionObjectArgs::default()
-            .name(spec.name)
-            .description(spec.description)
+            .name(&spec.name)
+            .description(&spec.description)
             .parameters(json!({
                 "type": "object",
                 "properties": properties,
-                "required": spec.parameters.iter().filter(|param| param.required).map(|param| param.name).collect_vec(),
+                "required": spec.parameters.iter().filter(|param| param.required).map(|param| &param.name).collect_vec(),
                 "additionalProperties": false,
             })).build()?).build()
         .map_err(anyhow::Error::from)

--- a/swiftide-integrations/src/open_router/chat_completion.rs
+++ b/swiftide-integrations/src/open_router/chat_completion.rs
@@ -116,7 +116,7 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
             param.name.to_string(),
             json!({
                 "type": param.ty.as_ref(),
-                "description": param.description,
+                "description": &param.description,
             }),
         );
     }
@@ -124,12 +124,12 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
     ChatCompletionToolArgs::default()
         .r#type(ChatCompletionToolType::Function)
         .function(FunctionObjectArgs::default()
-            .name(spec.name)
-            .description(spec.description)
+            .name(&spec.name)
+            .description(&spec.description)
             .parameters(json!({
                 "type": "object",
                 "properties": properties,
-                "required": spec.parameters.iter().filter(|param| param.required).map(|param| param.name).collect_vec(),
+                "required": spec.parameters.iter().filter(|param| param.required).map(|param| &param.name).collect_vec(),
                 "additionalProperties": false,
             })).build()?).build()
         .map_err(anyhow::Error::from)

--- a/swiftide-integrations/src/openai/chat_completion.rs
+++ b/swiftide-integrations/src/openai/chat_completion.rs
@@ -118,7 +118,7 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
             param.name.to_string(),
             json!({
                 "type": param.ty.as_ref(),
-                "description": param.description,
+                "description": &param.description,
             }),
         );
     }
@@ -126,13 +126,13 @@ fn tools_to_openai(spec: &ToolSpec) -> Result<ChatCompletionTool> {
     ChatCompletionToolArgs::default()
         .r#type(ChatCompletionToolType::Function)
         .function(FunctionObjectArgs::default()
-            .name(spec.name)
-            .description(spec.description)
+            .name(&spec.name)
+            .description(&spec.description)
             .strict(true)
             .parameters(json!({
                 "type": "object",
                 "properties": properties,
-                "required": spec.parameters.iter().filter(|param| param.required).map(|param| param.name).collect_vec(),
+                "required": spec.parameters.iter().filter(|param| param.required).map(|param| &param.name).collect_vec(),
                 "additionalProperties": false,
             })).build()?).build()
         .map_err(anyhow::Error::from)

--- a/swiftide-macros/src/tool/mod.rs
+++ b/swiftide-macros/src/tool/mod.rs
@@ -220,8 +220,8 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
                 #invoke_body
             }
 
-            fn name(&self) -> &'static str {
-                #tool_name
+            fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
+                #tool_name.into()
             }
 
             fn tool_spec(&self) -> ::swiftide::chat_completion::ToolSpec {
@@ -321,8 +321,8 @@ pub(crate) fn tool_derive_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
                 #invoke_body
             }
 
-            fn name(&self) -> &'static str {
-                #expected_fn_name
+            fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
+                #expected_fn_name.into()
             }
 
             fn tool_spec(&self) -> swiftide::chat_completion::ToolSpec {

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive.snap
@@ -14,8 +14,8 @@ impl swiftide::chat_completion::Tool for HelloDerive {
     > {
         return self.hello_derive(agent_context).await;
     }
-    fn name(&self) -> &'static str {
-        "hello_derive"
+    fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
+        "hello_derive".into()
     }
     fn tool_spec(&self) -> swiftide::chat_completion::ToolSpec {
         swiftide::chat_completion::ToolSpec::builder()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
@@ -30,8 +30,8 @@ impl swiftide::chat_completion::Tool for HelloDerive {
         let args: HelloDeriveArgs = ::swiftide::reexports::serde_json::from_str(&args)?;
         return self.hello_derive(agent_context, &args.test).await;
     }
-    fn name(&self) -> &'static str {
-        "hello_derive"
+    fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
+        "hello_derive".into()
     }
     fn tool_spec(&self) -> swiftide::chat_completion::ToolSpec {
         swiftide::chat_completion::ToolSpec::builder()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
@@ -30,8 +30,8 @@ impl<'a> swiftide::chat_completion::Tool for HelloDerive<'a> {
         let args: HelloDeriveArgs = ::swiftide::reexports::serde_json::from_str(&args)?;
         return self.hello_derive(agent_context, &args.test).await;
     }
-    fn name(&self) -> &'static str {
-        "hello_derive"
+    fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
+        "hello_derive".into()
     }
     fn tool_spec(&self) -> swiftide::chat_completion::ToolSpec {
         swiftide::chat_completion::ToolSpec::builder()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
@@ -45,8 +45,8 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
         let args: SearchCodeArgs = ::swiftide::reexports::serde_json::from_str(&args)?;
         return self.search_code(agent_context, &args.code_query, &args.other).await;
     }
-    fn name(&self) -> &'static str {
-        "search_code"
+    fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
+        "search_code".into()
     }
     fn tool_spec(&self) -> ::swiftide::chat_completion::ToolSpec {
         swiftide::chat_completion::ToolSpec::builder()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
@@ -43,8 +43,8 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
         let args: SearchCodeArgs = ::swiftide::reexports::serde_json::from_str(&args)?;
         return self.search_code(agent_context, &args.code_query).await;
     }
-    fn name(&self) -> &'static str {
-        "search_code"
+    fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
+        "search_code".into()
     }
     fn tool_spec(&self) -> ::swiftide::chat_completion::ToolSpec {
         swiftide::chat_completion::ToolSpec::builder()


### PR DESCRIPTION
Previously ToolSpec and name in the `Tool` trait worked with static. With these changes, there is a lot more flexibility, allowing for i.e. run-time tool generation.
