### PR TITLE
chore: release v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.2](https://github.com/bosun-ai/swiftide/compare/v0.22.1...v0.22.2) - 2025-03-11
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+- [e1c097d](https://github.com/bosun-ai/swiftide/commit/e1c097da885374ec9320c1847a7dda7c5d9d41cb)  Disable default features on all dependencies ([#675](https://github.com/bosun-ai/swiftide/pull/675))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.1...0.22.2
+
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 ## [0.22.1](https://github.com/bosun-ai/swiftide/compare/v0.22.0...v0.22.1) - 2025-03-09
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,7 +1301,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8601,7 +8601,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8629,7 +8629,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8651,7 +8651,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8679,7 +8679,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8698,7 +8698,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8727,7 +8727,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8794,7 +8794,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8817,7 +8817,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8836,7 +8836,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "async-openai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.1" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.2" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.2" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `swiftide-agents`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `swiftide-macros`: 0.22.1 -> 0.22.2
* `swiftide-indexing`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `swiftide-integrations`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `swiftide-query`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `swiftide`: 0.22.1 -> 0.22.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.2](https://github.com/bosun-ai/swiftide/compare/v0.22.1...v0.22.2) - 2025-03-11

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies

- [e1c097d](https://github.com/bosun-ai/swiftide/commit/e1c097da885374ec9320c1847a7dda7c5d9d41cb)  Disable default features on all dependencies ([#675](https://github.com/bosun-ai/swiftide/pull/675))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.1...0.22.2
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).