### PR TITLE
chore: release v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,50 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.1](https://github.com/bosun-ai/swiftide/compare/v0.22.0...v0.22.1) - 2025-03-09
+
+### New features
+
+- [474d612](https://github.com/bosun-ai/swiftide/commit/474d6122596e71132e35fcb181302dfed7794561) *(integrations)*  Add Duckdb support ([#578](https://github.com/bosun-ai/swiftide/pull/578))
+
+````text
+Adds support for Duckdb. Persist, Retrieve (Simple and Custom), and
+  NodeCache are implemented.
+````
+
+- [4cf417c](https://github.com/bosun-ai/swiftide/commit/4cf417c6a818fbec2641ad6576b4843412902bf6) *(treesitter)*  C and C++ support for splitter only ([#663](https://github.com/bosun-ai/swiftide/pull/663))
+
+````text
+- **feat(tree-sitter): C and C++ support for splitter only**
+  - **Rename to C++**
+````
+
+### Bug fixes
+
+- [590eaeb](https://github.com/bosun-ai/swiftide/commit/590eaeb3c6b5c14c56c925e038528326f88508a1) *(integrations)*  Make openai parallel_tool_calls an Option ([#664](https://github.com/bosun-ai/swiftide/pull/664))
+
+````text
+o3-mini needs to omit parallel_tool_calls - so we need to allow for a
+  None option to not include that field
+
+  needed for https://github.com/bosun-ai/kwaak/pull/392
+````
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+- [d864c7e](https://github.com/bosun-ai/swiftide/commit/d864c7e72ba01d3f187e4f6ab6ad3e6244ae0dc4)  Downgrade duckdb to 1.1.1 and fix ci ([#671](https://github.com/bosun-ai/swiftide/pull/671))
+
+- [9b685b3](https://github.com/bosun-ai/swiftide/commit/9b685b3281d9694c5faa58890a9aba32cba90f1c)  Update and loosen deps ([#670](https://github.com/bosun-ai/swiftide/pull/670))
+
+- [a64ca16](https://github.com/bosun-ai/swiftide/commit/a64ca1656b903a680cc70ac7b33ac40d9d356d4a)  Tokio_stream features should include `time`
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.0...0.22.1
+
+
+
 ## [0.22.0](https://github.com/bosun-ai/swiftide/compare/v0.21.1...v0.22.0) - 2025-03-03
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,12 @@ All notable changes to this project will be documented in this file.
 
 ````text
 Adds support for Duckdb. Persist, Retrieve (Simple and Custom), and
-  NodeCache are implemented.
+  NodeCache are implemented. Metadata and full upsert are not. Once 1.2
+  has its issues fixed, it's easy to add.
 ````
 
 - [4cf417c](https://github.com/bosun-ai/swiftide/commit/4cf417c6a818fbec2641ad6576b4843412902bf6) *(treesitter)*  C and C++ support for splitter only ([#663](https://github.com/bosun-ai/swiftide/pull/663))
 
-````text
-- **feat(tree-sitter): C and C++ support for splitter only**
-  - **Rename to C++**
-````
 
 ### Bug fixes
 
@@ -27,8 +24,6 @@ Adds support for Duckdb. Persist, Retrieve (Simple and Custom), and
 ````text
 o3-mini needs to omit parallel_tool_calls - so we need to allow for a
   None option to not include that field
-
-  needed for https://github.com/bosun-ai/kwaak/pull/392
 ````
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8608,7 +8608,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8636,7 +8636,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8686,7 +8686,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8705,7 +8705,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8734,7 +8734,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8801,7 +8801,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8824,7 +8824,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8843,7 +8843,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "async-openai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.0" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.1" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.1" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `swiftide-agents`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `swiftide-macros`: 0.22.0 -> 0.22.1
* `swiftide-indexing`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `swiftide-integrations`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `swiftide-query`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `swiftide`: 0.22.0 -> 0.22.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.1](https://github.com/bosun-ai/swiftide/compare/v0.22.0...v0.22.1) - 2025-03-09

### New features

- [474d612](https://github.com/bosun-ai/swiftide/commit/474d6122596e71132e35fcb181302dfed7794561) *(integrations)*  Add Duckdb support ([#578](https://github.com/bosun-ai/swiftide/pull/578))

````text
Adds support for Duckdb. Persist, Retrieve (Simple and Custom), and
  NodeCache are implemented.
````

- [4cf417c](https://github.com/bosun-ai/swiftide/commit/4cf417c6a818fbec2641ad6576b4843412902bf6) *(treesitter)*  C and C++ support for splitter only ([#663](https://github.com/bosun-ai/swiftide/pull/663))

````text
- **feat(tree-sitter): C and C++ support for splitter only**
  - **Rename to C++**
````

### Bug fixes

- [590eaeb](https://github.com/bosun-ai/swiftide/commit/590eaeb3c6b5c14c56c925e038528326f88508a1) *(integrations)*  Make openai parallel_tool_calls an Option ([#664](https://github.com/bosun-ai/swiftide/pull/664))

````text
o3-mini needs to omit parallel_tool_calls - so we need to allow for a
  None option to not include that field

  needed for https://github.com/bosun-ai/kwaak/pull/392
````

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies

- [d864c7e](https://github.com/bosun-ai/swiftide/commit/d864c7e72ba01d3f187e4f6ab6ad3e6244ae0dc4)  Downgrade duckdb to 1.1.1 and fix ci ([#671](https://github.com/bosun-ai/swiftide/pull/671))

- [9b685b3](https://github.com/bosun-ai/swiftide/commit/9b685b3281d9694c5faa58890a9aba32cba90f1c)  Update and loosen deps ([#670](https://github.com/bosun-ai/swiftide/pull/670))

- [a64ca16](https://github.com/bosun-ai/swiftide/commit/a64ca1656b903a680cc70ac7b33ac40d9d356d4a)  Tokio_stream features should include `time`


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.0...0.22.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).