### PR TITLE
chore(ci): Verify each feature compiles individually with cargo hack

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   lint:
@@ -33,10 +32,14 @@ jobs:
         uses: crate-ci/typos@master
       - name: "Rustfmt"
         run: cargo fmt --all --check
+        env:
+          RUSTFLAGS: "-Dwarnings"
       # - name: Lint dependencies
       #   uses: EmbarkStudios/cargo-deny-action@v2
       - name: clippy
         run: cargo clippy --all-targets --all-features --workspace
+        env:
+          RUSTFLAGS: "-Dwarnings"
 
   hack:
     name: Cargo Hack

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,3 +37,24 @@ jobs:
       #   uses: EmbarkStudios/cargo-deny-action@v2
       - name: clippy
         run: cargo clippy --all-targets --all-features --workspace
+
+  hack:
+    name: Cargo Hack
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: r7kamura/rust-problem-matchers@v1
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+      - name: Check features with Cargo Hack
+        run: cargo hack check --each-feature --no-dev-deps


### PR DESCRIPTION
Disabling default features in deps lead to some feature flags not compiling correctly on their own. Added as a future safety guard. (#684)