### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.0](https://github.com/bosun-ai/swiftide/compare/v0.20.1...v0.21.0) - 2025-02-25
+
+### New features
+
+- [12a9873](https://github.com/bosun-ai/swiftide/commit/12a98736ab171c25d860000bb95b1e6e318758fb) *(agents)*  Improve flexibility for tool generation (#641)
+
+````text
+Previously ToolSpec and name in the `Tool` trait worked with static.
+  With these changes, there is a lot more flexibility, allowing for i.e.
+  run-time tool generation.
+````
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.20.1...0.21.0
+
+
+
 ## [0.20.1](https://github.com/bosun-ai/swiftide/compare/v0.20.0...v0.20.1) - 2025-02-21
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8395,7 +8395,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8423,7 +8423,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8447,7 +8447,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8475,7 +8475,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8496,7 +8496,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8525,7 +8525,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8588,7 +8588,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8610,7 +8610,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8631,7 +8631,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.21.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.20" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.20" }
+swiftide-core = { path = "../swiftide-core", version = "0.21" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.21" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.20" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.20" }
+swiftide-core = { path = "../swiftide-core", version = "0.21" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.21" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.20" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.20" }
+swiftide-core = { path = "../swiftide-core", version = "0.21" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.21" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.20.1" }
+swiftide-core = { path = "../swiftide-core/", version = "0.21.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.20.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.21.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.20" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.20" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.20" }
-swiftide-query = { path = "../swiftide-query", version = "0.20" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.20", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.21" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.21" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.21" }
+swiftide-query = { path = "../swiftide-query", version = "0.21" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.21", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide`: 0.20.1 -> 0.21.0 (✓ API compatible changes)
* `swiftide-agents`: 0.20.1 -> 0.21.0 (✓ API compatible changes)
* `swiftide-core`: 0.20.1 -> 0.21.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.20.1 -> 0.21.0
* `swiftide-indexing`: 0.20.1 -> 0.21.0
* `swiftide-integrations`: 0.20.1 -> 0.21.0 (✓ API compatible changes)
* `swiftide-query`: 0.20.1 -> 0.21.0

### ⚠ `swiftide-core` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_core::chat_completion::ParamSpecBuilder::name takes 1 generic types instead of 0, in /tmp/.tmpTsAOzW/swiftide/swiftide-core/src/chat_completion/tools.rs:125
  swiftide_core::chat_completion::ParamSpecBuilder::description takes 1 generic types instead of 0, in /tmp/.tmpTsAOzW/swiftide/swiftide-core/src/chat_completion/tools.rs:125
  swiftide_core::chat_completion::ParamSpecBuilder::ty takes 1 generic types instead of 0, in /tmp/.tmpTsAOzW/swiftide/swiftide-core/src/chat_completion/tools.rs:125
  swiftide_core::chat_completion::ParamSpecBuilder::required takes 1 generic types instead of 0, in /tmp/.tmpTsAOzW/swiftide/swiftide-core/src/chat_completion/tools.rs:125
  swiftide_core::chat_completion::ToolSpecBuilder::name takes 1 generic types instead of 0, in /tmp/.tmpTsAOzW/swiftide/swiftide-core/src/chat_completion/tools.rs:92
  swiftide_core::chat_completion::ToolSpecBuilder::description takes 1 generic types instead of 0, in /tmp/.tmpTsAOzW/swiftide/swiftide-core/src/chat_completion/tools.rs:92
  swiftide_core::chat_completion::ToolSpecBuilder::parameters takes 1 generic types instead of 0, in /tmp/.tmpTsAOzW/swiftide/swiftide-core/src/chat_completion/tools.rs:92
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `swiftide`

<blockquote>

## [0.21.0](https://github.com/bosun-ai/swiftide/compare/v0.20.1...v0.21.0) - 2025-02-25

### New features

- [12a9873](https://github.com/bosun-ai/swiftide/commit/12a98736ab171c25d860000bb95b1e6e318758fb) *(agents)*  Improve flexibility for tool generation (#641)

````text
Previously ToolSpec and name in the `Tool` trait worked with static.
  With these changes, there is a lot more flexibility, allowing for i.e.
  run-time tool generation.
````

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.20.1...0.21.0
</blockquote>








</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).