### PR TITLE
chore: release v0.22.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.3](https://github.com/bosun-ai/swiftide/compare/v0.22.2...v0.22.3) - 2025-03-12
+
+### Miscellaneous
+
+- [834fcd3](https://github.com/bosun-ai/swiftide/commit/834fcd3b2270904bcfe8998a7015de15626128a8)  Update duckdb to 1.2.1 ([#680](https://github.com/bosun-ai/swiftide/pull/680))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.2...0.22.3
+
+
+
 ## [0.22.2](https://github.com/bosun-ai/swiftide/compare/v0.22.1...v0.22.2) - 2025-03-11
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,7 +1311,7 @@ checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8614,7 +8614,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8642,7 +8642,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8664,7 +8664,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8692,7 +8692,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8711,7 +8711,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8740,7 +8740,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8807,7 +8807,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8830,7 +8830,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8849,7 +8849,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "async-openai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.2"
+version = "0.22.3"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.2" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.3" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.2" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.3" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.2 -> 0.22.3
* `swiftide-agents`: 0.22.2 -> 0.22.3
* `swiftide-macros`: 0.22.2 -> 0.22.3
* `swiftide-indexing`: 0.22.2 -> 0.22.3
* `swiftide-integrations`: 0.22.2 -> 0.22.3 (✓ API compatible changes)
* `swiftide-query`: 0.22.2 -> 0.22.3
* `swiftide`: 0.22.2 -> 0.22.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.3](https://github.com/bosun-ai/swiftide/compare/v0.22.2...v0.22.3) - 2025-03-12

### Miscellaneous

- [834fcd3](https://github.com/bosun-ai/swiftide/commit/834fcd3b2270904bcfe8998a7015de15626128a8)  Update duckdb to 1.2.1 ([#680](https://github.com/bosun-ai/swiftide/pull/680))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.2...0.22.3
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).