### PR TITLE
chore: include filenames in errors in file io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ dependencies = [
  "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -3643,6 +3643,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
+name = "fs-err"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "fs4"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,7 +4306,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -6935,7 +6945,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -8212,7 +8222,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -8761,6 +8771,7 @@ dependencies = [
  "async-trait",
  "derive_builder",
  "dyn-clone",
+ "fs-err",
  "indoc",
  "insta",
  "mockall",
@@ -8829,6 +8840,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "derive_builder",
+ "fs-err",
  "futures-util",
  "ignore",
  "indoc",
@@ -8870,6 +8882,7 @@ dependencies = [
  "fastembed",
  "fluvio",
  "flv-util",
+ "fs-err",
  "futures-util",
  "htmd",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = { version = "1.0", default-features = false }
 thiserror = { version = "2.0", default-features = false }
 async-trait = { version = "0.1", default-features = false }
 derive_builder = { version = "0.20", default-features = true }
+fs-err = { version = "3.1", default-features = false }
 futures-util = { version = "0.3", default-features = true }
 tokio = { version = "1.43", features = [
   "rt-multi-thread",

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -24,6 +24,7 @@ strum.workspace = true
 strum_macros.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+fs-err = { workspace = true, features = ["tokio"] }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide-agents/src/tools/local_executor.rs
+++ b/swiftide-agents/src/tools/local_executor.rs
@@ -54,7 +54,7 @@ impl LocalExecutor {
     }
 
     async fn exec_read_file(&self, path: &Path) -> Result<CommandOutput, CommandError> {
-        let output = tokio::fs::read(path).await?;
+        let output = fs_err::tokio::read(path).await?;
 
         Ok(String::from_utf8(output)
             .context("Failed to parse read file output")?
@@ -67,9 +67,9 @@ impl LocalExecutor {
         content: &str,
     ) -> Result<CommandOutput, CommandError> {
         if let Some(parent) = path.parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
+            let _ = fs_err::tokio::create_dir_all(parent).await;
         }
-        tokio::fs::write(path, content).await?;
+        fs_err::tokio::write(path, content).await?;
 
         Ok(CommandOutput::empty())
     }

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -31,6 +31,7 @@ indoc = { workspace = true }
 
 ignore = { workspace = true }
 text-splitter = { workspace = true, features = ["markdown"] }
+fs-err.workspace = true
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide-indexing/src/loaders/file_loader.rs
+++ b/swiftide-indexing/src/loaders/file_loader.rs
@@ -84,7 +84,7 @@ impl FileLoader {
 
                 // Files might be invalid utf-8, so we need to read them as bytes and convert it
                 // lossy, as Swiftide (currently) works internally with strings.
-                let mut file = std::fs::File::open(entry.path()).context("Failed to open file")?;
+                let mut file = fs_err::File::open(entry.path()).context("Failed to open file")?;
                 let mut buf = vec![];
                 file.read_to_end(&mut buf).context("Failed to read file")?;
                 let content = String::from_utf8_lossy(&buf);
@@ -147,7 +147,7 @@ mod test {
     async fn test_ignores_invalid_utf8() {
         let tempdir = temp_dir::TempDir::new().unwrap();
 
-        std::fs::write(tempdir.child("invalid.txt"), [0x80, 0x80, 0x80]).unwrap();
+        fs_err::write(tempdir.child("invalid.txt"), [0x80, 0x80, 0x80]).unwrap();
 
         let loader = FileLoader::new(tempdir.path()).with_extensions(&["txt"]);
         let result = loader.into_stream().collect::<Vec<_>>().await;

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -93,6 +93,7 @@ parquet = { workspace = true, optional = true, features = [
 redb = { workspace = true, optional = true }
 duckdb = { workspace = true, optional = true }
 libduckdb-sys = { workspace = true, optional = true }
+fs-err = { workspace = true, features = ["tokio"] }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide-integrations/src/parquet/loader.rs
+++ b/swiftide-integrations/src/parquet/loader.rs
@@ -1,12 +1,13 @@
 use anyhow::{Context as _, Result};
 use arrow_array::StringArray;
+use fs_err::tokio::File;
 use futures_util::StreamExt as _;
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask};
 use swiftide_core::{
     indexing::{IndexingStream, Node},
     Loader,
 };
-use tokio::{fs::File, runtime::Handle};
+use tokio::runtime::Handle;
 
 use super::Parquet;
 


### PR DESCRIPTION
Uses fs-err crate to automatically include filenames in the error messages
