### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.1](https://github.com/bosun-ai/swiftide/compare/v0.21.0...v0.21.1) - 2025-02-28
+
+### Bug fixes
+
+- [f418c5e](https://github.com/bosun-ai/swiftide/commit/f418c5ee2f0d3ee87fb3715ec6b1d7ecc80bf714) *(ci)*  Run just a single real rerank test to please the flaky gods
+
+- [e387e82](https://github.com/bosun-ai/swiftide/commit/e387e826200e1bc0a608e1f680537751cfc17969) *(lancedb)*  Update Lancedb to 0.17 and pin Arrow to a lower version
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.21.0...0.21.1
+
+
+
 ## [0.21.0](https://github.com/bosun-ai/swiftide/compare/v0.20.1...v0.21.0) - 2025-02-25
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8319,7 +8319,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8347,7 +8347,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8371,7 +8371,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8399,7 +8399,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8420,7 +8420,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8512,7 +8512,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8534,7 +8534,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8555,7 +8555,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
 resolver = "2"
 
 [workspace.package]
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.21.0" }
+swiftide-core = { path = "../swiftide-core/", version = "0.21.1" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.21.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.21.1" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.21.0 -> 0.21.1 (✓ API compatible changes)
* `swiftide-macros`: 0.21.0 -> 0.21.1
* `swiftide-agents`: 0.21.0 -> 0.21.1
* `swiftide-indexing`: 0.21.0 -> 0.21.1
* `swiftide-integrations`: 0.21.0 -> 0.21.1 (✓ API compatible changes)
* `swiftide-query`: 0.21.0 -> 0.21.1
* `swiftide`: 0.21.0 -> 0.21.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.21.1](https://github.com/bosun-ai/swiftide/compare/v0.21.0...v0.21.1) - 2025-02-28

### Bug fixes

- [f418c5e](https://github.com/bosun-ai/swiftide/commit/f418c5ee2f0d3ee87fb3715ec6b1d7ecc80bf714) *(ci)*  Run just a single real rerank test to please the flaky gods

- [e387e82](https://github.com/bosun-ai/swiftide/commit/e387e826200e1bc0a608e1f680537751cfc17969) *(lancedb)*  Update Lancedb to 0.17 and pin Arrow to a lower version

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.21.0...0.21.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).