### PR TITLE
docs: document feature flags using doc_auto_cfg

### DIFF
--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -34,3 +34,8 @@ insta.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/swiftide-agents/src/lib.rs
+++ b/swiftide-agents/src/lib.rs
@@ -1,3 +1,9 @@
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
+
 //! Swiftide agents are a flexible way to build fast and reliable AI agents.
 //!
 //! # Features

--- a/swiftide-core/Cargo.toml
+++ b/swiftide-core/Cargo.toml
@@ -49,3 +49,8 @@ truncate-debug = []
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/swiftide-core/src/lib.rs
+++ b/swiftide-core/src/lib.rs
@@ -1,3 +1,8 @@
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod agent_traits;

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -46,3 +46,8 @@ tree-sitter = []
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/swiftide-indexing/src/lib.rs
+++ b/swiftide-indexing/src/lib.rs
@@ -1,3 +1,9 @@
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
+
 pub mod loaders;
 pub mod persist;
 pub mod transformers;

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -179,3 +179,8 @@ duckdb = ["dep:duckdb", "dep:libduckdb-sys"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/swiftide-integrations/src/lib.rs
+++ b/swiftide-integrations/src/lib.rs
@@ -1,3 +1,9 @@
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
+
 //! Integrations with various platforms and external services.
 
 #[cfg(feature = "anthropic")]

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -44,3 +44,8 @@ workspace = true
 # TODO: Clean up feature flag
 default = ["swiftide-agents"]
 swiftide-agents = ["dep:serde", "dep:serde_json"]
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/swiftide-macros/src/lib.rs
+++ b/swiftide-macros/src/lib.rs
@@ -1,3 +1,9 @@
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
+
 //! This crate provides macros for generating boilerplate code
 //! for indexing transformers
 use proc_macro::TokenStream;

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -34,3 +34,8 @@ insta = { workspace = true }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/swiftide-query/src/lib.rs
+++ b/swiftide-query/src/lib.rs
@@ -1,3 +1,9 @@
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
+
 pub mod answers;
 mod query;
 pub mod query_transformers;

--- a/swiftide-test-utils/Cargo.toml
+++ b/swiftide-test-utils/Cargo.toml
@@ -25,3 +25,8 @@ wiremock = { workspace = true }
 [features]
 default = ["test-utils"]
 test-utils = []
+
+[package.metadata.docs.rs]
+all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/swiftide-test-utils/src/lib.rs
+++ b/swiftide-test-utils/src/lib.rs
@@ -1,3 +1,9 @@
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
+
 #[cfg(feature = "test-utils")]
 mod test_utils;
 

--- a/swiftide/src/lib.rs
+++ b/swiftide/src/lib.rs
@@ -1,11 +1,9 @@
-//! # Swiftide
-//!
-//! <div>
-//! <img src="https://github.com/bosun-ai/swiftide/raw/master/images/logo.png" height="200"
-//! width="200" style="margin: auto; display: block;" />
-//! <br />
-//! </div>
-//!
+// show feature flags in the generated documentation
+// https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
+
 //! Swiftide is a data indexing and processing library, tailored for Retrieval Augmented Generation (RAG). When building applications with large language models (LLM), these LLMs need access to external resources. Data needs to be transformed, enriched, split up, embedded, and persisted. It is build in Rust, using parallel, asynchronous streams and is blazingly fast.
 //!
 //! Part of the [bosun.ai](https://bosun.ai) project. An upcoming platform for autonomous code improvement.
@@ -14,7 +12,7 @@
 //!
 //! Read more about the project on the [swiftide website](https://swiftide.rs)
 //!
-//! ## Features
+//! # Features
 //!
 //! - Extremely fast streaming indexing pipeline with async, parallel processing
 //! - Integrations with `OpenAI`, `Redis`, `Qdrant`, `FastEmbed`, `Treesitter` and more
@@ -25,13 +23,13 @@
 //! - Store into multiple backends
 //! - `tracing` supported for logging and tracing, see /examples and the `tracing` crate for more information.
 //!
-//! ## Querying
+//! # Querying
 //!
 //! After running an indexing pipeline, you can use the [`query`] module to query the indexed data.
 //!
-//! ## Examples
+//! # Examples
 //!
-//! ### Indexing markdown
+//! ## Indexing markdown
 //!
 //! ```no_run
 //! # use swiftide::indexing::loaders::FileLoader;
@@ -61,7 +59,7 @@
 //! # }
 //! ```
 //!
-//! ### Querying
+//! ## Querying
 //!
 //! ```no_run
 //! # use anyhow::Result;
@@ -95,7 +93,7 @@
 //! # }
 //! ```
 //!
-//! ## Feature flags
+//! # Feature flags
 //!
 //! Swiftide has little features enabled by default, as there are some dependency heavy
 //! integrations. You need to cherry-pick the tools and integrations you want to use.


### PR DESCRIPTION
https://doc.rust-lang.org/rustdoc/unstable-features.html#extensions-to-the-doc-attribute

This is an unstable feature, so it's feature flagged with a feature that
is always passed by docs.rs. To run the same settings use cargo-docs-rs

Also moves the logo into the top left corner of all docs, rather than
just in the main doc.

Makes the docs.rs config consistent across all crate manifests.