### PR TITLE
docs: wrap code comments at 100 chars

### DIFF
--- a/examples/aws_bedrock.rs
+++ b/examples/aws_bedrock.rs
@@ -1,6 +1,7 @@
 //! # [Swiftide] Aws Bedrock example
 //!
-//! This example demonstrates how to use the `AwsBedrock` integration to interact with the Bedrock service.
+//! This example demonstrates how to use the `AwsBedrock` integration to interact with the Bedrock
+//! service.
 //!
 //! To use bedrock you will need the following:
 //! - AWS cli or environment variables configured

--- a/examples/hybrid_search.rs
+++ b/examples/hybrid_search.rs
@@ -82,8 +82,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         fastembed_sparse.clone(),
     ))
     .then_retrieve(qdrant.clone())
-    // Answer with Simple, which either takes the documents as is (in this case), or any transformations applied
-    // after querying
+    // Answer with Simple, which either takes the documents as is (in this case), or any
+    // transformations applied after querying
     .then_answer(answers::Simple::from_client(openai.clone()));
 
     let answer = query_pipeline
@@ -95,13 +95,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // ## Different Pipelines in Swiftide and How They Work
     //
-    // Swiftide offers multiple pipelines, notably the indexing pipeline and the query pipeline. The functionality of these pipelines is enhanced using traits and components like transformers, stream handlers, and more. Below we elaborate on the key components and how they become part of the larger pipeline system:
+    // Swiftide offers multiple pipelines, notably the indexing pipeline and the query pipeline. The
+    // functionality of these pipelines is enhanced using traits and components like transformers,
+    // stream handlers, and more. Below we elaborate on the key components and how they become part
+    // of the larger pipeline system:
     //
     // ### Indexing Pipeline
     //
     // 1. **Transformers**:
-    //     - **Transformer Trait**: Transforms single nodes into single nodes. Mainly used for transforming data in a singular manner.
-    //     - **BatchableTransformer Trait**: Transforms a batch of nodes into a stream of nodes, useful for bulk processing.
+    //     - **Transformer Trait**: Transforms single nodes into single nodes. Mainly used for
+    //       transforming data in a singular manner.
+    //     - **BatchableTransformer Trait**: Transforms a batch of nodes into a stream of nodes,
+    //       useful for bulk processing.
     //
     //     ```rust
     //     #[async_trait]
@@ -124,8 +129,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     }
     //
     //     #[async_trait]
-    //     impl<F> BatchableTransformer for F where F: Fn(Vec<Node>) -> IndexingStream + Send + Sync {
-    //         async fn batch_transform(&self, nodes: Vec<Node>) -> IndexingStream {
+    //     impl<F> BatchableTransformer for F where F: Fn(Vec<Node>) -> IndexingStream + Send + Sync
+    // {         async fn batch_transform(&self, nodes: Vec<Node>) -> IndexingStream {
     //             self(nodes)
     //         }
     //     }
@@ -141,7 +146,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     ```
     //
     // 3. **Chunker Transformers**:
-    //     - Splits one node into multiple nodes. It's useful for breaking down large nodes into smaller, manageable chunks.
+    //     - Splits one node into multiple nodes. It's useful for breaking down large nodes into
+    //       smaller, manageable chunks.
     //
     //     ```rust
     //     #[async_trait]
@@ -152,7 +158,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //     ```
     //
     // 4. **IndexingStream**:
-    //     - An asynchronous stream of nodes, used internally by the indexing pipeline to handle streams of `Node` items.
+    //     - An asynchronous stream of nodes, used internally by the indexing pipeline to handle
+    //       streams of `Node` items.
     //
     //     ```rust
     //     pub struct IndexingStream {
@@ -191,7 +198,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // ### Extending the Pipeline with Traits
     //
-    // Swiftide allows developers to extend the pipeline by implementing custom transformers, loaders, and other components by implementing the respective traits. This design ensures flexibility and modularity, allowing seamless integration of custom functionality.
+    // Swiftide allows developers to extend the pipeline by implementing custom transformers,
+    // loaders, and other components by implementing the respective traits. This design ensures
+    // flexibility and modularity, allowing seamless integration of custom functionality.
     //
     // For example, to create a custom transformer:
     // ```rust
@@ -211,7 +220,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // ### Usage of Prompts in Transformers
     //
-    // Swiftide utilizes the [`Template`] for templating prompts, making it easy to define and manage prompts within transformers.
+    // Swiftide utilizes the [`Template`] for templating prompts, making it easy to define and
+    // manage prompts within transformers.
     //
     // ```rust
     // let template = PromptTemplate::try_compiled_from_str("hello {{world}}").await.unwrap();
@@ -221,7 +231,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     //
     // ### Conclusion
     //
-    // The Indexing and Query Pipelines in Swiftide are made extensible and modular via traits such as `Transformer`, `BatchableTransformer`, `Loader`, and more. Custom implementations can seamlessly integrate into the pipeline, providing flexibility in how data is processed, transformed, and indexed. The use of prompts further enhances the capability to manage dynamic and templated data within these pipelines.
+    // The Indexing and Query Pipelines in Swiftide are made extensible and modular via traits such
+    // as `Transformer`, `BatchableTransformer`, `Loader`, and more. Custom implementations can
+    // seamlessly integrate into the pipeline, providing flexibility in how data is processed,
+    // transformed, and indexed. The use of prompts further enhances the capability to manage
+    // dynamic and templated data within these pipelines.
 
     Ok(())
 }

--- a/examples/index_codebase_reduced_context.rs
+++ b/examples/index_codebase_reduced_context.rs
@@ -1,16 +1,18 @@
 //! # [Swiftide] Indexing the Swiftide itself example with reduced context size
 //!
-//! This example demonstrates how to index the Swiftide codebase itself, optimizing for a smaller context size.
-//! Note that for it to work correctly you need to have OPENAI_API_KEY set, redis and qdrant
-//! running.
+//! This example demonstrates how to index the Swiftide codebase itself, optimizing for a smaller
+//! context size. Note that for it to work correctly you need to have OPENAI_API_KEY set, redis and
+//! qdrant running.
 //!
 //! The pipeline will:
 //! - Load all `.rs` files from the current directory
 //! - Skip any nodes previously processed; hashes are based on the path and chunk (not the
 //!   metadata!)
-//! - Generate an outline of the symbols defined in each file to be used as context in a later step and store it in the metadata
+//! - Generate an outline of the symbols defined in each file to be used as context in a later step
+//!   and store it in the metadata
 //! - Chunk the code into pieces of 10 to 2048 bytes
-//! - For each chunk, generate a condensed subset of the symbols outline tailored for that specific chunk and store that in the metadata
+//! - For each chunk, generate a condensed subset of the symbols outline tailored for that specific
+//!   chunk and store that in the metadata
 //! - Run metadata QA on each chunk; generating questions and answers and adding metadata
 //! - Embed the chunks in batches of 10, Metadata is embedded by default
 //! - Store the nodes in Qdrant

--- a/examples/index_md_into_pgvector.rs
+++ b/examples/index_md_into_pgvector.rs
@@ -1,6 +1,6 @@
 /**
-* This example demonstrates how to index markdown into PGVector
-*/
+ * This example demonstrates how to index markdown into PGVector
+ */
 use std::path::PathBuf;
 use swiftide::{
     indexing::{

--- a/examples/index_ollama.rs
+++ b/examples/index_ollama.rs
@@ -6,7 +6,8 @@
 //! The pipeline will:
 //! - Loads the readme from the project
 //! - Chunk the code into pieces of 10 to 2048 bytes
-//! - Run metadata QA on each chunk with Ollama; generating questions and answers and adding metadata
+//! - Run metadata QA on each chunk with Ollama; generating questions and answers and adding
+//!   metadata
 //! - Embed the chunks in batches of 10, Metadata is embedded by default
 //! - Store the nodes in Memory Storage
 //!

--- a/examples/lancedb.rs
+++ b/examples/lancedb.rs
@@ -1,6 +1,6 @@
 /**
-* This example demonstrates how to use the LanceDB integration with Swiftide
-*/
+ * This example demonstrates how to use the LanceDB integration with Swiftide
+ */
 use swiftide::{
     indexing::{
         self,

--- a/examples/reranking.rs
+++ b/examples/reranking.rs
@@ -1,10 +1,10 @@
 /// Demonstrates reranking retrieved documents with fastembed
 ///
-/// When reranking, many more documents are retrieved than used for the initial query. Maybe even
-/// from multiple sources.
+/// When reranking, many more documents are retrieved than used for the initial query. Maybe
+/// even from multiple sources.
 ///
-/// Reranking compares the relevancy of the documents with the initial query, then filters out the
-/// `top_k` documents.
+/// Reranking compares the relevancy of the documents with the initial query, then filters out
+/// the `top_k` documents.
 ///
 /// By default the model uses 'bge-reranker-base'.
 use swiftide::{

--- a/examples/store_multiple_vectors.rs
+++ b/examples/store_multiple_vectors.rs
@@ -1,6 +1,7 @@
 //! # [Swiftide] Ingesting file with multiple metadata stored as named vectors
 //!
-//! This example demonstrates how to ingest a LICENSE file, generate multiple metadata, and store it all in Qdrant with individual named vectors
+//! This example demonstrates how to ingest a LICENSE file, generate multiple metadata, and store it
+//! all in Qdrant with individual named vectors
 //!
 //! The pipeline will:
 //! - Load the LICENSE file from the current directory

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,5 @@
+# docs: https://rust-lang.github.io/rustfmt/
+
+# Unstable options - to run these, use `cargo +nightly fmt`
+wrap_comments = true
+comment_width = 100

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -35,7 +35,8 @@ use tracing::{debug, Instrument};
 ///
 /// - The default context is the `DefaultContext`, executing tools locally with the `LocalExecutor`.
 /// - A default `stop` tool is provided for agents to explicitly stop if needed
-/// - The default `SystemPrompt` instructs the agent with chain of thought and some common safeguards, but is otherwise quite bare. In a lot of cases this can be sufficient.
+/// - The default `SystemPrompt` instructs the agent with chain of thought and some common
+///   safeguards, but is otherwise quite bare. In a lot of cases this can be sufficient.
 #[derive(Clone, Builder)]
 pub struct Agent {
     /// Hooks are functions that are called at specific points in the agent's lifecycle.
@@ -93,7 +94,8 @@ pub struct Agent {
     /// worth while. If the limit is not reached, the agent will send the formatted error back to
     /// the LLM.
     ///
-    /// The limit is hashed based on the tool call name and arguments, so the limit is per tool call.
+    /// The limit is hashed based on the tool call name and arguments, so the limit is per tool
+    /// call.
     ///
     /// This limit is _not_ reset when the agent is stopped.
     #[builder(default = 3)]
@@ -215,8 +217,8 @@ impl AgentBuilder {
 
     /// Define the available tools for the agent. Tools must implement the `Tool` trait.
     ///
-    /// See the [tool attribute macro](`swiftide_macros::tool`) and the [tool derive macro](`swiftide_macros::Tool`)
-    /// for easy ways to create (many) tools.
+    /// See the [tool attribute macro](`swiftide_macros::tool`) and the [tool derive
+    /// macro](`swiftide_macros::Tool`) for easy ways to create (many) tools.
     pub fn tools<TOOL, I: IntoIterator<Item = TOOL>>(&mut self, tools: I) -> &mut Self
     where
         TOOL: Into<Box<dyn Tool>>,
@@ -258,14 +260,15 @@ impl Agent {
         self.run_agent(Some(query.into()), true).await
     }
 
-    /// Run the agent with without user message. The agent will loop completions, make tool calls, until
-    /// no new messages are available.
+    /// Run the agent with without user message. The agent will loop completions, make tool calls,
+    /// until no new messages are available.
     #[tracing::instrument(skip_all, name = "agent.run")]
     pub async fn run(&mut self) -> Result<()> {
         self.run_agent(None, false).await
     }
 
-    /// Run the agent with without user message. The agent will loop completions, make tool calls, until
+    /// Run the agent with without user message. The agent will loop completions, make tool calls,
+    /// until
     #[tracing::instrument(skip_all, name = "agent.run_once")]
     pub async fn run_once(&mut self) -> Result<()> {
         self.run_agent(None, true).await

--- a/swiftide-agents/src/hooks.rs
+++ b/swiftide-agents/src/hooks.rs
@@ -16,9 +16,9 @@
 //!         agent.context().add_message(ChatMessage::new_user("Hello, world")).await;
 //!         Ok(())
 //!     })
-//!});
-//!# }
-//!```
+//! });
+//! # }
+//! ```
 //! Rust has a long outstanding issue where it captures outer lifetimes when returning an impl
 //! that also has lifetimes, see [this issue](https://github.com/rust-lang/rust/issues/42940)
 //!
@@ -42,7 +42,7 @@
 //!      Box::pin(async move {{ Ok(())}})
 //!     }
 //!   }
-//!}
+//! }
 use anyhow::Result;
 use std::{future::Future, pin::Pin};
 
@@ -101,7 +101,6 @@ pub trait AfterCompletionFn:
 dyn_clone::clone_trait_object!(AfterCompletionFn);
 
 /// Hooks that are called after each tool
-///
 pub trait AfterToolFn:
     for<'tool> Fn(
         &'tool Agent,

--- a/swiftide-agents/src/lib.rs
+++ b/swiftide-agents/src/lib.rs
@@ -8,11 +8,18 @@
 //!
 //! # Features
 //!
-//! * **Tools**: Tools can be defined as functions using the `#[tool]` attribute macro, the `Tool` derive macro, or manually implementing the `Tool` trait.
-//! * **Hooks**: At various stages of the agent lifecycle, hooks can be defined to run custom logic. These are defined when building the agent, and each take a closure.
-//! * **Context**: Agents operate in an `AgentContext`, which is a shared state between tools and hooks. The context is responsible for managing the completions and interacting with the outside world.
-//! * **Tool Execution**: A context takes a tool executor (local by default) to execute its tools on. This enables tools to be run i.e. in containers, remote, etc.
-//! * **System prompt defaults**: `SystemPrompt` provides a default, customizable prompt for the agent. If you want to provider your own prompt, the builder takes anything that converts into a `Prompt`, including strings.
+//! * **Tools**: Tools can be defined as functions using the `#[tool]` attribute macro, the `Tool`
+//!   derive macro, or manually implementing the `Tool` trait.
+//! * **Hooks**: At various stages of the agent lifecycle, hooks can be defined to run custom logic.
+//!   These are defined when building the agent, and each take a closure.
+//! * **Context**: Agents operate in an `AgentContext`, which is a shared state between tools and
+//!   hooks. The context is responsible for managing the completions and interacting with the
+//!   outside world.
+//! * **Tool Execution**: A context takes a tool executor (local by default) to execute its tools
+//!   on. This enables tools to be run i.e. in containers, remote, etc.
+//! * **System prompt defaults**: `SystemPrompt` provides a default, customizable prompt for the
+//!   agent. If you want to provider your own prompt, the builder takes anything that converts into
+//!   a `Prompt`, including strings.
 //! * **Open Telemetry**: Agents are fully instrumented with open telemetry.
 //!
 //! # Example

--- a/swiftide-core/src/chat_completion/mod.rs
+++ b/swiftide-core/src/chat_completion/mod.rs
@@ -1,6 +1,7 @@
 //! This module enables the implementation of chat completion on LLM providers
 //!
-//! The main trait to implement is `ChatCompletion`, which takes a `ChatCompletionRequest` and returns a `ChatCompletionResponse`.
+//! The main trait to implement is `ChatCompletion`, which takes a `ChatCompletionRequest` and
+//! returns a `ChatCompletionResponse`.
 //!
 //! A chat completion request is comprised of a list of `ChatMessage` to complete, with optionally
 //! tool specifications. The response optionally contains a message and zero or more tool calls.

--- a/swiftide-core/src/indexing_stream.rs
+++ b/swiftide-core/src/indexing_stream.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::from_over_into)]
 
-//! This module defines the `IndexingStream` type, which is used internally by a pipeline  for handling asynchronous streams of `Node` items in the indexing pipeline.
+//! This module defines the `IndexingStream` type, which is used internally by a pipeline  for
+//! handling asynchronous streams of `Node` items in the indexing pipeline.
 
 use crate::node::Node;
 use anyhow::Result;

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -59,7 +59,8 @@ pub struct Node {
     /// Size of the input this node was originally derived from in bytes
     #[builder(default)]
     pub original_size: usize,
-    /// Offset of the chunk relative to the start of the input this node was originally derived from in bytes
+    /// Offset of the chunk relative to the start of the input this node was originally derived
+    /// from in bytes
     #[builder(default)]
     pub offset: usize,
 }
@@ -205,8 +206,8 @@ impl Node {
 
     /// Converts the node into an [`self::EmbeddedField::Combined`] type of embeddable.
     ///
-    /// This embeddable format consists of the metadata formatted as key-value pairs, each on a new line,
-    /// followed by the data chunk.
+    /// This embeddable format consists of the metadata formatted as key-value pairs, each on a new
+    /// line, followed by the data chunk.
     ///
     /// # Returns
     ///
@@ -266,7 +267,8 @@ pub enum EmbedMode {
     SingleWithMetadata,
     /// Embedding Chunk of data and every Metadata separately.
     PerField,
-    /// Embedding Chunk of data and every Metadata separately and Chunk of data combined with Metadata.
+    /// Embedding Chunk of data and every Metadata separately and Chunk of data combined with
+    /// Metadata.
     Both,
 }
 

--- a/swiftide-core/src/prompt.rs
+++ b/swiftide-core/src/prompt.rs
@@ -11,8 +11,8 @@
 //! needed.
 //!
 //! [`Template`] can be added with [`Template::try_compiled_from_str`]. Prompts can also be
-//! created on the fly from anything that implements [`Into<String>`]. Compiled prompts are stored in
-//! an internal repository.
+//! created on the fly from anything that implements [`Into<String>`]. Compiled prompts are stored
+//! in an internal repository.
 //!
 //! Additionally, `Template::String` and `Template::Static` can be used to create
 //! templates on the fly as well.

--- a/swiftide-indexing/src/loaders/file_loader.rs
+++ b/swiftide-indexing/src/loaders/file_loader.rs
@@ -8,7 +8,8 @@ use anyhow::Context as _;
 use swiftide_core::{indexing::IndexingStream, indexing::Node, Loader};
 
 /// The `FileLoader` struct is responsible for loading files from a specified directory,
-/// filtering them based on their extensions, and creating a stream of these files for further processing.
+/// filtering them based on their extensions, and creating a stream of these files for further
+/// processing.
 ///
 /// # Example
 ///

--- a/swiftide-indexing/src/loaders/mod.rs
+++ b/swiftide-indexing/src/loaders/mod.rs
@@ -1,8 +1,10 @@
 //! The `loaders` module provides functionality for loading files from a specified directory.
-//! It includes the `FileLoader` struct which is used to filter and stream files based on their extensions.
+//! It includes the `FileLoader` struct which is used to filter and stream files based on their
+//! extensions.
 //!
-//! This module is a part of the Swiftide project, designed for asynchronous file indexing and processing.
-//! The `FileLoader` struct is re-exported for ease of use in other parts of the project.
+//! This module is a part of the Swiftide project, designed for asynchronous file indexing and
+//! processing. The `FileLoader` struct is re-exported for ease of use in other parts of the
+//! project.
 
 pub mod file_loader;
 

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -14,17 +14,18 @@ use swiftide_core::indexing::{EmbedMode, IndexingStream, Node};
 /// The default batch size for batch processing.
 const DEFAULT_BATCH_SIZE: usize = 256;
 
-/// A pipeline for indexing files, adding metadata, chunking, transforming, embedding, and then storing them.
+/// A pipeline for indexing files, adding metadata, chunking, transforming, embedding, and then
+/// storing them.
 ///
-/// The `Pipeline` struct orchestrates the entire file indexing process. It is designed to be flexible and
-/// performant, allowing for various stages of data transformation and storage to be configured and executed asynchronously.
+/// The `Pipeline` struct orchestrates the entire file indexing process. It is designed to be
+/// flexible and performant, allowing for various stages of data transformation and storage to be
+/// configured and executed asynchronously.
 ///
 /// # Fields
 ///
 /// * `stream` - The stream of `Node` items to be processed.
 /// * `storage` - Optional storage backend where the processed nodes will be stored.
 /// * `concurrency` - The level of concurrency for processing nodes.
-///
 pub struct Pipeline {
     stream: IndexingStream,
     storage: Vec<Arc<dyn Persist>>,
@@ -34,7 +35,8 @@ pub struct Pipeline {
 }
 
 impl Default for Pipeline {
-    /// Creates a default `Pipeline` with an empty stream, no storage, and a concurrency level equal to the number of CPUs.
+    /// Creates a default `Pipeline` with an empty stream, no storage, and a concurrency level equal
+    /// to the number of CPUs.
     fn default() -> Self {
         Self {
             stream: IndexingStream::empty(),
@@ -104,8 +106,8 @@ impl Pipeline {
         self
     }
 
-    /// Sets the embed mode for the pipeline. The embed mode controls what (combination) fields of a [`Node`]
-    /// be embedded with a vector when transforming with [`crate::transformers::Embed`]
+    /// Sets the embed mode for the pipeline. The embed mode controls what (combination) fields of a
+    /// [`Node`] be embedded with a vector when transforming with [`crate::transformers::Embed`]
     ///
     /// See also [`swiftide_core::indexing::EmbedMode`].
     ///
@@ -208,7 +210,8 @@ impl Pipeline {
 
     /// Adds a batch transformer to the pipeline.
     ///
-    /// If the transformer has a batch size set, the batch size from the transformer is used, otherwise the pipeline default batch size ([`DEFAULT_BATCH_SIZE`]).
+    /// If the transformer has a batch size set, the batch size from the transformer is used,
+    /// otherwise the pipeline default batch size ([`DEFAULT_BATCH_SIZE`]).
     ///
     /// # Arguments
     ///
@@ -216,7 +219,8 @@ impl Pipeline {
     ///
     /// # Returns
     ///
-    /// An instance of `Pipeline` with the updated stream that applies the batch transformer to each batch of nodes.
+    /// An instance of `Pipeline` with the updated stream that applies the batch transformer to each
+    /// batch of nodes.
     #[must_use]
     pub fn then_in_batch(
         mut self,
@@ -263,7 +267,8 @@ impl Pipeline {
     ///
     /// # Returns
     ///
-    /// An instance of `Pipeline` with the updated stream that applies the chunker transformer to each node.
+    /// An instance of `Pipeline` with the updated stream that applies the chunker transformer to
+    /// each node.
     #[must_use]
     pub fn then_chunk(mut self, chunker: impl ChunkerTransformer + 'static) -> Self {
         let chunker = Arc::new(chunker);
@@ -449,7 +454,8 @@ impl Pipeline {
 
     /// Throttles the stream of nodes, limiting the rate to 1 per duration.
     ///
-    /// Useful for rate limiting the indexing pipeline. Uses `tokio_stream::StreamExt::throttle` internally which has a granualarity of 1ms.
+    /// Useful for rate limiting the indexing pipeline. Uses `tokio_stream::StreamExt::throttle`
+    /// internally which has a granualarity of 1ms.
     #[must_use]
     pub fn throttle(mut self, duration: impl Into<Duration>) -> Self {
         self.stream = tokio_stream::StreamExt::throttle(self.stream, duration.into())
@@ -460,8 +466,8 @@ impl Pipeline {
 
     // Silently filters out errors encountered by the pipeline.
     //
-    // This method filters out errors encountered by the pipeline, preventing them from bubbling up and terminating the stream.
-    // Note that errors are not logged.
+    // This method filters out errors encountered by the pipeline, preventing them from bubbling up
+    // and terminating the stream. Note that errors are not logged.
     #[must_use]
     pub fn filter_errors(mut self) -> Self {
         self.stream = self
@@ -535,7 +541,8 @@ impl Pipeline {
 
     /// Runs the indexing pipeline.
     ///
-    /// This method processes the stream of nodes, applying all configured transformations and storing the results.
+    /// This method processes the stream of nodes, applying all configured transformations and
+    /// storing the results.
     ///
     /// # Returns
     ///

--- a/swiftide-indexing/src/transformers/embed.rs
+++ b/swiftide-indexing/src/transformers/embed.rs
@@ -52,8 +52,8 @@ impl Embed {
     }
 
     /// Sets the batch size for the transformer.
-    /// If the batch size is not set, the transformer will use the default batch size set by the pipeline
-    /// # Parameters
+    /// If the batch size is not set, the transformer will use the default batch size set by the
+    /// pipeline # Parameters
     ///
     /// * `batch_size` - The batch size to use for the transformer.
     ///

--- a/swiftide-indexing/src/transformers/sparse_embed.rs
+++ b/swiftide-indexing/src/transformers/sparse_embed.rs
@@ -10,7 +10,8 @@ use swiftide_core::{
 
 /// A transformer that can generate embeddings for an `Node`
 ///
-/// This file defines the `SparseEmbed` struct and its implementation of the `BatchableTransformer` trait.
+/// This file defines the `SparseEmbed` struct and its implementation of the `BatchableTransformer`
+/// trait.
 #[derive(Clone)]
 pub struct SparseEmbed {
     embed_model: Arc<dyn SparseEmbeddingModel>,
@@ -51,8 +52,8 @@ impl SparseEmbed {
     }
 
     /// Sets the batch size for the transformer.
-    /// If the batch size is not set, the transformer will use the default batch size set by the pipeline
-    /// # Parameters
+    /// If the batch size is not set, the transformer will use the default batch size set by the
+    /// pipeline # Parameters
     ///
     /// * `batch_size` - The batch size to use for the transformer.
     ///

--- a/swiftide-integrations/src/duckdb/mod.rs
+++ b/swiftide-integrations/src/duckdb/mod.rs
@@ -24,7 +24,9 @@ const DEFAULT_UPSERT_QUERY: &str = include_str!("upsert.sql");
 pub struct Duckdb {
     /// The connection to the database
     #[builder(setter(custom))]
-    connection: Arc<Mutex<duckdb::Connection>>, // should be rwlock, however, internally duckdb uses a refcell, so we need the mutex for sync :(
+    connection: Arc<Mutex<duckdb::Connection>>, /* should be rwlock, however, internally duckdb
+                                                 * uses a refcell, so we need the mutex for sync
+                                                 * :( */
 
     /// The name of the table to use for storing nodes. Defaults to "swiftide".
     #[builder(default = "swiftide".into())]

--- a/swiftide-integrations/src/duckdb/persist.rs
+++ b/swiftide-integrations/src/duckdb/persist.rs
@@ -29,7 +29,7 @@ impl ToSql for NodeValues<'_> {
     fn to_sql(&self) -> duckdb::Result<ToSqlOutput<'_>> {
         match self {
             NodeValues::Uuid(uuid) => Ok(ToSqlOutput::Owned(uuid.to_string().into())),
-            NodeValues::Path(path) => Ok(path.to_string_lossy().to_string().into()), // Should be borrow-able
+            NodeValues::Path(path) => Ok(path.to_string_lossy().to_string().into()), /* Should be borrow-able */
             NodeValues::Chunk(chunk) => chunk.to_sql(),
             NodeValues::Metadata(_metadata) => {
                 unimplemented!("maps are not yet implemented for duckdb");
@@ -174,9 +174,11 @@ mod tests {
                     Ok((
                         row.get::<_, String>(0).unwrap(), // id
                         row.get::<_, String>(1).unwrap(), // chunk
-                        row.get::<_, String>(2).unwrap(), // path
-                                                          // row.get::<_, String>(3).unwrap(), // metadata
-                                                          // row.get::<_, Vec<f32>>(4).unwrap(), // vector
+                        row.get::<_, String>(2).unwrap(), /* path
+                                                           * row.get::<_, String>(3).unwrap(),
+                                                           * // metadata
+                                                           * row.get::<_, Vec<f32>>(4).unwrap(),
+                                                           * // vector */
                     ))
                 })
                 .unwrap();
@@ -211,9 +213,11 @@ mod tests {
                     Ok((
                         row.get::<_, String>(0).unwrap(), // id
                         row.get::<_, String>(1).unwrap(), // chunk
-                        row.get::<_, String>(2).unwrap(), // path
-                                                          // row.get::<_, String>(3).unwrap(), // metadata
-                                                          // row.get::<_, Vec<f32>>(4).unwrap(), // vector
+                        row.get::<_, String>(2).unwrap(), /* path
+                                                           * row.get::<_, String>(3).unwrap(),
+                                                           * // metadata
+                                                           * row.get::<_, Vec<f32>>(4).unwrap(),
+                                                           * // vector */
                     ))
                 })
                 .unwrap();
@@ -244,9 +248,11 @@ mod tests {
                     Ok((
                         row.get::<_, String>(0).unwrap(), // id
                         row.get::<_, String>(1).unwrap(), // chunk
-                        row.get::<_, String>(2).unwrap(), // path
-                                                          // row.get::<_, String>(3).unwrap(), // metadata
-                                                          // row.get::<_, Vec<f32>>(4).unwrap(), // vector
+                        row.get::<_, String>(2).unwrap(), /* path
+                                                           * row.get::<_, String>(3).unwrap(),
+                                                           * // metadata
+                                                           * row.get::<_, Vec<f32>>(4).unwrap(),
+                                                           * // vector */
                     ))
                 })
                 .unwrap();

--- a/swiftide-integrations/src/fastembed/mod.rs
+++ b/swiftide-integrations/src/fastembed/mod.rs
@@ -53,7 +53,8 @@ const DEFAULT_BATCH_SIZE: usize = 256;
 /// also be set and is recommended. Batch size should match the batch size in the indexing
 /// pipeline.
 ///
-/// Note that the embedding vector dimensions need to match the dimensions of the vector database collection
+/// Note that the embedding vector dimensions need to match the dimensions of the vector database
+/// collection
 ///
 /// Requires the `fastembed` feature to be enabled.
 #[derive(Builder, Clone)]

--- a/swiftide-integrations/src/fastembed/rerank.rs
+++ b/swiftide-integrations/src/fastembed/rerank.rs
@@ -25,7 +25,6 @@ const TOP_K: usize = 10;
 ///
 /// Can be customized with any rerank model from `fastembed` and the number of top documents to
 /// return. Optionally you can provide a template to render the document before reranking.
-///
 #[derive(Clone, Builder)]
 pub struct Rerank {
     /// The reranker model from [`Fastembed`]

--- a/swiftide-integrations/src/groq/mod.rs
+++ b/swiftide-integrations/src/groq/mod.rs
@@ -1,6 +1,6 @@
-//! This module provides integration with `Groq`'s API, enabling the use of language models within the Swiftide project.
-//! It includes the `Groq` struct for managing API clients and default options for prompt models.
-//! The module is conditionally compiled based on the "groq" feature flag.
+//! This module provides integration with `Groq`'s API, enabling the use of language models within
+//! the Swiftide project. It includes the `Groq` struct for managing API clients and default options
+//! for prompt models. The module is conditionally compiled based on the "groq" feature flag.
 
 use crate::openai;
 

--- a/swiftide-integrations/src/ollama/mod.rs
+++ b/swiftide-integrations/src/ollama/mod.rs
@@ -1,6 +1,7 @@
-//! This module provides integration with `Ollama`'s API, enabling the use of language models and embeddings within the Swiftide project.
-//! It includes the `Ollama` struct for managing API clients and default options for embedding and prompt models.
-//! The module is conditionally compiled based on the "ollama" feature flag.
+//! This module provides integration with `Ollama`'s API, enabling the use of language models and
+//! embeddings within the Swiftide project. It includes the `Ollama` struct for managing API clients
+//! and default options for embedding and prompt models. The module is conditionally compiled based
+//! on the "ollama" feature flag.
 
 use config::OllamaConfig;
 use derive_builder::Builder;
@@ -11,12 +12,13 @@ pub mod config;
 pub mod embed;
 pub mod simple_prompt;
 
-/// The `Ollama` struct encapsulates an `Ollama` client and default options for embedding and prompt models.
-/// It uses the `Builder` pattern for flexible and customizable instantiation.
+/// The `Ollama` struct encapsulates an `Ollama` client and default options for embedding and prompt
+/// models. It uses the `Builder` pattern for flexible and customizable instantiation.
 ///
-/// By default it will look for a `OLLAMA_API_KEY` environment variable. Note that either a prompt model or embedding model
-/// always need to be set, either with [`Ollama::with_default_prompt_model`] or [`Ollama::with_default_embed_model`] or via the builder.
-/// You can find available models in the Ollama documentation.
+/// By default it will look for a `OLLAMA_API_KEY` environment variable. Note that either a prompt
+/// model or embedding model always need to be set, either with
+/// [`Ollama::with_default_prompt_model`] or [`Ollama::with_default_embed_model`] or via the
+/// builder. You can find available models in the Ollama documentation.
 ///
 /// Under the hood it uses [`async_openai`], with the Ollama openai mapping. This means
 /// some features might not work as expected. See the Ollama documentation for details.

--- a/swiftide-integrations/src/ollama/simple_prompt.rs
+++ b/swiftide-integrations/src/ollama/simple_prompt.rs
@@ -1,6 +1,6 @@
 //! This module provides an implementation of the `SimplePrompt` trait for the `Ollama` struct.
-//! It defines an asynchronous function to interact with the `Ollama` API, allowing prompt processing
-//! and generating responses as part of the Swiftide system.
+//! It defines an asynchronous function to interact with the `Ollama` API, allowing prompt
+//! processing and generating responses as part of the Swiftide system.
 use async_openai::types::{ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs};
 use async_trait::async_trait;
 use swiftide_core::{prompt::Prompt, util::debug_long_utf8, SimplePrompt};
@@ -8,7 +8,8 @@ use swiftide_core::{prompt::Prompt, util::debug_long_utf8, SimplePrompt};
 use super::Ollama;
 use anyhow::{Context as _, Result};
 
-/// The `SimplePrompt` trait defines a method for sending a prompt to an AI model and receiving a response.
+/// The `SimplePrompt` trait defines a method for sending a prompt to an AI model and receiving a
+/// response.
 #[async_trait]
 impl SimplePrompt for Ollama {
     /// Sends a prompt to the Ollama API and returns the response content.
@@ -17,8 +18,8 @@ impl SimplePrompt for Ollama {
     /// - `prompt`: A string slice that holds the prompt to be sent to the Ollama API.
     ///
     /// # Returns
-    /// - `Result<String>`: On success, returns the content of the response as a `String`.
-    ///   On failure, returns an error wrapped in a `Result`.
+    /// - `Result<String>`: On success, returns the content of the response as a `String`. On
+    ///   failure, returns an error wrapped in a `Result`.
     ///
     /// # Errors
     /// - Returns an error if the model is not set in the default options.

--- a/swiftide-integrations/src/open_router/mod.rs
+++ b/swiftide-integrations/src/open_router/mod.rs
@@ -1,6 +1,7 @@
-//! This module provides integration with `OpenRouter`'s API, enabling the use of language models and embeddings within the Swiftide project.
-//! It includes the `OpenRouter` struct for managing API clients and default options for embedding and prompt models.
-//! The module is conditionally compiled based on the "openrouter" feature flag.
+//! This module provides integration with `OpenRouter`'s API, enabling the use of language models
+//! and embeddings within the Swiftide project. It includes the `OpenRouter` struct for managing API
+//! clients and default options for embedding and prompt models. The module is conditionally
+//! compiled based on the "openrouter" feature flag.
 
 use config::OpenRouterConfig;
 use derive_builder::Builder;
@@ -10,12 +11,13 @@ pub mod chat_completion;
 pub mod config;
 pub mod simple_prompt;
 
-/// The `OpenRouter` struct encapsulates an `OpenRouter` client and default options for embedding and prompt models.
-/// It uses the `Builder` pattern for flexible and customizable instantiation.
+/// The `OpenRouter` struct encapsulates an `OpenRouter` client and default options for embedding
+/// and prompt models. It uses the `Builder` pattern for flexible and customizable instantiation.
 ///
-/// By default it will look for a `OPENROUTER_API_KEY` environment variable. Note that either a prompt model or embedding model
-/// always need to be set, either with [`OpenRouter::with_default_prompt_model`] or [`OpenRouter::with_default_embed_model`] or via the builder.
-/// You can find available models in the `OpenRouter` documentation.
+/// By default it will look for a `OPENROUTER_API_KEY` environment variable. Note that either a
+/// prompt model or embedding model always need to be set, either with
+/// [`OpenRouter::with_default_prompt_model`] or [`OpenRouter::with_default_embed_model`] or via the
+/// builder. You can find available models in the `OpenRouter` documentation.
 ///
 /// Under the hood it uses [`async_openai`], with the `OpenRouter` openai compatible api. This means
 /// some features might not work as expected. See the `OpenRouter` documentation for details.

--- a/swiftide-integrations/src/open_router/simple_prompt.rs
+++ b/swiftide-integrations/src/open_router/simple_prompt.rs
@@ -1,6 +1,6 @@
 //! This module provides an implementation of the `SimplePrompt` trait for the `OpenRouter` struct.
-//! It defines an asynchronous function to interact with the `OpenRouter` API, allowing prompt processing
-//! and generating responses as part of the Swiftide system.
+//! It defines an asynchronous function to interact with the `OpenRouter` API, allowing prompt
+//! processing and generating responses as part of the Swiftide system.
 use async_openai::types::{ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs};
 use async_trait::async_trait;
 use swiftide_core::{prompt::Prompt, util::debug_long_utf8, SimplePrompt};
@@ -8,7 +8,8 @@ use swiftide_core::{prompt::Prompt, util::debug_long_utf8, SimplePrompt};
 use super::OpenRouter;
 use anyhow::{Context as _, Result};
 
-/// The `SimplePrompt` trait defines a method for sending a prompt to an AI model and receiving a response.
+/// The `SimplePrompt` trait defines a method for sending a prompt to an AI model and receiving a
+/// response.
 #[async_trait]
 impl SimplePrompt for OpenRouter {
     /// Sends a prompt to the OpenRouter API and returns the response content.
@@ -17,8 +18,8 @@ impl SimplePrompt for OpenRouter {
     /// - `prompt`: A string slice that holds the prompt to be sent to the OpenRouter API.
     ///
     /// # Returns
-    /// - `Result<String>`: On success, returns the content of the response as a `String`.
-    ///   On failure, returns an error wrapped in a `Result`.
+    /// - `Result<String>`: On success, returns the content of the response as a `String`. On
+    ///   failure, returns an error wrapped in a `Result`.
     ///
     /// # Errors
     /// - Returns an error if the model is not set in the default options.

--- a/swiftide-integrations/src/openai/mod.rs
+++ b/swiftide-integrations/src/openai/mod.rs
@@ -1,6 +1,7 @@
-//! This module provides integration with `OpenAI`'s API, enabling the use of language models and embeddings within the Swiftide project.
-//! It includes the `OpenAI` struct for managing API clients and default options for embedding and prompt models.
-//! The module is conditionally compiled based on the "openai" feature flag.
+//! This module provides integration with `OpenAI`'s API, enabling the use of language models and
+//! embeddings within the Swiftide project. It includes the `OpenAI` struct for managing API clients
+//! and default options for embedding and prompt models. The module is conditionally compiled based
+//! on the "openai" feature flag.
 
 use derive_builder::Builder;
 use std::sync::Arc;
@@ -13,8 +14,8 @@ mod simple_prompt;
 pub use async_openai::config::AzureConfig;
 pub use async_openai::config::OpenAIConfig;
 
-/// The `OpenAI` struct encapsulates an `OpenAI` client and default options for embedding and prompt models.
-/// It uses the `Builder` pattern for flexible and customizable instantiation.
+/// The `OpenAI` struct encapsulates an `OpenAI` client and default options for embedding and prompt
+/// models. It uses the `Builder` pattern for flexible and customizable instantiation.
 ///
 /// # Example
 ///
@@ -34,7 +35,7 @@ pub use async_openai::config::OpenAIConfig;
 ///     .default_prompt_model("gpt-4")
 ///     .client(async_openai::Client::with_config(async_openai::config::OpenAIConfig::default().with_api_key("my-api-key")))
 ///     .build().unwrap();
-///```
+/// ```
 pub type OpenAI = GenericOpenAI<OpenAIConfig>;
 pub type OpenAIBuilder = GenericOpenAIBuilder<OpenAIConfig>;
 

--- a/swiftide-integrations/src/openai/simple_prompt.rs
+++ b/swiftide-integrations/src/openai/simple_prompt.rs
@@ -1,6 +1,6 @@
 //! This module provides an implementation of the `SimplePrompt` trait for the `OpenAI` struct.
-//! It defines an asynchronous function to interact with the `OpenAI` API, allowing prompt processing
-//! and generating responses as part of the Swiftide system.
+//! It defines an asynchronous function to interact with the `OpenAI` API, allowing prompt
+//! processing and generating responses as part of the Swiftide system.
 use async_openai::types::{ChatCompletionRequestUserMessageArgs, CreateChatCompletionRequestArgs};
 use async_trait::async_trait;
 use swiftide_core::{prompt::Prompt, util::debug_long_utf8, SimplePrompt};
@@ -8,7 +8,8 @@ use swiftide_core::{prompt::Prompt, util::debug_long_utf8, SimplePrompt};
 use super::GenericOpenAI;
 use anyhow::{Context as _, Result};
 
-/// The `SimplePrompt` trait defines a method for sending a prompt to an AI model and receiving a response.
+/// The `SimplePrompt` trait defines a method for sending a prompt to an AI model and receiving a
+/// response.
 #[async_trait]
 impl<C: async_openai::config::Config + std::default::Default + Sync + Send + std::fmt::Debug>
     SimplePrompt for GenericOpenAI<C>
@@ -19,8 +20,8 @@ impl<C: async_openai::config::Config + std::default::Default + Sync + Send + std
     /// - `prompt`: A string slice that holds the prompt to be sent to the OpenAI API.
     ///
     /// # Returns
-    /// - `Result<String>`: On success, returns the content of the response as a `String`.
-    ///   On failure, returns an error wrapped in a `Result`.
+    /// - `Result<String>`: On success, returns the content of the response as a `String`. On
+    ///   failure, returns an error wrapped in a `Result`.
     ///
     /// # Errors
     /// - Returns an error if the model is not set in the default options.

--- a/swiftide-integrations/src/pgvector/mod.rs
+++ b/swiftide-integrations/src/pgvector/mod.rs
@@ -53,8 +53,9 @@ const BATCH_SIZE: usize = 50;
 
 /// Represents a Pgvector client with configuration options.
 ///
-/// This struct is used to interact with the Pgvector vector database, providing methods to manage vector collections,
-/// store data, and ensure efficient searches. The client can be cloned with low cost as it shares connections.
+/// This struct is used to interact with the Pgvector vector database, providing methods to manage
+/// vector collections, store data, and ensure efficient searches. The client can be cloned with low
+/// cost as it shares connections.
 #[derive(Builder, Clone)]
 #[builder(setter(into, strip_option), build_fn(error = "anyhow::Error"))]
 pub struct PgVector {
@@ -121,18 +122,18 @@ impl PgVector {
 
     /// Retrieves a connection pool for `PostgreSQL`.
     ///
-    /// This function returns the connection pool used for interacting with the `PostgreSQL` database.
-    /// It fetches the pool from the `PgDBConnectionPool` struct.
+    /// This function returns the connection pool used for interacting with the `PostgreSQL`
+    /// database. It fetches the pool from the `PgDBConnectionPool` struct.
     ///
     /// # Returns
     ///
-    /// A `Result` that, on success, contains the `PgPool` representing the database connection pool.
-    /// On failure, an error is returned.
+    /// A `Result` that, on success, contains the `PgPool` representing the database connection
+    /// pool. On failure, an error is returned.
     ///
     /// # Errors
     ///
-    /// This function will return an error if it fails to retrieve the connection pool, which could occur
-    /// if the underlying connection to `PostgreSQL` has not been properly established.
+    /// This function will return an error if it fails to retrieve the connection pool, which could
+    /// occur if the underlying connection to `PostgreSQL` has not been properly established.
     pub async fn get_pool(&self) -> Result<&PgPool> {
         self.pool_get_or_initialize().await
     }
@@ -163,8 +164,9 @@ impl PgVectorBuilder {
 
     /// Sets the metadata configuration for the vector similarity search.
     ///
-    /// This method allows you to specify metadata configurations for vector similarity search using `MetadataConfig`.
-    /// The provided configuration will be added as a new field in the builder.
+    /// This method allows you to specify metadata configurations for vector similarity search using
+    /// `MetadataConfig`. The provided configuration will be added as a new field in the
+    /// builder.
     ///
     /// # Arguments
     ///

--- a/swiftide-integrations/src/pgvector/pgv_table_types.rs
+++ b/swiftide-integrations/src/pgvector/pgv_table_types.rs
@@ -5,7 +5,6 @@
 //! - Field configuration for different vector embedding types
 //! - HNSW index creation for similarity search optimization
 //! - Bulk data preparation and SQL query generation
-//!
 use crate::pgvector::PgVector;
 use anyhow::{anyhow, Result};
 use pgvector as ExtPgVector;
@@ -172,7 +171,7 @@ impl PgVector {
     ///
     /// # Errors
     ///
-    /// *  Returns an error if the table name is invalid or if `vector_size` is not configured.
+    /// * Returns an error if the table name is invalid or if `vector_size` is not configured.
     pub fn generate_create_table_sql(&self) -> Result<String> {
         // Validate table_name and field_name (e.g., check against allowed patterns)
         if !Self::is_valid_identifier(&self.table_name) {
@@ -246,7 +245,8 @@ impl PgVector {
     ///
     /// This function will return an error if:
     /// - The database connection pool is not established.
-    /// - Any of the SQL queries fail to execute due to schema mismatch, constraint violations, or connectivity issues.
+    /// - Any of the SQL queries fail to execute due to schema mismatch, constraint violations, or
+    ///   connectivity issues.
     /// - Committing the transaction fails.
     pub async fn store_nodes(&self, nodes: &[Node]) -> Result<()> {
         let pool = self.pool_get_or_initialize().await?;

--- a/swiftide-integrations/src/qdrant/indexing_node.rs
+++ b/swiftide-integrations/src/qdrant/indexing_node.rs
@@ -30,8 +30,8 @@ impl TryInto<qdrant::PointStruct> for NodeWithVectors<'_> {
     ///
     /// # Returns
     ///
-    /// A `Result` which is `Ok` if the conversion is successful, containing the `qdrant::PointStruct`.
-    /// If the conversion fails, it returns an `anyhow::Error`.
+    /// A `Result` which is `Ok` if the conversion is successful, containing the
+    /// `qdrant::PointStruct`. If the conversion fails, it returns an `anyhow::Error`.
     fn try_into(self) -> Result<qdrant::PointStruct> {
         let node = self.node;
         // Calculate a unique identifier for the node.

--- a/swiftide-integrations/src/qdrant/mod.rs
+++ b/swiftide-integrations/src/qdrant/mod.rs
@@ -1,6 +1,6 @@
 //! This module provides integration with the Qdrant vector database.
-//! It includes functionalities to interact with Qdrant, such as creating and managing vector collections,
-//! storing data, and ensuring proper indexing for efficient searches.
+//! It includes functionalities to interact with Qdrant, such as creating and managing vector
+//! collections, storing data, and ensuring proper indexing for efficient searches.
 //!
 //! Qdrant can be used both in `indexing::Pipeline` and `query::Pipeline`
 
@@ -23,8 +23,8 @@ const DEFAULT_BATCH_SIZE: usize = 50;
 
 /// A struct representing a Qdrant client with configuration options.
 ///
-/// This struct is used to interact with the Qdrant vector database, providing methods to create and manage
-/// vector collections, store data, and ensure proper indexing for efficient searches.
+/// This struct is used to interact with the Qdrant vector database, providing methods to create and
+/// manage vector collections, store data, and ensure proper indexing for efficient searches.
 ///
 /// Can be cloned with relative low cost as the client is shared.
 #[derive(Builder, Clone)]
@@ -65,7 +65,8 @@ impl Qdrant {
         QdrantBuilder::default()
     }
 
-    /// Tries to create a `QdrantBuilder` from a given URL. Will use the api key in `QDRANT_API_KEY` if present.
+    /// Tries to create a `QdrantBuilder` from a given URL. Will use the api key in `QDRANT_API_KEY`
+    /// if present.
     ///
     /// Returns
     ///
@@ -90,8 +91,8 @@ impl Qdrant {
 
     /// Creates an index in the Qdrant collection if it does not already exist.
     ///
-    /// This method checks if the specified collection exists in Qdrant. If it does not exist, it creates a new collection
-    /// with the specified vector size and cosine distance metric.
+    /// This method checks if the specified collection exists in Qdrant. If it does not exist, it
+    /// creates a new collection with the specified vector size and cosine distance metric.
     ///
     /// # Returns
     ///
@@ -196,9 +197,10 @@ impl QdrantBuilder {
 
     /// Configures a dense vector on the collection
     ///
-    /// When not configured Pipeline by default configures vector only for [`EmbeddedField::Combined`]
-    /// Default config is enough when `indexing::Pipeline::with_embed_mode` is not set
-    /// or when the value is set to [`swiftide_core::indexing::EmbedMode::SingleWithMetadata`].
+    /// When not configured Pipeline by default configures vector only for
+    /// [`EmbeddedField::Combined`] Default config is enough when
+    /// `indexing::Pipeline::with_embed_mode` is not set or when the value is set to
+    /// [`swiftide_core::indexing::EmbedMode::SingleWithMetadata`].
     #[must_use]
     pub fn with_vector(mut self, vector: impl Into<VectorConfig>) -> QdrantBuilder {
         if self.vectors.is_none() {

--- a/swiftide-integrations/src/qdrant/persist.rs
+++ b/swiftide-integrations/src/qdrant/persist.rs
@@ -1,6 +1,6 @@
 //! This module provides an implementation of the `Storage` trait for the `Qdrant` struct.
-//! It includes methods for setting up the storage, storing a single node, and storing a batch of nodes.
-//! This integration allows the Swiftide project to use Qdrant as a storage backend.
+//! It includes methods for setting up the storage, storing a single node, and storing a batch of
+//! nodes. This integration allows the Swiftide project to use Qdrant as a storage backend.
 
 use std::collections::HashSet;
 use swiftide_core::{

--- a/swiftide-integrations/src/redis/mod.rs
+++ b/swiftide-integrations/src/redis/mod.rs
@@ -12,7 +12,8 @@
 //! - Setting a node in the cache
 //! - Resetting the cache (primarily for testing purposes)
 //!
-//! This integration is essential for ensuring efficient node management and caching in the Swiftide system.
+//! This integration is essential for ensuring efficient node management and caching in the Swiftide
+//! system.
 
 use anyhow::{Context as _, Result};
 use derive_builder::Builder;
@@ -94,7 +95,8 @@ impl Redis {
     ///
     /// # Returns
     ///
-    /// An `Option` containing the `ConnectionManager` if the connection is successful, or `None` if it fails.
+    /// An `Option` containing the `ConnectionManager` if the connection is successful, or `None` if
+    /// it fails.
     ///
     /// # Errors
     ///

--- a/swiftide-integrations/src/redis/persist.rs
+++ b/swiftide-integrations/src/redis/persist.rs
@@ -21,9 +21,11 @@ impl Persist for Redis {
 
     /// Stores a node in Redis using the SET command.
     ///
-    /// By default nodes are stored with the path and hash as key and the node serialized as JSON as value.
+    /// By default nodes are stored with the path and hash as key and the node serialized as JSON as
+    /// value.
     ///
-    /// You can customize the key and value used for storing nodes by setting the `persist_key_fn` and `persist_value_fn` fields.
+    /// You can customize the key and value used for storing nodes by setting the `persist_key_fn`
+    /// and `persist_value_fn` fields.
     async fn store(&self, node: Node) -> Result<Node> {
         if let Some(mut cm) = self.lazy_connect().await {
             redis::cmd("SET")
@@ -41,9 +43,11 @@ impl Persist for Redis {
 
     /// Stores a batch of nodes in Redis using the MSET command.
     ///
-    /// By default nodes are stored with the path and hash as key and the node serialized as JSON as value.
+    /// By default nodes are stored with the path and hash as key and the node serialized as JSON as
+    /// value.
     ///
-    /// You can customize the key and value used for storing nodes by setting the `persist_key_fn` and `persist_value_fn` fields.
+    /// You can customize the key and value used for storing nodes by setting the `persist_key_fn`
+    /// and `persist_value_fn` fields.
     async fn batch_store(&self, nodes: Vec<Node>) -> IndexingStream {
         // use mset for batch store
         if let Some(mut cm) = self.lazy_connect().await {

--- a/swiftide-integrations/src/treesitter/chunk_code.rs
+++ b/swiftide-integrations/src/treesitter/chunk_code.rs
@@ -43,10 +43,12 @@ impl ChunkCode {
     /// Tries to create a `ChunkCode` instance for a given programming language.
     ///
     /// # Parameters
-    /// - `lang`: The programming language to be used for chunking. It should implement `TryInto<SupportedLanguages>`.
+    /// - `lang`: The programming language to be used for chunking. It should implement
+    ///   `TryInto<SupportedLanguages>`.
     ///
     /// # Returns
-    /// - `Result<Self>`: Returns an instance of `ChunkCode` if successful, otherwise returns an error.
+    /// - `Result<Self>`: Returns an instance of `ChunkCode` if successful, otherwise returns an
+    ///   error.
     ///
     /// # Errors
     /// - Returns an error if the language is not supported or if the `CodeSplitter` fails to build.
@@ -60,14 +62,17 @@ impl ChunkCode {
     /// Tries to create a `ChunkCode` instance for a given programming language and chunk size.
     ///
     /// # Parameters
-    /// - `lang`: The programming language to be used for chunking. It should implement `TryInto<SupportedLanguages>`.
+    /// - `lang`: The programming language to be used for chunking. It should implement
+    ///   `TryInto<SupportedLanguages>`.
     /// - `chunk_size`: The size of the chunks. It should implement `Into<ChunkSize>`.
     ///
     /// # Returns
-    /// - `Result<Self>`: Returns an instance of `ChunkCode` if successful, otherwise returns an error.
+    /// - `Result<Self>`: Returns an instance of `ChunkCode` if successful, otherwise returns an
+    ///   error.
     ///
     /// # Errors
-    /// - Returns an error if the language is not supported, if the chunk size is invalid, or if the `CodeSplitter` fails to build.
+    /// - Returns an error if the language is not supported, if the chunk size is invalid, or if the
+    ///   `CodeSplitter` fails to build.
     pub fn try_for_language_and_chunk_size(
         lang: impl TryInto<SupportedLanguages>,
         chunk_size: impl Into<ChunkSize>,

--- a/swiftide-integrations/src/treesitter/compress_code_outline.rs
+++ b/swiftide-integrations/src/treesitter/compress_code_outline.rs
@@ -1,4 +1,5 @@
-//! `CompressCodeOutline` is a transformer that reduces the size of the outline of a the parent file of a chunk to make it more relevant to the chunk.
+//! `CompressCodeOutline` is a transformer that reduces the size of the outline of a the parent file
+//! of a chunk to make it more relevant to the chunk.
 use std::sync::OnceLock;
 
 use anyhow::Result;
@@ -26,9 +27,11 @@ fn extract_markdown_codeblock(text: String) -> String {
 
 #[async_trait]
 impl Transformer for CompressCodeOutline {
-    /// Asynchronously transforms an `Node` by reducing the size of the outline to make it more relevant to the chunk.
+    /// Asynchronously transforms an `Node` by reducing the size of the outline to make it more
+    /// relevant to the chunk.
     ///
-    /// This method uses the `SimplePrompt` client to compress the outline of the `Node` and updates the `Node` with the compressed outline.
+    /// This method uses the `SimplePrompt` client to compress the outline of the `Node` and updates
+    /// the `Node` with the compressed outline.
     ///
     /// # Arguments
     ///
@@ -40,7 +43,8 @@ impl Transformer for CompressCodeOutline {
     ///
     /// # Errors
     ///
-    /// This function will return an error if the `SimplePrompt` client fails to generate a response.
+    /// This function will return an error if the `SimplePrompt` client fails to generate a
+    /// response.
     #[tracing::instrument(skip_all, name = "transformers.compress_code_outline")]
     async fn transform_node(&self, mut node: Node) -> Result<Node> {
         if node.metadata.get(NAME).is_none() {

--- a/swiftide-integrations/src/treesitter/metadata_qa_code.rs
+++ b/swiftide-integrations/src/treesitter/metadata_qa_code.rs
@@ -20,8 +20,8 @@ pub struct MetadataQACode {
 impl Transformer for MetadataQACode {
     /// Asynchronously transforms a `Node` by generating questions and answers for its code chunk.
     ///
-    /// This method uses the `SimplePrompt` client to generate questions and answers based on the code chunk
-    /// and adds this information to the node's metadata.
+    /// This method uses the `SimplePrompt` client to generate questions and answers based on the
+    /// code chunk and adds this information to the node's metadata.
     ///
     /// # Arguments
     ///
@@ -33,7 +33,8 @@ impl Transformer for MetadataQACode {
     ///
     /// # Errors
     ///
-    /// This function will return an error if the `SimplePrompt` client fails to generate a response.
+    /// This function will return an error if the `SimplePrompt` client fails to generate a
+    /// response.
     #[tracing::instrument(skip_all, name = "transformers.metadata_qa_code")]
     async fn transform_node(&self, mut node: Node) -> Result<Node> {
         let mut prompt = self

--- a/swiftide-integrations/src/treesitter/outline_code_tree_sitter.rs
+++ b/swiftide-integrations/src/treesitter/outline_code_tree_sitter.rs
@@ -20,10 +20,12 @@ impl OutlineCodeTreeSitter {
     /// Tries to create a `OutlineCodeTreeSitter` instance for a given programming language.
     ///
     /// # Parameters
-    /// - `lang`: The programming language to be used to parse the code. It should implement `TryInto<SupportedLanguages>`.
+    /// - `lang`: The programming language to be used to parse the code. It should implement
+    ///   `TryInto<SupportedLanguages>`.
     ///
     /// # Returns
-    /// - `Result<Self>`: Returns an instance of `OutlineCodeTreeSitter` if successful, otherwise returns an error.
+    /// - `Result<Self>`: Returns an instance of `OutlineCodeTreeSitter` if successful, otherwise
+    ///   returns an error.
     ///
     /// # Errors
     /// - Returns an error if the language is not supported or if the `CodeOutliner` fails to build.
@@ -51,7 +53,8 @@ impl Transformer for OutlineCodeTreeSitter {
     /// - `node`: The `Node` containing the code of which the context is to be generated.
     ///
     /// # Returns
-    /// - `Node`: The same `Node` instances, with the metadata updated to include the generated context.
+    /// - `Node`: The same `Node` instances, with the metadata updated to include the generated
+    ///   context.
     ///
     /// # Errors
     /// - If the code outlining fails, an error is sent downstream.

--- a/swiftide-integrations/src/treesitter/outliner.rs
+++ b/swiftide-integrations/src/treesitter/outliner.rs
@@ -8,12 +8,11 @@ use super::supported_languages::SupportedLanguages;
 #[derive(Debug, Builder, Clone)]
 /// Generates a summary of a code file.
 ///
-/// It does so by parsing the code file and removing function bodies, leaving only the function signatures and
-/// other top-level declarations along with any comments.
+/// It does so by parsing the code file and removing function bodies, leaving only the function
+/// signatures and other top-level declarations along with any comments.
 ///
-/// The resulting summary can be used as a context when considering subsets of the code file, or for determining
-/// relevance of the code file to a given task.
-///
+/// The resulting summary can be used as a context when considering subsets of the code file, or for
+/// determining relevance of the code file to a given task.
 #[builder(setter(into), build_fn(error = "anyhow::Error"))]
 pub struct CodeOutliner {
     #[builder(setter(custom))]
@@ -29,7 +28,8 @@ impl CodeOutlinerBuilder {
     ///
     /// # Returns
     ///
-    /// * `Result<Self>` - The builder instance with the language set, or an error if the language is not supported.
+    /// * `Result<Self>` - The builder instance with the language set, or an error if the language
+    ///   is not supported.
     ///
     /// # Errors
     /// * If the language is not supported, an error is returned.
@@ -75,7 +75,8 @@ impl CodeOutliner {
     ///
     /// # Returns
     ///
-    /// * `Result<String>` - A result containing a string, or an error if the code could not be parsed.
+    /// * `Result<String>` - A result containing a string, or an error if the code could not be
+    ///   parsed.
     ///
     /// # Errors
     /// * If the code could not be parsed, an error is returned.
@@ -179,7 +180,8 @@ mod tests {
 
     // Test every supported language.
     // We should strip away all code blocks and leave only imports, comments, function signatures,
-    // class, interface and structure definitions and definitions of constants, variables and other members.
+    // class, interface and structure definitions and definitions of constants, variables and other
+    // members.
     #[test]
     fn test_outline_rust() {
         let code = r#"

--- a/swiftide-integrations/src/treesitter/splitter.rs
+++ b/swiftide-integrations/src/treesitter/splitter.rs
@@ -31,7 +31,8 @@ impl CodeSplitterBuilder {
     ///
     /// # Returns
     ///
-    /// * `Result<Self>` - The builder instance with the language set, or an error if the language is not supported.
+    /// * `Result<Self>` - The builder instance with the language set, or an error if the language
+    ///   is not supported.
     ///
     /// # Errors
     ///
@@ -131,8 +132,10 @@ impl CodeSplitter {
             );
 
             // if the next child will make the chunk too big then there are two options:
-            // 1. if the next child is too big to fit in a whole chunk, then recursively chunk it one level down
-            // 2. if the next child is small enough to fit in a chunk, then add the current chunk to the list and start a new chunk
+            // 1. if the next child is too big to fit in a whole chunk, then recursively chunk it
+            //    one level down
+            // 2. if the next child is small enough to fit in a chunk, then add the current chunk to
+            //    the list and start a new chunk
 
             let next_child_size = child.end_byte() - last_end;
             if current_chunk.len() + next_child_size >= self.max_bytes() {
@@ -142,7 +145,8 @@ impl CodeSplitter {
                     current_chunk = sub_chunks.pop().unwrap_or_default();
                     new_chunks.extend(sub_chunks);
                 } else {
-                    // NOTE: if the current chunk was smaller than then the min_bytes, then it is discarded here
+                    // NOTE: if the current chunk was smaller than then the min_bytes, then it is
+                    // discarded here
                     if !current_chunk.is_empty() && current_chunk.len() > self.min_bytes() {
                         new_chunks.push(current_chunk);
                     }
@@ -170,7 +174,8 @@ impl CodeSplitter {
     ///
     /// # Returns
     ///
-    /// * `Result<Vec<String>>` - A result containing a vector of code chunks as strings, or an error if the code could not be parsed.
+    /// * `Result<Vec<String>>` - A result containing a vector of code chunks as strings, or an
+    ///   error if the code could not be parsed.
     ///
     /// # Errors
     ///

--- a/swiftide-integrations/src/treesitter/supported_languages.rs
+++ b/swiftide-integrations/src/treesitter/supported_languages.rs
@@ -1,8 +1,10 @@
-//! This module defines the supported programming languages for the Swiftide project and provides utility functions
-//! for mapping these languages to their respective file extensions and tree-sitter language objects.
+//! This module defines the supported programming languages for the Swiftide project and provides
+//! utility functions for mapping these languages to their respective file extensions and
+//! tree-sitter language objects.
 //!
-//! The primary purpose of this module is to facilitate the recognition and handling of different programming languages
-//! by mapping file extensions and converting language enums to tree-sitter language objects for accurate parsing and syntax analysis.
+//! The primary purpose of this module is to facilitate the recognition and handling of different
+//! programming languages by mapping file extensions and converting language enums to tree-sitter
+//! language objects for accurate parsing and syntax analysis.
 //!
 //! # Supported Languages
 //! - Rust
@@ -19,9 +21,10 @@ use serde::{Deserialize, Serialize};
 
 /// Enum representing the supported programming languages in the Swiftide project.
 ///
-/// This enum is used to map programming languages to their respective file extensions and tree-sitter language objects.
-/// The `EnumString` and `Display` macros from the `strum_macros` crate are used to provide string conversion capabilities.
-/// The `ascii_case_insensitive` attribute allows for case-insensitive string matching.
+/// This enum is used to map programming languages to their respective file extensions and
+/// tree-sitter language objects. The `EnumString` and `Display` macros from the `strum_macros`
+/// crate are used to provide string conversion capabilities. The `ascii_case_insensitive` attribute
+/// allows for case-insensitive string matching.
 #[derive(
     Debug,
     PartialEq,
@@ -118,14 +121,15 @@ impl SupportedLanguages {
 impl From<SupportedLanguages> for tree_sitter::Language {
     /// Converts a `SupportedLanguages` enum to a `tree_sitter::Language` object.
     ///
-    /// This implementation allows for the conversion of the supported languages to their respective tree-sitter language objects,
-    /// enabling accurate parsing and syntax analysis.
+    /// This implementation allows for the conversion of the supported languages to their respective
+    /// tree-sitter language objects, enabling accurate parsing and syntax analysis.
     ///
     /// # Parameters
     /// - `val`: The `SupportedLanguages` enum value to be converted.
     ///
     /// # Returns
-    /// A `tree_sitter::Language` object corresponding to the provided `SupportedLanguages` enum value.
+    /// A `tree_sitter::Language` object corresponding to the provided `SupportedLanguages` enum
+    /// value.
     fn from(val: SupportedLanguages) -> Self {
         match val {
             SupportedLanguages::Rust => tree_sitter_rust::LANGUAGE,

--- a/swiftide-macros/src/lib.rs
+++ b/swiftide-macros/src/lib.rs
@@ -40,9 +40,7 @@ pub fn indexing_transformer(args: TokenStream, input: TokenStream) -> TokenStrea
 /// // Or
 ///
 /// Agent::builder().tools([SearchCode::default()])
-///
 /// ```
-///
 pub fn tool(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemFn);
     tool_impl(&args.into(), &input).into()
@@ -66,9 +64,7 @@ pub fn tool(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     context.exec_cmd(&self.search_command.into()).await.map(Into::into)
 ///   }
 /// }
-///
 /// ```
-///
 #[proc_macro_derive(Tool, attributes(tool))]
 pub fn derive_tool(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/swiftide-query/src/answers/simple.rs
+++ b/swiftide-query/src/answers/simple.rs
@@ -12,11 +12,12 @@ use swiftide_core::{
 /// Generate an answer based on the current query
 ///
 /// For most general purposes, this transformer should provide a sensible default. It takes either
-/// a transformation that has already been applied to the documents (in `Query::current`), or the documents themselves,
-/// and will then feed them as context with the _original_ question to an llm to generate an
-/// answer.
+/// a transformation that has already been applied to the documents (in `Query::current`), or the
+/// documents themselves, and will then feed them as context with the _original_ question to an llm
+/// to generate an answer.
 ///
-/// Optionally, a custom document template can be provided to render the documents in a specific way.
+/// Optionally, a custom document template can be provided to render the documents in a specific
+/// way.
 #[derive(Debug, Clone, Builder)]
 pub struct Simple {
     #[builder(setter(custom))]

--- a/swiftide/src/lib.rs
+++ b/swiftide/src/lib.rs
@@ -4,11 +4,15 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc(html_logo_url = "https://github.com/bosun-ai/swiftide/raw/master/images/logo.png")]
 
-//! Swiftide is a data indexing and processing library, tailored for Retrieval Augmented Generation (RAG). When building applications with large language models (LLM), these LLMs need access to external resources. Data needs to be transformed, enriched, split up, embedded, and persisted. It is build in Rust, using parallel, asynchronous streams and is blazingly fast.
+//! Swiftide is a data indexing and processing library, tailored for Retrieval Augmented Generation
+//! (RAG). When building applications with large language models (LLM), these LLMs need access to
+//! external resources. Data needs to be transformed, enriched, split up, embedded, and persisted.
+//! It is build in Rust, using parallel, asynchronous streams and is blazingly fast.
 //!
 //! Part of the [bosun.ai](https://bosun.ai) project. An upcoming platform for autonomous code improvement.
 //!
-//! We <3 feedback: project ideas, suggestions, and complaints are very welcome. Feel free to open an issue.
+//! We <3 feedback: project ideas, suggestions, and complaints are very welcome. Feel free to open
+//! an issue.
 //!
 //! Read more about the project on the [swiftide website](https://swiftide.rs)
 //!
@@ -21,7 +25,8 @@
 //! - Splitting and merging pipelines
 //! - Jinja-like templating for prompts
 //! - Store into multiple backends
-//! - `tracing` supported for logging and tracing, see /examples and the `tracing` crate for more information.
+//! - `tracing` supported for logging and tracing, see /examples and the `tracing` crate for more
+//!   information.
 //!
 //! # Querying
 //!
@@ -133,8 +138,8 @@ pub mod integrations {
 
 /// This module serves as the main entry point for indexing in Swiftide.
 ///
-/// The indexing system in Swiftide is designed to handle the asynchronous processing of large volumes
-/// of data, including loading, transforming, and storing data chunks.
+/// The indexing system in Swiftide is designed to handle the asynchronous processing of large
+/// volumes of data, including loading, transforming, and storing data chunks.
 pub mod indexing {
     #[doc(inline)]
     pub use swiftide_core::indexing::*;
@@ -154,7 +159,8 @@ pub mod indexing {
 ///
 /// Swiftide allows you to define sophisticated query pipelines.
 ///
-/// Consider the following code that uses Swiftide to load some markdown text, chunk it, embed it, and store it in a Qdrant index:
+/// Consider the following code that uses Swiftide to load some markdown text, chunk it, embed it,
+/// and store it in a Qdrant index:
 ///
 /// ```no_run
 /// use swiftide::{
@@ -239,10 +245,10 @@ pub mod indexing {
 /// # }
 /// ```
 ///
-/// By using a query pipeline to transform queries, we can improve the quality of the answers we get from our index.
-/// In this example, we used an LLM to generate subquestions, embedding those and then using them to search the index.
-/// Finally, we summarize the results and combine them together into a single answer.
-///
+/// By using a query pipeline to transform queries, we can improve the quality of the answers we get
+/// from our index. In this example, we used an LLM to generate subquestions, embedding those and
+/// then using them to search the index. Finally, we summarize the results and combine them together
+/// into a single answer.
 pub mod query {
     #[doc(inline)]
     pub use swiftide_core::querying::*;

--- a/swiftide/tests/dyn_traits.rs
+++ b/swiftide/tests/dyn_traits.rs
@@ -1,5 +1,4 @@
 //! Tests for dyn trait objects
-//!
 use swiftide::{indexing::transformers::ChunkCode, integrations};
 use swiftide_core::{
     BatchableTransformer, ChunkerTransformer, EmbeddingModel, Loader, NodeCache, Persist,

--- a/swiftide/tests/indexing_pipeline.rs
+++ b/swiftide/tests/indexing_pipeline.rs
@@ -1,6 +1,7 @@
 //! This module contains tests for the indexing pipeline in the Swiftide project.
 //! The tests validate the functionality of the pipeline, ensuring it processes data correctly
-//! from a temporary file, simulates API responses, and stores data accurately in the Qdrant vector database.
+//! from a temporary file, simulates API responses, and stores data accurately in the Qdrant vector
+//! database.
 
 use qdrant_client::qdrant::vectors_output::VectorsOptions;
 use qdrant_client::qdrant::{ScrollPointsBuilder, SearchPointsBuilder, Value};

--- a/swiftide/tests/pgvector.rs
+++ b/swiftide/tests/pgvector.rs
@@ -40,7 +40,8 @@ struct VectorSearchResult {
 /// - Executes an indexing pipeline for Rust code chunks with embedded vector metadata.
 /// - Performs a similarity-based vector search on the database and validates the retrieved results.
 ///
-/// Ensures correctness of end-to-end data flow, including table management, vector storage, and query execution.
+/// Ensures correctness of end-to-end data flow, including table management, vector storage, and
+/// query execution.
 #[test_log::test(tokio::test)]
 async fn test_pgvector_indexing() {
     // Setup temporary directory and file for testing
@@ -259,7 +260,7 @@ async fn test_pgvector_retrieve() {
 /// The test demonstrates the recommended configuration approach:
 /// - Define search parameters as constants in the implementation scope
 /// - Pass configuration through the query generator closure
-/// - Keep the strategy struct minimal and focused on query generation    
+/// - Keep the strategy struct minimal and focused on query generation
 #[test_log::test(tokio::test)]
 async fn test_pgvector_retrieve_dynamic_search() {
     // Setup temporary directory and file for testing

--- a/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
+++ b/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
@@ -1,6 +1,7 @@
 //! This module contains tests for the indexing pipeline in the Swiftide project.
 //! The tests validate the functionality of the pipeline, ensuring it processes data correctly
-//! from a temporary file, simulates API responses, and stores data accurately in the Qdrant vector database.
+//! from a temporary file, simulates API responses, and stores data accurately in the Qdrant vector
+//! database.
 
 use qdrant_client::qdrant::{
     Fusion, PrefetchQueryBuilder, Query, QueryPointsBuilder, ScrollPointsBuilder,


### PR DESCRIPTION
This makes it easier to read the source code without horizontal scrolling in github and withing an IDE running on a laptop with a reasonably sized side bar showing
