### PR TITLE
chore: release v0.22.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,48 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.5](https://github.com/bosun-ai/swiftide/compare/v0.22.4...v0.22.5) - 2025-03-23
+
+### New features
+
+- [eb4e044](https://github.com/bosun-ai/swiftide/commit/eb4e0442293e17722743aa2b88d8dd7582dd9236)  Estimate tokens for OpenAI like apis with tiktoken-rs ([#699](https://github.com/bosun-ai/swiftide/pull/699))
+
+### Miscellaneous
+
+- [345c57a](https://github.com/bosun-ai/swiftide/commit/345c57a663dd0d315a28f0927c5d598ba21d019d)  Improve file loader logging ([#695](https://github.com/bosun-ai/swiftide/pull/695))
+
+````text
+The logging now logs appropriate detail about each file and node
+  processed
+
+  - Skipped files are logged at TRACE level
+  - Configuration of the loader is logged at the start
+  - The necessary details to identify the loader (path) is included in the
+  span fields
+  - You can now correlate a node id with a path
+
+  <img width="1630" alt="image"
+  src="https://github.com/user-attachments/assets/308e95cc-5b94-41bd-9b77-7089d4bdabd3"
+  />
+
+  ```
+  2025-03-17T00:34:18.965601Z DEBUG pipeline:file_loader{root=.}: swiftide_indexing::loaders::file_loader: Loading files extensions=Some(["rs"])
+  2025-03-17T00:34:18.968115Z TRACE pipeline:file_loader{root=.}:load{path=./Cargo.toml}: swiftide_indexing::loaders::file_loader: Skipping file with extension toml
+  2025-03-17T00:34:18.968153Z TRACE pipeline:file_loader{root=.}:load{path=./Cargo.lock}: swiftide_indexing::loaders::file_loader: Skipping file with extension lock
+  2025-03-17T00:34:18.968186Z TRACE pipeline:file_loader{root=.}:load{path=./README.md}: swiftide_indexing::loaders::file_loader: Skipping file with extension md
+  2025-03-17T00:34:18.968248Z DEBUG pipeline:file_loader{root=.}:load{path=./src/main.rs}: swiftide_indexing::loaders::file_loader: Loading file
+  2025-03-17T00:34:18.968302Z DEBUG pipeline:file_loader{root=.}:load{path=./src/main.rs}: swiftide_indexing::loaders::file_loader: Loaded file node_id=9cef7b97-dfbb-327b-a47d-0816f4ed69db
+  2025-03-17T00:34:18.968324Z TRACE pipeline:file_loader{root=.}:load{path=./src/compose.yaml}: swiftide_indexing::loaders::file_loader: Skipping file with extension yaml
+  ```
+
+  Related to https://github.com/bosun-ai/swiftide/issues/686
+````
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.4...0.22.5
+
+
+
 ## [0.22.4](https://github.com/bosun-ai/swiftide/compare/v0.22.3...v0.22.4) - 2025-03-17
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,34 +12,6 @@ All notable changes to this project will be documented in this file.
 
 - [345c57a](https://github.com/bosun-ai/swiftide/commit/345c57a663dd0d315a28f0927c5d598ba21d019d)  Improve file loader logging ([#695](https://github.com/bosun-ai/swiftide/pull/695))
 
-````text
-The logging now logs appropriate detail about each file and node
-  processed
-
-  - Skipped files are logged at TRACE level
-  - Configuration of the loader is logged at the start
-  - The necessary details to identify the loader (path) is included in the
-  span fields
-  - You can now correlate a node id with a path
-
-  <img width="1630" alt="image"
-  src="https://github.com/user-attachments/assets/308e95cc-5b94-41bd-9b77-7089d4bdabd3"
-  />
-
-  ```
-  2025-03-17T00:34:18.965601Z DEBUG pipeline:file_loader{root=.}: swiftide_indexing::loaders::file_loader: Loading files extensions=Some(["rs"])
-  2025-03-17T00:34:18.968115Z TRACE pipeline:file_loader{root=.}:load{path=./Cargo.toml}: swiftide_indexing::loaders::file_loader: Skipping file with extension toml
-  2025-03-17T00:34:18.968153Z TRACE pipeline:file_loader{root=.}:load{path=./Cargo.lock}: swiftide_indexing::loaders::file_loader: Skipping file with extension lock
-  2025-03-17T00:34:18.968186Z TRACE pipeline:file_loader{root=.}:load{path=./README.md}: swiftide_indexing::loaders::file_loader: Skipping file with extension md
-  2025-03-17T00:34:18.968248Z DEBUG pipeline:file_loader{root=.}:load{path=./src/main.rs}: swiftide_indexing::loaders::file_loader: Loading file
-  2025-03-17T00:34:18.968302Z DEBUG pipeline:file_loader{root=.}:load{path=./src/main.rs}: swiftide_indexing::loaders::file_loader: Loaded file node_id=9cef7b97-dfbb-327b-a47d-0816f4ed69db
-  2025-03-17T00:34:18.968324Z TRACE pipeline:file_loader{root=.}:load{path=./src/compose.yaml}: swiftide_indexing::loaders::file_loader: Skipping file with extension yaml
-  ```
-
-  Related to https://github.com/bosun-ai/swiftide/issues/686
-````
-
-
 **Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.4...0.22.5
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8895,7 +8895,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8946,7 +8946,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8974,7 +8974,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8993,7 +8993,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9092,7 +9092,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9134,7 +9134,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.4"
+version = "0.22.5"
 dependencies = [
  "async-openai 0.28.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.4"
+version = "0.22.5"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.4" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.5" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.4" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.5" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.4 -> 0.22.5 (✓ API compatible changes)
* `swiftide-agents`: 0.22.4 -> 0.22.5 (✓ API compatible changes)
* `swiftide-macros`: 0.22.4 -> 0.22.5
* `swiftide-indexing`: 0.22.4 -> 0.22.5 (✓ API compatible changes)
* `swiftide-integrations`: 0.22.4 -> 0.22.5 (✓ API compatible changes)
* `swiftide-query`: 0.22.4 -> 0.22.5
* `swiftide`: 0.22.4 -> 0.22.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.5](https://github.com/bosun-ai/swiftide/compare/v0.22.4...v0.22.5) - 2025-03-23

### New features

- [eb4e044](https://github.com/bosun-ai/swiftide/commit/eb4e0442293e17722743aa2b88d8dd7582dd9236)  Estimate tokens for OpenAI like apis with tiktoken-rs ([#699](https://github.com/bosun-ai/swiftide/pull/699))

### Miscellaneous

- [345c57a](https://github.com/bosun-ai/swiftide/commit/345c57a663dd0d315a28f0927c5d598ba21d019d)  Improve file loader logging ([#695](https://github.com/bosun-ai/swiftide/pull/695))

````text
The logging now logs appropriate detail about each file and node
  processed

  - Skipped files are logged at TRACE level
  - Configuration of the loader is logged at the start
  - The necessary details to identify the loader (path) is included in the
  span fields
  - You can now correlate a node id with a path

  <img width="1630" alt="image"
  src="https://github.com/user-attachments/assets/308e95cc-5b94-41bd-9b77-7089d4bdabd3"
  />

  ```
  2025-03-17T00:34:18.965601Z DEBUG pipeline:file_loader{root=.}: swiftide_indexing::loaders::file_loader: Loading files extensions=Some(["rs"])
  2025-03-17T00:34:18.968115Z TRACE pipeline:file_loader{root=.}:load{path=./Cargo.toml}: swiftide_indexing::loaders::file_loader: Skipping file with extension toml
  2025-03-17T00:34:18.968153Z TRACE pipeline:file_loader{root=.}:load{path=./Cargo.lock}: swiftide_indexing::loaders::file_loader: Skipping file with extension lock
  2025-03-17T00:34:18.968186Z TRACE pipeline:file_loader{root=.}:load{path=./README.md}: swiftide_indexing::loaders::file_loader: Skipping file with extension md
  2025-03-17T00:34:18.968248Z DEBUG pipeline:file_loader{root=.}:load{path=./src/main.rs}: swiftide_indexing::loaders::file_loader: Loading file
  2025-03-17T00:34:18.968302Z DEBUG pipeline:file_loader{root=.}:load{path=./src/main.rs}: swiftide_indexing::loaders::file_loader: Loaded file node_id=9cef7b97-dfbb-327b-a47d-0816f4ed69db
  2025-03-17T00:34:18.968324Z TRACE pipeline:file_loader{root=.}:load{path=./src/compose.yaml}: swiftide_indexing::loaders::file_loader: Skipping file with extension yaml
  ```

  Related to https://github.com/bosun-ai/swiftide/issues/686
````


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.4...0.22.5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).