### PR TITLE
fix(integrations): Add chrono/utc feature flag when using qdrant

### DIFF
--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -127,7 +127,7 @@ default = ["rustls"]
 # Ensures rustls is used
 rustls = ["reqwest?/rustls-tls-native-roots", "fastembed?/hf-hub-native-tls"]
 # Qdrant for storage
-qdrant = ["dep:qdrant-client", "swiftide-core/qdrant"]
+qdrant = ["dep:qdrant-client", "swiftide-core/qdrant", "chrono/now"]
 # PgVector for storage
 pgvector = ["dep:sqlx", "dep:pgvector"]
 # Redis for caching and storage


### PR DESCRIPTION
The Qdrant integration calls chrono::Utc::now(), which requires the now feature flag to be enabled in the chrono crate when using qdrant

https://github.com/bosun-ai/swiftide/blob/5f2a5e29b8ba98ddf4fc44f20c1e8da3f25229fa/swiftide-integrations/src/qdrant/indexing_node.rs#L57