### PR TITLE
feat: Agent mcp client support 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9209,6 +9209,7 @@ version = "0.22.8"
 dependencies = [
  "anyhow",
  "fluvio",
+ "rmcp",
  "serde",
  "serde_json",
  "spider",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,22 +3427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eventsource-client"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80c6714d1a380314fcb11a22eeff022e1e1c9642f0bb54e15dc9cb29f37b29"
-dependencies = [
- "futures",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "hyper-timeout 0.4.1",
- "log",
- "pin-project",
- "rand 0.8.5",
- "tokio",
-]
-
-[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4664,19 +4648,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.8",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -6060,64 +6032,6 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
  "rayon",
-]
-
-[[package]]
-name = "mcp-client"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7e00680bf6bd7430397536dd07ce9027aebb2854c2270b2da1f489bc20955b"
-dependencies = [
- "anyhow",
- "async-trait",
- "eventsource-client",
- "futures",
- "mcp-spec",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tower 0.4.13",
- "tower-service",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
-name = "mcp-core"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a8e4375fe44579ffd9c7a8d682059ee33f1bf2bf36cad94cbe1ebff2e5b111"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "libc",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "mcp-spec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a294f4fcf9c3a0b3d168937947ecb906feb691089dd9fbbefc9707c8a4557163"
-dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.21.7",
- "chrono",
- "schemars",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]
@@ -7855,7 +7769,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -7912,7 +7825,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.8",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -8004,6 +7917,38 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmcp"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a0110d28bd076f39e14bfd5b0340216dd18effeb5d02b43215944cc3e5c751"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e2b2fd7497540489fa2db285edd43b7ed14c49157157438664278da6e42a7a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -9216,10 +9161,9 @@ dependencies = [
  "fs-err",
  "indoc",
  "insta",
- "mcp-client",
- "mcp-core",
- "mcp-spec",
  "mockall",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "strum 0.27.1",
@@ -9228,7 +9172,6 @@ dependencies = [
  "temp-dir",
  "test-log",
  "tokio",
- "tower-service",
  "tracing",
 ]
 
@@ -10102,16 +10045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10258,7 +10191,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-timeout 0.5.2",
+ "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
@@ -10704,7 +10637,7 @@ dependencies = [
  "serde_json",
  "socks",
  "url",
- "webpki-roots 0.26.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -10962,12 +10895,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,6 +3427,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "eventsource-client"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c80c6714d1a380314fcb11a22eeff022e1e1c9642f0bb54e15dc9cb29f37b29"
+dependencies = [
+ "futures",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "hyper-timeout 0.4.1",
+ "log",
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "eventsource-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4648,7 +4664,19 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.8",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -6032,6 +6060,64 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
  "rayon",
+]
+
+[[package]]
+name = "mcp-client"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7e00680bf6bd7430397536dd07ce9027aebb2854c2270b2da1f489bc20955b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "eventsource-client",
+ "futures",
+ "mcp-spec",
+ "rand 0.8.5",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower 0.4.13",
+ "tower-service",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "mcp-core"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a8e4375fe44579ffd9c7a8d682059ee33f1bf2bf36cad94cbe1ebff2e5b111"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "libc",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "mcp-spec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a294f4fcf9c3a0b3d168937947ecb906feb691089dd9fbbefc9707c8a4557163"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "base64 0.21.7",
+ "chrono",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -7769,6 +7855,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -7825,7 +7912,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
@@ -8160,6 +8247,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8286,6 +8397,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9094,6 +9216,9 @@ dependencies = [
  "fs-err",
  "indoc",
  "insta",
+ "mcp-client",
+ "mcp-core",
+ "mcp-spec",
  "mockall",
  "serde",
  "serde_json",
@@ -9103,6 +9228,7 @@ dependencies = [
  "temp-dir",
  "test-log",
  "tokio",
+ "tower-service",
  "tracing",
 ]
 
@@ -9976,6 +10102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10122,7 +10258,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-timeout",
+ "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
  "pin-project",
@@ -10568,7 +10704,7 @@ dependencies = [
  "serde_json",
  "socks",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -10826,6 +10962,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,10 +56,8 @@ dyn-clone = { version = "1.0", default-features = false }
 convert_case = { version = "0.8", default-features = false }
 
 # Mcp
-mcp-core = "0.1.42"
-mcp-client = "0.1.0"
-mcp-spec = "0.1.0"
-tower-service = { version = "0.3" }
+rmcp = { version = "0.1", default-features = false }
+schemars = { version = "0.8", default-features = false }
 
 # Integrations
 spider = { version = "2.34", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,12 @@ uuid = { version = "1.16", features = [
 dyn-clone = { version = "1.0", default-features = false }
 convert_case = { version = "0.8", default-features = false }
 
+# Mcp
+mcp-core = "0.1.42"
+mcp-client = "0.1.0"
+mcp-spec = "0.1.0"
+tower-service = { version = "0.3" }
+
 # Integrations
 spider = { version = "2.34", default-features = false }
 async-openai = { version = "0.28", default-features = false }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,6 +24,7 @@ swiftide = { path = "../swiftide/", features = [
   "pgvector",
   "swiftide-agents",
   "dashscope",
+  "mcp",
 ] }
 swiftide-macros = { path = "../swiftide-macros" }
 tracing-subscriber = { workspace = true }
@@ -36,6 +37,7 @@ sqlx = { workspace = true }
 swiftide-test-utils = { path = "../swiftide-test-utils" }
 tracing = { workspace = true }
 serde = { workspace = true }
+rmcp = { workspace = true, features = ["transport-child-process", "client"] }
 
 
 [[example]]
@@ -116,3 +118,7 @@ path = "dashscope.rs"
 [[example]]
 name = "reranking"
 path = "reranking.rs"
+
+[[example]]
+name = "agents-mcp"
+path = "agents_mcp_tools.rs"

--- a/examples/agents_mcp_tools.rs
+++ b/examples/agents_mcp_tools.rs
@@ -1,0 +1,73 @@
+//! This is an example of how to build a Swiftide agent with tools using the MCP protocol.
+//!
+//! The agent in this example prints all messages using a channel.
+use anyhow::Result;
+use rmcp::{
+    model::{ClientInfo, Implementation},
+    transport::TokioChildProcess,
+    ServiceExt as _,
+};
+use swiftide::agents::{self, tools::mcp::McpToolbox};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("Hello, agents!");
+
+    let openai = swiftide::integrations::openai::OpenAI::builder()
+        .default_embed_model("text-embeddings-3-small")
+        .default_prompt_model("gpt-4o-mini")
+        .build()?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+    tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            println!("{}", msg);
+        }
+    });
+
+    // First set up our client info to identify ourselves to the server
+    let client_info = ClientInfo {
+        client_info: Implementation {
+            name: "swiftide-example".into(),
+            version: env!("CARGO_PKG_VERSION").into(),
+        },
+        ..Default::default()
+    };
+
+    // Use `rmcp` to start the server
+    let running_service = client_info
+        .serve(TokioChildProcess::new(
+            &mut tokio::process::Command::new("npx")
+                .args(["-y", "@modelcontextprotocol/server-everything"]),
+        )?)
+        .await?;
+
+    // Create a toolbox from the running server, and only use the `add` tool
+    //
+    // A toolbox reveals it's tools to the swiftide agent the first time it starts (if the state of
+    // the agent was pending). You can add as many toolboxes as you want. MCP services are an
+    // implmenentation of a toolbox. A list of tools is another.
+    let everything_toolbox = McpToolbox::from_running_service(running_service)
+        .with_whitelist(["add"])
+        .to_owned();
+
+    agents::Agent::builder()
+        .llm(&openai)
+        // Add the toolbox to the agent
+        .add_toolbox(everything_toolbox)
+        // Every message added by the agent will be printed to stdout
+        .on_new_message(move |_, msg| {
+            let msg = msg.to_string();
+            let tx = tx.clone();
+            Box::pin(async move {
+                tx.send(msg).unwrap();
+                Ok(())
+            })
+        })
+        .build()?
+        .query("Use the add tool to add 1 and 2")
+        .await?;
+
+    Ok(())
+}

--- a/examples/agents_mcp_tools.rs
+++ b/examples/agents_mcp_tools.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
     // Use `rmcp` to start the server
     let running_service = client_info
         .serve(TokioChildProcess::new(
-            &mut tokio::process::Command::new("npx")
+            tokio::process::Command::new("npx")
                 .args(["-y", "@modelcontextprotocol/server-everything"]),
         )?)
         .await?;

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -25,6 +25,10 @@ strum_macros.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
+mcp-core = { workspace = true }
+mcp-client = { workspace = true }
+mcp-spec = { workspace = true }
+tower-service = { workspace = true }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }
@@ -40,3 +44,6 @@ workspace = true
 all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["--cfg", "docsrs"]
+
+[features]
+mcp = []

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -27,10 +27,11 @@ serde_json.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
 
 # Mcp
-mcp-core = { workspace = true, optional = true }
-mcp-client = { workspace = true, optional = true }
-mcp-spec = { workspace = true, optional = true }
-tower-service = { workspace = true, optional = true }
+rmcp = { workspace = true, optional = true, default-features = false, features = [
+  "base64",
+  "client",
+  "macros",
+] }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }
@@ -38,6 +39,8 @@ mockall.workspace = true
 test-log.workspace = true
 temp-dir.workspace = true
 insta.workspace = true
+rmcp = { workspace = true, features = ["server"] }
+schemars = { workspace = true }
 
 [lints]
 workspace = true
@@ -48,4 +51,4 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-mcp = ["dep:mcp-core", "dep:mcp-client", "dep:mcp-spec", "dep:tower-service"]
+mcp = ["dep:rmcp"]

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -25,10 +25,12 @@ strum_macros.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 fs-err = { workspace = true, features = ["tokio"] }
-mcp-core = { workspace = true }
-mcp-client = { workspace = true }
-mcp-spec = { workspace = true }
-tower-service = { workspace = true }
+
+# Mcp
+mcp-core = { workspace = true, optional = true }
+mcp-client = { workspace = true, optional = true }
+mcp-spec = { workspace = true, optional = true }
+tower-service = { workspace = true, optional = true }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }
@@ -46,4 +48,4 @@ cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-mcp = []
+mcp = ["dep:mcp-core", "dep:mcp-client", "dep:mcp-spec", "dep:tower-service"]

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -246,6 +246,8 @@ impl AgentBuilder {
     /// Add a toolbox to the agent. Toolboxes are collections of tools that can be added to the
     /// to the agent. Available tools are evaluated at runtime, when the agent starts for the first
     /// time.
+    ///
+    /// Agents can have many toolboxes.
     pub fn add_toolbox(&mut self, toolbox: impl ToolBox + 'static) -> &mut Self {
         self.toolboxes.get_or_insert_with(Vec::new);
 
@@ -514,12 +516,12 @@ impl Agent {
                 let stop = self.tool_calls_over_limit(&tool_call);
                 if stop {
                     tracing::error!(
-                        "Tool call failed, retry limit reached, stopping agent: {err}",
-                        err = error
+                        ?error,
+                        "Tool call failed, retry limit reached, stopping agent: {error}",
                     );
                 } else {
                     tracing::warn!(
-                        error = error.to_string(),
+                        ?error,
                         tool_call = ?tool_call,
                         "Tool call failed, retrying",
                     );

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -639,7 +639,7 @@ impl Agent {
 
     async fn load_toolboxes(&mut self) -> Result<()> {
         for toolbox in &self.toolboxes {
-            let tools = toolbox.available_tools().await;
+            let tools = toolbox.available_tools().await?;
             self.toolbox_tools.extend(tools);
         }
 

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
-use anyhow::Context as _;
+use anyhow::{Context as _, Result};
 use async_trait::async_trait;
 use mcp_client::{transport::Error, McpClientTrait as _, Transport};
 use mcp_spec::{protocol::JsonRpcMessage, Content};
@@ -59,13 +59,14 @@ where
         <S as tower_service::Service<mcp_spec::protocol::JsonRpcMessage>>::Error,
     >,
 {
-    async fn available_tools(&self) -> Vec<Box<dyn Tool>> {
+    #[tracing::instrument(skip_all)]
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
         let tools = match self.client.list_tools(None).await {
             Ok(tools) => tools,
             Err(e) => {
                 // Probably should return the error instead but it is late
                 tracing::error!("Failed to list tools: {:?}", e);
-                return vec![];
+                return Ok(vec![]);
             }
         };
 
@@ -73,7 +74,8 @@ where
             .tools
             .into_iter()
             .map(|t| {
-                let schema: ToolInputSchema = serde_json::from_value(t.input_schema).unwrap();
+                let schema: ToolInputSchema = serde_json::from_value(t.input_schema)
+                    .context("Failed to parse tool input schema")?;
 
                 let mut tool_spec = ToolSpec::builder()
                     .name(t.name.clone())
@@ -83,27 +85,35 @@ where
 
                 if let Some(p) = schema.properties {
                     let param = ParamSpec::builder()
-                        .name(p.get("name").unwrap().to_string())
-                        .description(p.get("description").unwrap().to_string())
+                        .name(
+                            p.get("name")
+                                .and_then(serde_json::Value::as_str)
+                                .context("No name for param")?,
+                        )
+                        .description(
+                            p.get("description")
+                                .and_then(serde_json::Value::as_str)
+                                .unwrap_or_default(),
+                        )
                         .ty(p.get("type").map_or(ParamType::String, |t| {
                             serde_json::from_value(t.clone()).unwrap_or(ParamType::String)
                         }))
                         .build()
-                        .unwrap();
+                        .context("Failed to build parameters")?;
 
                     parameters.push(param);
                 }
 
                 tool_spec.parameters(parameters);
-                let tool_spec = tool_spec.build().unwrap();
+                let tool_spec = tool_spec.build().context("Failed to build tool spec")?;
 
-                Box::new(McpTool {
+                Ok(Box::new(McpTool {
                     client: self.client.clone(),
                     tool_name: t.name.clone(),
                     tool_spec,
-                }) as Box<dyn Tool>
+                }) as Box<dyn Tool>)
             })
-            .collect()
+            .collect::<Result<Vec<_>>>()
     }
 }
 

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -29,12 +29,8 @@ pub enum ToolFilter {
 
 /// Connects to an MCP server and provides tools at runtime to the agent.
 ///
-/// # Example
-///
-/// ```no_run
-///
-///
-/// ```
+/// WARN: The rmcp has a quirky feature to serve from `()`. This does not work; serve from
+/// `ClientInfo` instead, or from the transport and `Swiftide` will handle the rest.
 #[derive(Clone)]
 pub struct McpToolbox {
     service: Arc<RunningService<RoleClient, InitializeRequestParam>>,

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -1,80 +1,131 @@
+//! Add tools provided by an MCP server to an agent
+//!
+//! Uses the `rmcp` crate to connect to an MCP server and list available tools, and invoke them
+//!
+//! Supports any transport that the `rmcp` crate supports
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
-use mcp_client::{transport::Error, McpClientTrait as _, Transport};
-use mcp_spec::{protocol::JsonRpcMessage, Content};
+use derive_builder::Builder;
+use rmcp::model::{ClientCapabilities, ClientInfo, Implementation, InitializeRequestParam};
+use rmcp::service::RunningService;
+use rmcp::transport::IntoTransport;
+use rmcp::{model::CallToolRequestParam, ServiceExt};
+use rmcp::{RoleClient, Service};
 use serde::Deserialize;
 use serde_json::{json, Value};
 use swiftide_core::{
     chat_completion::{errors::ToolError, ParamSpec, ParamType, ToolSpec},
     Tool, ToolBox,
 };
-use tower_service::Service;
 
-#[derive(Clone)]
-struct McpClient<S>
-where
-    S: Service<JsonRpcMessage, Response = JsonRpcMessage> + Clone + Send + Sync + 'static,
-    S::Error: Into<Error>,
-    S::Future: Send,
-    mcp_client::Error: std::convert::From<
-        <S as tower_service::Service<mcp_spec::protocol::JsonRpcMessage>>::Error,
-    >,
-{
-    client: Arc<mcp_client::client::McpClient<S>>,
+enum Filter {
+    Blacklist(Vec<String>),
+    Whitelist(Vec<String>),
 }
 
-impl<S> McpClient<S>
-where
-    S: Service<JsonRpcMessage, Response = JsonRpcMessage> + Clone + Send + Sync + 'static,
-    S::Error: Into<Error>,
-    S::Future: Send,
-    mcp_client::Error: std::convert::From<
-        <S as tower_service::Service<mcp_spec::protocol::JsonRpcMessage>>::Error,
-    >,
-{
-    pub fn from_client(client: impl Into<Arc<mcp_client::client::McpClient<S>>>) -> Self {
+/// A client for an MCP server
+///
+/// # Example
+///
+/// ```no_run
+///
+///
+///
+/// ```
+#[derive(Clone)]
+pub struct McpClient {
+    client: Arc<RunningService<RoleClient, InitializeRequestParam>>,
+    filter: Arc<Option<Filter>>,
+}
+
+impl McpClient {
+    /// Blacklist tools by name, the agent will not be able to use these tools
+    pub fn with_blacklist<ITEM: Into<String>, I: IntoIterator<Item = ITEM>>(
+        &mut self,
+        blacklist: I,
+    ) -> &mut Self {
+        let list = blacklist.into_iter().map(Into::into).collect::<Vec<_>>();
+        self.filter = Some(Filter::Blacklist(list)).into();
+        self
+    }
+
+    /// Whitelist tools by name, the agent will only be able to use these tools
+    pub fn with_whitelist<ITEM: Into<String>, I: IntoIterator<Item = ITEM>>(
+        &mut self,
+        blacklist: I,
+    ) -> &mut Self {
+        let list = blacklist.into_iter().map(Into::into).collect::<Vec<_>>();
+        self.filter = Some(Filter::Whitelist(list)).into();
+        self
+    }
+
+    /// Create a new client from a transport
+    ///
+    /// # Errors
+    ///
+    /// Errors if the transport fails to connect
+    pub async fn try_from_transport<
+        E: std::error::Error + From<std::io::Error> + Send + Sync + 'static,
+        A,
+    >(
+        transport: impl IntoTransport<RoleClient, E, A>,
+    ) -> Result<Self> {
+        let info = Self::default_client_info();
+        let client = Arc::new(info.serve(transport).await?);
+
+        Ok(Self {
+            client,
+            filter: None.into(),
+        })
+    }
+
+    /// Create a new client from a running service
+    pub fn from_running_service(
+        client: impl Into<Arc<RunningService<RoleClient, InitializeRequestParam>>>,
+    ) -> Self {
         Self {
             client: client.into(),
+            filter: None.into(),
+        }
+    }
+
+    fn default_client_info() -> ClientInfo {
+        ClientInfo {
+            client_info: Implementation {
+                name: "swiftide".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+            },
+            ..Default::default()
         }
     }
 }
 
-// wtf nice schema bro
 #[derive(Deserialize)]
 struct ToolInputSchema {
-    pub type_: String,
+    #[serde(rename = "type")]
+    #[allow(dead_code)]
+    pub type_: String, // This _must_ be object
     pub properties: Option<HashMap<String, Value>>,
     pub required: Option<Vec<String>>,
 }
 
 #[async_trait]
-impl<S> ToolBox for McpClient<S>
-where
-    S: Service<JsonRpcMessage, Response = JsonRpcMessage> + Clone + Send + Sync + 'static,
-    S::Error: Into<Error>,
-    S::Future: Send,
-    mcp_client::Error: std::convert::From<
-        <S as tower_service::Service<mcp_spec::protocol::JsonRpcMessage>>::Error,
-    >,
-{
+impl ToolBox for McpClient {
     #[tracing::instrument(skip_all)]
     async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
-        let tools = match self.client.list_tools(None).await {
-            Ok(tools) => tools,
-            Err(e) => {
-                // Probably should return the error instead but it is late
-                tracing::error!("Failed to list tools: {:?}", e);
-                return Ok(vec![]);
-            }
-        };
+        let tools = self
+            .client
+            .list_tools(None)
+            .await
+            .context("Failed to list tools")?;
 
-        tools
+        let tools = tools
             .tools
             .into_iter()
             .map(|t| {
-                let schema: ToolInputSchema = serde_json::from_value(t.input_schema)
+                let schema: ToolInputSchema = serde_json::from_value(t.schema_as_json_value())
                     .context("Failed to parse tool input schema")?;
 
                 let mut tool_spec = ToolSpec::builder()
@@ -84,24 +135,24 @@ where
                 let mut parameters = Vec::new();
 
                 if let Some(p) = schema.properties {
-                    let param = ParamSpec::builder()
-                        .name(
-                            p.get("name")
-                                .and_then(serde_json::Value::as_str)
-                                .context("No name for param")?,
-                        )
-                        .description(
-                            p.get("description")
-                                .and_then(serde_json::Value::as_str)
-                                .unwrap_or_default(),
-                        )
-                        .ty(p.get("type").map_or(ParamType::String, |t| {
-                            serde_json::from_value(t.clone()).unwrap_or(ParamType::String)
-                        }))
-                        .build()
-                        .context("Failed to build parameters")?;
+                    for (name, value) in &p {
+                        let param = ParamSpec::builder()
+                            .name(name)
+                            .description(
+                                value
+                                    .get("description")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or(""),
+                            )
+                            .ty(value.get("type").map_or(ParamType::String, |t| {
+                                serde_json::from_value(t.clone()).unwrap_or(ParamType::String)
+                            }))
+                            .build()
+                            .context("Failed to build parameters")
+                            .unwrap();
 
-                    parameters.push(param);
+                        parameters.push(param);
+                    }
                 }
 
                 tool_spec.parameters(parameters);
@@ -109,39 +160,44 @@ where
 
                 Ok(Box::new(McpTool {
                     client: self.client.clone(),
-                    tool_name: t.name.clone(),
+                    tool_name: t.name.into(),
                     tool_spec,
                 }) as Box<dyn Tool>)
             })
-            .collect::<Result<Vec<_>>>()
+            .collect::<Result<Vec<_>>>()?;
+
+        if let Some(filter) = self.filter.as_ref() {
+            match filter {
+                Filter::Blacklist(blacklist) => {
+                    let blacklist = blacklist.iter().map(String::as_str).collect::<Vec<_>>();
+                    Ok(tools
+                        .into_iter()
+                        .filter(|t| !blacklist.contains(&t.name().as_ref()))
+                        .collect())
+                }
+                Filter::Whitelist(whitelist) => {
+                    let whitelist = whitelist.iter().map(String::as_str).collect::<Vec<_>>();
+                    Ok(tools
+                        .into_iter()
+                        .filter(|t| whitelist.contains(&t.name().as_ref()))
+                        .collect())
+                }
+            }
+        } else {
+            Ok(tools)
+        }
     }
 }
 
 #[derive(Clone)]
-struct McpTool<S>
-where
-    S: Service<JsonRpcMessage, Response = JsonRpcMessage> + Clone + Send + Sync + 'static,
-    S::Error: Into<Error>,
-    S::Future: Send,
-    mcp_client::Error: std::convert::From<
-        <S as tower_service::Service<mcp_spec::protocol::JsonRpcMessage>>::Error,
-    >,
-{
-    client: Arc<mcp_client::client::McpClient<S>>,
+struct McpTool {
+    client: Arc<RunningService<RoleClient, InitializeRequestParam>>,
     tool_name: String,
     tool_spec: ToolSpec,
 }
 
 #[async_trait]
-impl<S> Tool for McpTool<S>
-where
-    S: Service<JsonRpcMessage, Response = JsonRpcMessage> + Clone + Send + Sync + 'static,
-    S::Error: Into<Error>,
-    S::Future: Send,
-    mcp_client::Error: std::convert::From<
-        <S as tower_service::Service<mcp_spec::protocol::JsonRpcMessage>>::Error,
-    >,
-{
+impl Tool for McpTool {
     async fn invoke(
         &self,
         _agent_context: &dyn swiftide_core::AgentContext,
@@ -150,22 +206,36 @@ where
         swiftide_core::chat_completion::ToolOutput,
         swiftide_core::chat_completion::errors::ToolError,
     > {
+        let args = match raw_args {
+            Some(args) => Some(serde_json::from_str(args)?),
+            None => None,
+        };
+
+        let request = CallToolRequestParam {
+            name: self.tool_name.clone().into(),
+            arguments: args,
+        };
+
+        tracing::debug!(request = ?request, tool = self.name().as_ref(), "Invoking mcp tool");
         let response = self
             .client
-            .call_tool(&self.tool_name, serde_json::to_value(raw_args)?)
+            .call_tool(request)
             .await
             .context("Failed to call mcp tool")?;
 
+        tracing::debug!(response = ?response, tool = self.name().as_ref(), "Received response from mcp tool");
         let content = response
             .content
-            .iter()
-            .filter_map(|c| c.as_text())
+            .into_iter()
+            .filter_map(|c| c.as_text().map(|t| t.text.to_string()))
             .collect::<Vec<_>>()
             .join("\n");
 
         if let Some(error) = response.is_error {
             if error {
-                ToolError::Unknown(anyhow::anyhow!("Failed to execute mcp tool: {content}"));
+                return Err(ToolError::Unknown(anyhow::anyhow!(
+                    "Failed to execute mcp tool: {content}"
+                )));
             }
         }
 
@@ -178,5 +248,150 @@ where
 
     fn tool_spec(&self) -> ToolSpec {
         self.tool_spec.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use copied_from_rmcp::Calculator;
+    use rmcp::serve_server;
+    use tokio::net::{UnixListener, UnixStream};
+
+    const SOCKET_PATH: &str = "/tmp/swiftide-mcp.sock";
+
+    #[allow(clippy::similar_names)]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_socket() -> Result<()> {
+        let _ = std::fs::remove_file(SOCKET_PATH);
+
+        match UnixListener::bind(SOCKET_PATH) {
+            Ok(unix_listener) => {
+                println!("Server successfully listening on {SOCKET_PATH}");
+                tokio::spawn(server(unix_listener));
+            }
+            Err(e) => {
+                println!("Unable to bind to {SOCKET_PATH}: {e}");
+            }
+        }
+
+        let client = client().await?;
+
+        let t = client.available_tools().await?;
+        assert_eq!(client.available_tools().await?.len(), 2);
+
+        let mut names = t.iter().map(|t| t.name()).collect::<Vec<_>>();
+        names.sort();
+        assert_eq!(names, ["sub", "sum"]);
+
+        let sum_tool = t.iter().find(|t| t.name() == "sum").unwrap();
+        assert_eq!(
+            sum_tool.tool_spec(),
+            ToolSpec::builder().name("sub").build()?
+        );
+        let result = sum_tool
+            .invoke(&(), Some(r#"{"a": 10, "b": 20}"#))
+            .await?
+            .content()
+            .unwrap()
+            .to_string();
+        assert_eq!(result, "30");
+
+        let sub_tool = t.iter().find(|t| t.name() == "sub").unwrap();
+        assert_eq!(
+            sub_tool.tool_spec(),
+            ToolSpec::builder().name("sub").build()?
+        );
+        let result = sub_tool
+            .invoke(&(), Some(r#"{"a": 10, "b": 20}"#))
+            .await?
+            .content()
+            .unwrap()
+            .to_string();
+        assert_eq!(result, "-10");
+
+        // Clean up socket file
+        let _ = std::fs::remove_file(SOCKET_PATH);
+
+        Ok(())
+    }
+
+    async fn server(unix_listener: UnixListener) -> anyhow::Result<()> {
+        while let Ok((stream, addr)) = unix_listener.accept().await {
+            println!("Client connected: {addr:?}");
+            tokio::spawn(async move {
+                match serve_server(Calculator, stream).await {
+                    Ok(server) => {
+                        println!("Server initialized successfully");
+                        if let Err(e) = server.waiting().await {
+                            println!("Error while server waiting: {e:?}");
+                        }
+                    }
+                    Err(e) => println!("Server initialization failed: {e:?}"),
+                }
+
+                anyhow::Ok(())
+            });
+        }
+        Ok(())
+    }
+
+    async fn client() -> anyhow::Result<McpClient> {
+        println!("Client connecting to {SOCKET_PATH}");
+        let stream = UnixStream::connect(SOCKET_PATH).await?;
+
+        // let client = serve_client((), stream).await?;
+        let client = McpClient::try_from_transport(stream).await?;
+        println!("Client connected and initialized successfully");
+
+        Ok(client)
+    }
+
+    #[allow(clippy::unused_self)]
+    mod copied_from_rmcp {
+        use rmcp::{
+            model::{ServerCapabilities, ServerInfo},
+            schemars, tool, ServerHandler,
+        };
+
+        #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+        pub struct SumRequest {
+            #[schemars(description = "the left hand side number")]
+            pub a: i32,
+            pub b: i32,
+        }
+        #[derive(Debug, Clone)]
+        pub struct Calculator;
+        #[rmcp::tool(tool_box)]
+        impl Calculator {
+            #[tool(description = "Calculate the sum of two numbers")]
+            fn sum(&self, #[tool(aggr)] SumRequest { a, b }: SumRequest) -> String {
+                (a + b).to_string()
+            }
+
+            #[tool(description = "Calculate the sum of two numbers")]
+            fn sub(
+                &self,
+                #[tool(param)]
+                #[schemars(description = "the left hand side number", required)]
+                a: i32,
+                #[tool(param)]
+                #[schemars(description = "the left hand side number")]
+                b: i32,
+            ) -> String {
+                (a - b).to_string()
+            }
+        }
+
+        #[rmcp::tool(tool_box)]
+        impl ServerHandler for Calculator {
+            fn get_info(&self) -> ServerInfo {
+                ServerInfo {
+                    instructions: Some("A simple calculator".into()),
+                    capabilities: ServerCapabilities::builder().enable_tools().build(),
+                    ..Default::default()
+                }
+            }
+        }
     }
 }

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -1,0 +1,87 @@
+use std::{sync::Arc, time::Duration};
+
+use async_mcp::{protocol::RequestOptions, transport::Transport};
+use async_trait::async_trait;
+use serde_json::json;
+use swiftide_core::{chat_completion::ToolSpec, Tool};
+
+struct McpClient<T: Transport> {
+    client: Arc<async_mcp::client::Client<T>>,
+}
+
+impl<T: Transport> McpClient<T> {
+    // {
+    //   "jsonrpc": "2.0",
+    //   "id": 1,
+    //   "result": {
+    //     "tools": [
+    //       {
+    //         "name": "get_weather",
+    //         "description": "Get current weather information for a location",
+    //         "inputSchema": {
+    //           "type": "object",
+    //           "properties": {
+    //             "location": {
+    //               "type": "string",
+    //               "description": "City name or zip code"
+    //             }
+    //           },
+    //           "required": ["location"]
+    //         }
+    //       }
+    //     ],
+    //     "nextCursor": "next-page-cursor"
+    //   }
+    // }
+    pub async fn list_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
+        let specs =
+
+    }
+
+}
+
+#[derive(Clone)]
+struct McpTool<T: Transport> {
+    client: Arc<async_mcp::client::Client<T>>,
+    tool_spec: ToolSpec,
+}
+
+#[async_trait]
+impl<T: Transport + Clone> Tool for McpTool<T> {
+    async fn invoke(
+        &self,
+        _agent_context: &dyn swiftide_core::AgentContext,
+        raw_args: Option<&str>,
+    ) -> Result<
+        swiftide_core::chat_completion::ToolOutput,
+        swiftide_core::chat_completion::errors::ToolError,
+    > {
+        // TODO:  validate the input based on the tool spec
+
+        let args = serde_json::from_str(raw_args.unwrap_or("{}"))?;
+        let response = self
+            .client
+            .request(
+                "tools/call",
+                Some(json!({
+                    "name": self.name(),
+                    "arguments": args
+                })),
+                RequestOptions::default().timeout(Duration::from_secs(5)),
+            )
+            .await?; // TODO: Handle this error properly
+                     //
+                     //
+
+        // TODO: Do something with this value, should parse like `{ content: { type: text, text: string} }`, tool errors should have a handleable 'isError' in the root
+        todo!()
+    }
+
+    fn name(&self) -> std::borrow::Cow<'_, str> {
+        self.tool_spec().name.into()
+    }
+
+    fn tool_spec(&self) -> ToolSpec {
+        self.tool_spec.clone()
+    }
+}

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -3,18 +3,17 @@
 //! Uses the `rmcp` crate to connect to an MCP server and list available tools, and invoke them
 //!
 //! Supports any transport that the `rmcp` crate supports
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
-use derive_builder::Builder;
-use rmcp::model::{ClientCapabilities, ClientInfo, Implementation, InitializeRequestParam};
+use rmcp::model::{ClientInfo, Implementation, InitializeRequestParam};
 use rmcp::service::RunningService;
 use rmcp::transport::IntoTransport;
+use rmcp::RoleClient;
 use rmcp::{model::CallToolRequestParam, ServiceExt};
-use rmcp::{RoleClient, Service};
 use serde::Deserialize;
-use serde_json::{json, Value};
+use serde_json::Value;
 use swiftide_core::{
     chat_completion::{errors::ToolError, ParamSpec, ParamType, ToolSpec},
     Tool, ToolBox,
@@ -30,8 +29,7 @@ enum Filter {
 /// # Example
 ///
 /// ```no_run
-///
-///
+/// 
 ///
 /// ```
 #[derive(Clone)]

--- a/swiftide-agents/src/tools/mod.rs
+++ b/swiftide-agents/src/tools/mod.rs
@@ -2,3 +2,7 @@
 pub mod arg_preprocessor;
 pub mod control;
 pub mod local_executor;
+
+/// Add tools from a Model Context Protocol endpoint
+#[cfg(feature = "mcp")]
+pub mod mcp;

--- a/swiftide-core/src/agent_traits.rs
+++ b/swiftide-core/src/agent_traits.rs
@@ -251,3 +251,33 @@ impl AgentContext for &dyn AgentContext {
         (**self).redrive().await;
     }
 }
+
+/// Convenience implementation for empty agent context
+///
+/// Errors if tools attempt to execute commands
+#[async_trait]
+impl AgentContext for () {
+    async fn next_completion(&self) -> Option<Vec<ChatMessage>> {
+        None
+    }
+
+    async fn current_new_messages(&self) -> Vec<ChatMessage> {
+        Vec::new()
+    }
+
+    async fn add_messages(&self, _item: Vec<ChatMessage>) {}
+
+    async fn add_message(&self, _item: ChatMessage) {}
+
+    async fn exec_cmd(&self, _cmd: &Command) -> Result<CommandOutput, CommandError> {
+        Err(CommandError::ExecutorError(anyhow::anyhow!(
+            "Empty agent context does not have a tool executor"
+        )))
+    }
+
+    async fn history(&self) -> Vec<ChatMessage> {
+        Vec::new()
+    }
+
+    async fn redrive(&self) {}
+}

--- a/swiftide-core/src/chat_completion/mod.rs
+++ b/swiftide-core/src/chat_completion/mod.rs
@@ -12,7 +12,7 @@ pub mod errors;
 mod tools;
 
 // Re-exported in the root per convention
-pub(crate) mod traits;
+pub mod traits;
 
 pub use chat_completion_request::*;
 pub use chat_completion_response::*;

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -1,5 +1,5 @@
 use derive_builder::Builder;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 /// Output of a `ToolCall` which will be added as a message for the agent to use.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -109,7 +109,9 @@ impl ToolSpec {
     }
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, Default, strum_macros::AsRefStr)]
+#[derive(
+    Clone, Debug, Hash, Eq, PartialEq, Default, strum_macros::AsRefStr, Serialize, Deserialize,
+)]
 #[strum(serialize_all = "camelCase")]
 pub enum ParamType {
     #[default]

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -1,5 +1,5 @@
 use derive_builder::Builder;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// Output of a `ToolCall` which will be added as a message for the agent to use.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -113,6 +113,7 @@ impl ToolSpec {
     Clone, Debug, Hash, Eq, PartialEq, Default, strum_macros::AsRefStr, Serialize, Deserialize,
 )]
 #[strum(serialize_all = "camelCase")]
+#[serde(rename_all = "camelCase")]
 pub enum ParamType {
     #[default]
     String,
@@ -136,8 +137,6 @@ pub struct ParamSpec {
     #[builder(default)]
     pub ty: ParamType,
     /// Whether the parameter is required
-    ///
-    /// Note that macros will always generate required parameters
     #[builder(default = true)]
     pub required: bool,
 }

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use async_trait::async_trait;
 use dyn_clone::DynClone;
 use std::{borrow::Cow, sync::Arc};
@@ -107,41 +108,41 @@ pub trait Tool: Send + Sync + DynClone {
 /// It also allows for tools to be dynamically loaded and unloaded, etc.
 #[async_trait]
 pub trait ToolBox: Send + Sync + DynClone {
-    async fn available_tools(&self) -> Vec<Box<dyn Tool>>;
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>>;
 }
 
 #[async_trait]
 impl ToolBox for Vec<Box<dyn Tool>> {
-    async fn available_tools(&self) -> Vec<Box<dyn Tool>> {
-        self.clone()
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
+        Ok(self.clone())
     }
 }
 
 #[async_trait]
 impl ToolBox for Box<dyn ToolBox> {
-    async fn available_tools(&self) -> Vec<Box<dyn Tool>> {
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
         (**self).available_tools().await
     }
 }
 
 #[async_trait]
 impl ToolBox for Arc<dyn ToolBox> {
-    async fn available_tools(&self) -> Vec<Box<dyn Tool>> {
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
         (**self).available_tools().await
     }
 }
 
 #[async_trait]
 impl ToolBox for &dyn ToolBox {
-    async fn available_tools(&self) -> Vec<Box<dyn Tool>> {
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
         (**self).available_tools().await
     }
 }
 
 #[async_trait]
 impl ToolBox for &[Box<dyn Tool>] {
-    async fn available_tools(&self) -> Vec<Box<dyn Tool>> {
-        self.to_vec()
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
+        Ok(self.to_vec())
     }
 }
 

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -110,6 +110,10 @@ pub trait Tool: Send + Sync + DynClone {
 pub trait ToolBox: Send + Sync + DynClone {
     async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>>;
 
+    fn name(&self) -> Cow<'_, str> {
+        Cow::Borrowed("Unnamed ToolBox")
+    }
+
     fn boxed<'a>(self) -> Box<dyn ToolBox + 'a>
     where
         Self: Sized + 'a,

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -157,6 +157,13 @@ impl ToolBox for &[Box<dyn Tool>] {
     }
 }
 
+#[async_trait]
+impl ToolBox for [Box<dyn Tool>] {
+    async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
+        Ok(self.to_vec())
+    }
+}
+
 dyn_clone::clone_trait_object!(ToolBox);
 
 #[async_trait]

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -109,6 +109,13 @@ pub trait Tool: Send + Sync + DynClone {
 #[async_trait]
 pub trait ToolBox: Send + Sync + DynClone {
     async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>>;
+
+    fn boxed<'a>(self) -> Box<dyn ToolBox + 'a>
+    where
+        Self: Sized + 'a,
+    {
+        Box::new(self) as Box<dyn ToolBox>
+    }
 }
 
 #[async_trait]

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -104,6 +104,9 @@ redb = ["swiftide-integrations/redb"]
 ## Duckdb; sqlite fork, support Persist, Retrieve and NodeCache
 duckdb = ["swiftide-integrations/duckdb"]
 
+## MCP tool support for agents (tools only)
+mcp = ["swiftide-agents", "swiftide-agents/mcp"]
+
 #! ### Experimental
 swiftide-agents = ["dep:swiftide-agents"]
 

--- a/swiftide/src/lib.rs
+++ b/swiftide/src/lib.rs
@@ -120,6 +120,8 @@ pub mod traits {
     #[doc(inline)]
     pub use swiftide_core::agent_traits::*;
     #[doc(inline)]
+    pub use swiftide_core::chat_completion::traits::*;
+    #[doc(inline)]
     pub use swiftide_core::indexing_traits::*;
     #[doc(inline)]
     pub use swiftide_core::query_traits::*;


### PR DESCRIPTION
Adds support for agents to use tools from MCP servers. All transports are supported via the `rmcp` crate. 

Additionally adds the possibility to add toolboxes to agents (of which MCP is one). Tool boxes declare their available tools at runtime, like tool box.