### PR TITLE
chore: release v0.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.4](https://github.com/bosun-ai/swiftide/compare/v0.22.3...v0.22.4) - 2025-03-17
+
+### Bug fixes
+
+- [4ec00bb](https://github.com/bosun-ai/swiftide/commit/4ec00bb0fed214f27629f32569406bfa2c786dd7) *(integrations)*  Add chrono/utc feature flag when using qdrant ([#684](https://github.com/bosun-ai/swiftide/pull/684))
+
+````text
+The Qdrant integration calls chrono::Utc::now(), which requires the now
+  feature flag to be enabled in the chrono crate when using qdrant
+````
+
+- [0b204d9](https://github.com/bosun-ai/swiftide/commit/0b204d90a68978bb4b75516c537a56d665771c55)  Ensure `groq`, `fastembed`, `test-utils` features compile individually ([#689](https://github.com/bosun-ai/swiftide/pull/689))
+
+### Miscellaneous
+
+- [bd4ef97](https://github.com/bosun-ai/swiftide/commit/bd4ef97f2b9207b5ac03d610b76bdb3440e3d5c0)  Include filenames in errors in file io ([#694](https://github.com/bosun-ai/swiftide/pull/694))
+
+````text
+Uses fs-err crate to automatically include filenames in the error
+  messages
+````
+
+- [9453e06](https://github.com/bosun-ai/swiftide/commit/9453e06d5338c99cec5f51b085739cc30a5f12be)  Use std::sync::Mutex instead of tokio mutex ([#693](https://github.com/bosun-ai/swiftide/pull/693))
+
+- [b3456e2](https://github.com/bosun-ai/swiftide/commit/b3456e25af99f661aff1779ae5f2d4da460f128c)  Log qdrant setup messages at debug level ([#696](https://github.com/bosun-ai/swiftide/pull/696))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.3...0.22.4
+
+
+
 ## [0.22.3](https://github.com/bosun-ai/swiftide/compare/v0.22.2...v0.22.3) - 2025-03-13
 
 ### Miscellaneous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1342,7 +1342,7 @@ checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8737,7 +8737,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8765,7 +8765,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8788,7 +8788,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8816,7 +8816,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8835,7 +8835,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8865,7 +8865,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8933,7 +8933,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8956,7 +8956,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8975,7 +8975,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "async-openai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.3"
+version = "0.22.4"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.3" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.4" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.3" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.4" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `swiftide-agents`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `swiftide-macros`: 0.22.3 -> 0.22.4
* `swiftide-indexing`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `swiftide-integrations`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `swiftide-query`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `swiftide`: 0.22.3 -> 0.22.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.4](https://github.com/bosun-ai/swiftide/compare/v0.22.3...v0.22.4) - 2025-03-17

### Bug fixes

- [4ec00bb](https://github.com/bosun-ai/swiftide/commit/4ec00bb0fed214f27629f32569406bfa2c786dd7) *(integrations)*  Add chrono/utc feature flag when using qdrant ([#684](https://github.com/bosun-ai/swiftide/pull/684))

````text
The Qdrant integration calls chrono::Utc::now(), which requires the now
  feature flag to be enabled in the chrono crate when using qdrant
````

- [0b204d9](https://github.com/bosun-ai/swiftide/commit/0b204d90a68978bb4b75516c537a56d665771c55)  Ensure `groq`, `fastembed`, `test-utils` features compile individually ([#689](https://github.com/bosun-ai/swiftide/pull/689))

### Miscellaneous

- [bd4ef97](https://github.com/bosun-ai/swiftide/commit/bd4ef97f2b9207b5ac03d610b76bdb3440e3d5c0)  Include filenames in errors in file io ([#694](https://github.com/bosun-ai/swiftide/pull/694))

````text
Uses fs-err crate to automatically include filenames in the error
  messages
````

- [9453e06](https://github.com/bosun-ai/swiftide/commit/9453e06d5338c99cec5f51b085739cc30a5f12be)  Use std::sync::Mutex instead of tokio mutex ([#693](https://github.com/bosun-ai/swiftide/pull/693))

- [b3456e2](https://github.com/bosun-ai/swiftide/commit/b3456e25af99f661aff1779ae5f2d4da460f128c)  Log qdrant setup messages at debug level ([#696](https://github.com/bosun-ai/swiftide/pull/696))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.3...0.22.4
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).