### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.0](https://github.com/bosun-ai/swiftide/compare/v0.21.1...v0.22.0) - 2025-03-03
+
+### New features
+
+- [a754846](https://github.com/bosun-ai/swiftide/commit/a7548463367023d3e5a3a25dd84f06632b372f18) *(agents)*  Implement Serialize and Deserialize for chat messages
+
+````text
+Persist, retry later, evaluate it completions in a script, you name it.
+````
+
+- [0a592c6](https://github.com/bosun-ai/swiftide/commit/0a592c67621f3eba4ad6e0bfd5a539e19963cf17) *(indexing)*  Add `iter()` for file loader ([#655](https://github.com/bosun-ai/swiftide/pull/655))
+
+````text
+Allows playing with the iterator outside of the stream.
+
+  Relates to https://github.com/bosun-ai/kwaak/issues/337
+````
+
+- [57116e9](https://github.com/bosun-ai/swiftide/commit/57116e9a30c722f47398be61838cc1ef4d0bbfac)  Groq ChatCompletion ([#650](https://github.com/bosun-ai/swiftide/pull/650))
+
+````text
+Use the new generics to _just-make-it-work_.
+````
+
+- [4fd3259](https://github.com/bosun-ai/swiftide/commit/4fd325921555a14552e33b2481bc9dfcf0c313fc)  Continue Agent on Tool Failure ([#628](https://github.com/bosun-ai/swiftide/pull/628))
+
+````text
+Ensure tool calls and responses are always balanced, even when the tool retry limit is reached
+  https://github.com/bosun-ai/kwaak/issues/313
+````
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.21.1...0.22.0
+
+
+
 ## [0.21.1](https://github.com/bosun-ai/swiftide/compare/v0.21.0...v0.21.1) - 2025-02-28
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8319,7 +8319,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8347,7 +8347,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8371,7 +8371,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8399,7 +8399,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8420,7 +8420,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8449,7 +8449,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -8512,7 +8512,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8534,7 +8534,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8555,7 +8555,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["swiftide", "swiftide-*", "examples", "benchmarks"]
 resolver = "2"
 
 [workspace.package]
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.21" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.21" }
+swiftide-core = { path = "../swiftide-core", version = "0.22" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.22" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.21" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.21" }
+swiftide-core = { path = "../swiftide-core", version = "0.22" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.22" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.21" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.21" }
+swiftide-core = { path = "../swiftide-core", version = "0.22" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.22" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.21.1" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.21.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.21" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.21" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.21" }
-swiftide-query = { path = "../swiftide-query", version = "0.21" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.21", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.22" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.22" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.22" }
+swiftide-query = { path = "../swiftide-query", version = "0.22" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.22", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `swiftide-macros`: 0.21.1 -> 0.22.0
* `swiftide-agents`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `swiftide-indexing`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.21.1 -> 0.22.0 (⚠ API breaking changes)
* `swiftide-query`: 0.21.1 -> 0.22.0 (✓ API compatible changes)
* `swiftide`: 0.21.1 -> 0.22.0 (✓ API compatible changes)

### ⚠ `swiftide-integrations` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_missing.ron

Failed in:
  enum swiftide_integrations::groq::GroqBuilderError, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/groq/mod.rs:23
  enum swiftide_integrations::openai::OpenAIBuilderError, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/openai/mod.rs:38
  enum swiftide_integrations::groq::OptionsBuilderError, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/groq/mod.rs:46

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_missing.ron

Failed in:
  struct swiftide_integrations::groq::GroqBuilder, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/groq/mod.rs:23
  struct swiftide_integrations::openai::OpenAIBuilder, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/openai/mod.rs:38
  struct swiftide_integrations::groq::OptionsBuilder, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/groq/mod.rs:46
  struct swiftide_integrations::groq::Groq, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/groq/mod.rs:25
  struct swiftide_integrations::openai::OpenAI, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/openai/mod.rs:40
  struct swiftide_integrations::groq::Options, previously in file /tmp/.tmp04qAim/swiftide-integrations/src/groq/mod.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.0](https://github.com/bosun-ai/swiftide/compare/v0.21.1...v0.22.0) - 2025-03-03

### New features

- [a754846](https://github.com/bosun-ai/swiftide/commit/a7548463367023d3e5a3a25dd84f06632b372f18) *(agents)*  Implement Serialize and Deserialize for chat messages

````text
Persist, retry later, evaluate it completions in a script, you name it.
````

- [0a592c6](https://github.com/bosun-ai/swiftide/commit/0a592c67621f3eba4ad6e0bfd5a539e19963cf17) *(indexing)*  Add `iter()` for file loader ([#655](https://github.com/bosun-ai/swiftide/pull/655))

````text
Allows playing with the iterator outside of the stream.

  Relates to https://github.com/bosun-ai/kwaak/issues/337
````

- [57116e9](https://github.com/bosun-ai/swiftide/commit/57116e9a30c722f47398be61838cc1ef4d0bbfac)  Groq ChatCompletion ([#650](https://github.com/bosun-ai/swiftide/pull/650))

````text
Use the new generics to _just-make-it-work_.
````

- [4fd3259](https://github.com/bosun-ai/swiftide/commit/4fd325921555a14552e33b2481bc9dfcf0c313fc)  Continue Agent on Tool Failure ([#628](https://github.com/bosun-ai/swiftide/pull/628))

````text
Ensure tool calls and responses are always balanced, even when the tool retry limit is reached
  https://github.com/bosun-ai/kwaak/issues/313
````

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.21.1...0.22.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).