### PR TITLE
feat(macros): Support optional values and make them even nicer to use

### DIFF
--- a/examples/hello_agents.rs
+++ b/examples/hello_agents.rs
@@ -63,7 +63,7 @@ async fn read_file(context: &dyn AgentContext, path: &str) -> Result<ToolOutput,
 // For non-string types, the `json_type` is required to be specified.
 #[swiftide_macros::tool(
     description = "Guess a number",
-    param(name = "number", description = "Number to guess", json_type = "number")
+    param(name = "number", description = "Number to guess")
 )]
 async fn guess_a_number(
     _context: &dyn AgentContext,

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -411,7 +411,7 @@ impl Agent {
 
         if let Some(tool_calls) = response.tool_calls {
             self.invoke_tools(tool_calls).await?;
-        };
+        }
 
         for hook in self.hooks_by_type(HookTypes::AfterEach) {
             if let Hook::AfterEach(hook) = hook {

--- a/swiftide-integrations/src/pgvector/fixtures.rs
+++ b/swiftide-integrations/src/pgvector/fixtures.rs
@@ -166,7 +166,7 @@ impl TestContext {
             for field in metadata_fields_inner {
                 builder = builder.with_metadata(field);
             }
-        };
+        }
 
         let pgv_storage = builder.build().map_err(|err| {
             tracing::error!("Failed to build PgVector: {}", err);

--- a/swiftide-macros/src/lib.rs
+++ b/swiftide-macros/src/lib.rs
@@ -14,7 +14,7 @@ mod test_utils;
 mod tool;
 use indexing_transformer::indexing_transformer_impl;
 use syn::{parse_macro_input, DeriveInput, ItemFn, ItemStruct};
-use tool::{tool_derive_impl, tool_impl};
+use tool::{tool_attribute_impl, tool_derive_impl};
 
 /// Generates boilerplate for an indexing transformer.
 #[proc_macro_attribute]
@@ -43,7 +43,7 @@ pub fn indexing_transformer(args: TokenStream, input: TokenStream) -> TokenStrea
 /// ```
 pub fn tool(args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemFn);
-    tool_impl(&args.into(), &input).into()
+    tool_attribute_impl(&args.into(), &input).into()
 }
 
 /// Derive tool on a struct. The macro expects a snake case method on the struct that takes the

--- a/swiftide-macros/src/tool/args.rs
+++ b/swiftide-macros/src/tool/args.rs
@@ -1,6 +1,342 @@
+use convert_case::{Case, Casing as _};
+use darling::{ast::NestedMeta, Error, FromMeta};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens as _};
-use syn::{parse::Result, Error, FnArg, Ident, ItemFn, PatType};
+use syn::{parse_quote, FnArg, Ident, ItemFn, Pat, PatType};
+
+use super::rust_to_json_type::rust_type_to_json_type;
+
+#[derive(FromMeta, Default, Debug)]
+pub struct ToolArgs {
+    #[darling(default)]
+    /// Name of the tool
+    /// Defaults to the underscored version of the function name or struct
+    name: String,
+
+    /// Name of the function to call
+    /// Defaults to the underscored version of the function name or struct
+    #[darling(default)]
+    fn_name: String,
+
+    /// Description of the tool
+    description: Description,
+
+    /// Parameters the tool can take
+    #[darling(multiple, rename = "param")]
+    params: Vec<ParamOptions>,
+}
+
+#[derive(FromMeta, Debug)]
+#[darling(default)]
+pub struct ParamOptions {
+    pub name: String,
+    pub description: String,
+
+    /// The type the parameter should be in the JSON spec
+    /// Defaults to `String`
+    pub json_type: ParamType,
+
+    /// The type the parameter should be in Rust
+    /// Defaults to what can be derived from `json_type`
+    pub rust_type: syn::Type,
+}
+
+impl Default for ParamOptions {
+    fn default() -> Self {
+        ParamOptions {
+            name: String::new(),
+            description: String::new(),
+            json_type: ParamType::String,
+            rust_type: syn::parse_quote! { String },
+        }
+    }
+}
+
+impl ParamOptions {
+    #[cfg(test)]
+    pub fn new(name: &str, description: &str, json_type: ParamType, rust_type: syn::Type) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            json_type,
+            rust_type,
+        }
+    }
+}
+
+#[derive(Debug, FromMeta, PartialEq, Eq, Default, Clone, Copy)]
+#[darling(rename_all = "camelCase")]
+pub enum ParamType {
+    #[default]
+    String,
+    Number,
+    Boolean,
+    Array,
+}
+
+impl ParamType {
+    fn default_rust_type(&self) -> syn::Type {
+        match self {
+            ParamType::String => syn::parse_quote! { String },
+            ParamType::Number => syn::parse_quote! { usize },
+            ParamType::Boolean => syn::parse_quote! { bool },
+            ParamType::Array => syn::parse_quote! { Vec<String> },
+        }
+    }
+
+    fn try_from_rust_type(ty: &syn::Type) -> Result<ParamType, Error> {
+        rust_type_to_json_type(&ty)
+    }
+}
+
+#[derive(Debug)]
+pub enum Description {
+    Literal(String),
+    Path(syn::Path),
+}
+
+impl Default for Description {
+    fn default() -> Self {
+        Description::Literal(String::new())
+    }
+}
+
+impl FromMeta for Description {
+    fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
+        match expr {
+            syn::Expr::Lit(lit) => {
+                if let syn::Lit::Str(s) = &lit.lit {
+                    Ok(Description::Literal(s.value()))
+                } else {
+                    Err(Error::unsupported_format(
+                        "expected a string literal or a const",
+                    ))
+                }
+            }
+            syn::Expr::Path(path) => Ok(Description::Path(path.path.clone())),
+            _ => Err(Error::unsupported_format(
+                "expected a string literal or a const",
+            )),
+        }
+    }
+}
+
+impl ToolArgs {
+    pub fn try_from_attribute_input(input: &ItemFn, args: TokenStream) -> Result<Self, Error> {
+        validate_first_argument_is_agent_context(input)?;
+
+        let attr_args = NestedMeta::parse_meta_list(args)?;
+
+        let mut args = ToolArgs::from_list(&attr_args)?;
+        for arg in input.sig.inputs.iter().skip(1) {
+            if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
+                if let Pat::Ident(ident) = &**pat {
+                    let ty = as_owned_ty(ty);
+
+                    // It will error later if the types don't match
+                    //
+                    // It overwrites any json_type or rust_type set earlier in the attribute macro
+                    args.params
+                        .iter_mut()
+                        .find(|p| ident.ident == p.name)
+                        .map(|p| {
+                            p.json_type = ParamType::try_from_rust_type(&ty)?;
+                            p.rust_type = ty;
+
+                            Ok::<(), Error>(())
+                        })
+                        .transpose()?;
+                }
+            }
+        }
+
+        validate_spec_and_fn_args_match(&args, input)?;
+
+        args.with_name_from_ident(&input.sig.ident);
+
+        Ok(args)
+    }
+
+    pub fn infer_param_types(&mut self) -> Result<(), Error> {
+        for param in &mut self.params {
+            if param.json_type == ParamType::String
+                && param.rust_type != syn::parse_quote! { String }
+            {
+                param.json_type = ParamType::try_from_rust_type(&param.rust_type)?;
+                continue;
+            }
+
+            if param.json_type != ParamType::String
+                && param.rust_type == syn::parse_quote! { String }
+            {
+                param.rust_type = param.json_type.default_rust_type();
+                continue;
+            }
+
+            if ParamType::try_from_rust_type(&param.rust_type)? != param.json_type {
+                return Err(Error::custom(format!(
+                    "The type of the parameter {} is not compatible with the json type",
+                    param.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn with_name_from_ident(&mut self, ident: &syn::Ident) {
+        if self.name.is_empty() {
+            self.name = ident.to_string().to_case(Case::Snake);
+        }
+
+        if self.fn_name.is_empty() {
+            self.fn_name = ident.to_string().to_case(Case::Snake);
+        }
+    }
+
+    pub fn tool_name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn fn_name(&self) -> &str {
+        &self.fn_name
+    }
+
+    pub fn tool_description(&self) -> &Description {
+        &self.description
+    }
+
+    pub fn tool_params(&self) -> &[ParamOptions] {
+        &self.params
+    }
+
+    pub fn arg_names(&self) -> Vec<&str> {
+        self.params
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>()
+    }
+
+    pub fn args_struct(&self) -> TokenStream {
+        if self.params.is_empty() {
+            return quote! {};
+        }
+
+        let mut fields = Vec::new();
+
+        for param in &self.params {
+            let ty = &param.rust_type;
+            let ident = syn::Ident::new(&param.name, proc_macro2::Span::call_site());
+            fields.push(quote! { pub #ident: #ty });
+        }
+
+        let args_struct_ident = self.args_struct_ident();
+        quote! {
+            #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize, Debug)]
+            pub struct #args_struct_ident {
+                #(#fields),*
+            }
+        }
+    }
+
+    pub fn args_struct_ident(&self) -> Ident {
+        syn::Ident::new(
+            &format!("{}Args", self.name.to_case(Case::Pascal)),
+            proc_macro2::Span::call_site(),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new(name: &str, description: Description, params: Vec<ParamOptions>) -> Self {
+        Self {
+            name: name.into(),
+            fn_name: name.into(),
+            description,
+            params,
+        }
+    }
+}
+
+fn validate_spec_and_fn_args_match(tool_args: &ToolArgs, item_fn: &ItemFn) -> Result<(), Error> {
+    let mut found_spec_arg_names = tool_args
+        .params
+        .iter()
+        .map(|param| param.name.clone())
+        .collect::<Vec<_>>();
+    found_spec_arg_names.sort();
+
+    let mut seen_arg_names = vec![];
+
+    let mut only_strings = true;
+    item_fn
+        .sig
+        .inputs
+        .iter()
+        .skip(1)
+        .filter_map(|arg| {
+            if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
+                if let Pat::Ident(ident) = &**pat {
+                    seen_arg_names.push(ident.ident.to_string());
+                    if let syn::Type::Path(p) = &**ty {
+                        if !p.path.is_ident("str") || !p.path.is_ident("String") {
+                            only_strings = false;
+                        }
+                    }
+
+                    // If the argument is a reference, we need to reference the quote as well
+                    if let syn::Type::Reference(_) = &**ty {
+                        Some(quote! { &args.#ident })
+                    } else {
+                        Some(quote! { args.#ident })
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    seen_arg_names.sort();
+
+    let mut errors = Error::accumulator();
+    if found_spec_arg_names != seen_arg_names {
+        let missing_args = found_spec_arg_names
+            .iter()
+            .filter(|name| !seen_arg_names.contains(name))
+            .collect::<Vec<_>>();
+
+        let missing_params = seen_arg_names
+            .iter()
+            .filter(|name| !found_spec_arg_names.contains(name))
+            .collect::<Vec<_>>();
+
+        if !missing_args.is_empty() {
+            errors.push(Error::custom(
+                format!("The following parameters are missing from the function signature: {missing_args:?}")
+            ));
+        }
+
+        if !missing_params.is_empty() {
+            errors.push(Error::custom(format!(
+                "The following parameters are missing from the spec: {missing_params:?}"
+            )));
+        }
+    }
+
+    if !only_strings
+        && tool_args
+            .params
+            .iter()
+            .all(|p| matches!(p.json_type, ParamType::String))
+    {
+        errors.push(Error::custom(
+            "Params that are not strings need to have their `type` as json spec specified",
+        ));
+    }
+
+    errors.finish()?;
+    Ok(())
+}
 
 pub(crate) fn args_struct_name(input: &ItemFn) -> Ident {
     let struct_name_str = input
@@ -22,11 +358,11 @@ pub(crate) fn args_struct_name(input: &ItemFn) -> Ident {
     Ident::new(&struct_name_str, input.sig.ident.span())
 }
 
-fn as_owned_ty(ty: &syn::Type) -> TokenStream {
+fn as_owned_ty(ty: &syn::Type) -> syn::Type {
     if let syn::Type::Reference(r) = ty {
         if let syn::Type::Path(p) = &*r.elem {
             if p.path.is_ident("str") {
-                return quote!(String);
+                return parse_quote!(String);
             }
 
             // Does this happen?
@@ -41,54 +377,54 @@ fn as_owned_ty(ty: &syn::Type) -> TokenStream {
         if let syn::Type::Slice(slice_type) = &*r.elem {
             // slice_type.elem is T. We'll replace with Vec<T>.
             let elem = &slice_type.elem;
-            return quote!(Vec<#elem>);
+            return parse_quote!(Vec<#elem>);
         }
-        quote!(String)
+        parse_quote!(String)
     } else {
-        ty.to_token_stream()
+        ty.to_owned()
     }
 }
 
 /// Builds the parse-able arg struct
-pub(crate) fn build_tool_args(input: &ItemFn) -> Result<TokenStream> {
-    validate_first_argument_is_agent_context(input)?;
+// pub(crate) fn build_tool_args(input: &ItemFn) -> Result<TokenStream> {
+//     validate_first_argument_is_agent_context(input)?;
+//
+//     let args = &input.sig.inputs;
+//     let mut struct_fields = Vec::new();
+//
+//     for arg in args.iter().skip(1) {
+//         if let syn::FnArg::Typed(PatType { pat, ty, .. }) = arg {
+//             if let syn::Pat::Ident(ident) = &**pat {
+//                 let ty = as_owned_ty(ty);
+//                 struct_fields.push(quote! { pub #ident: #ty });
+//             }
+//         }
+//     }
+//
+//     if struct_fields.is_empty() {
+//         return Ok(quote! {});
+//     }
+//
+//     let struct_name = args_struct_name(input);
+//
+//     Ok(quote! {
+//         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
+//         struct #struct_name {
+//             #(#struct_fields),*
+//         }
+//     })
+// }
 
-    let args = &input.sig.inputs;
-    let mut struct_fields = Vec::new();
-
-    for arg in args.iter().skip(1) {
-        if let syn::FnArg::Typed(PatType { pat, ty, .. }) = arg {
-            if let syn::Pat::Ident(ident) = &**pat {
-                let ty = as_owned_ty(ty);
-                struct_fields.push(quote! { pub #ident: #ty });
-            }
-        }
-    }
-
-    if struct_fields.is_empty() {
-        return Ok(quote! {});
-    }
-
-    let struct_name = args_struct_name(input);
-
-    Ok(quote! {
-        #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-        struct #struct_name {
-            #(#struct_fields),*
-        }
-    })
-}
-
-fn validate_first_argument_is_agent_context(input_fn: &ItemFn) -> Result<()> {
+fn validate_first_argument_is_agent_context(input_fn: &ItemFn) -> Result<(), Error> {
     let expected_first_arg = quote! { &dyn AgentContext };
     let error_msg = "The first argument must be `&dyn AgentContext`";
 
     if let Some(FnArg::Typed(first_arg)) = input_fn.sig.inputs.first() {
         if first_arg.ty.to_token_stream().to_string() != expected_first_arg.to_string() {
-            return Err(Error::new_spanned(&first_arg.ty, error_msg));
+            return Err(Error::custom(error_msg).with_span(&first_arg.ty));
         }
     } else {
-        return Err(Error::new_spanned(&input_fn.sig, error_msg));
+        return Err(Error::custom(error_msg).with_span(&input_fn.sig));
     }
 
     Ok(())
@@ -102,117 +438,117 @@ mod tests {
     use quote::quote;
     use syn::{parse_quote, ItemFn};
 
-    #[test]
-    fn test_agent_context_as_first_arg_required() {
-        let input: ItemFn = parse_quote! {
-            pub async fn search_code(code_query: &str) -> Result<ToolOutput> {
-                return Ok("hello".into())
-            }
-        };
-
-        let output = build_tool_args(&input).unwrap_err();
-
-        assert_eq!(
-            output.to_string(),
-            "The first argument must be `&dyn AgentContext`"
-        );
-    }
-
-    #[test]
-    fn test_agent_multiple_args() {
-        let input: ItemFn = parse_quote! {
-            pub async fn search_code(context: &dyn AgentContext, code_query: &str, other: &str) -> Result<ToolOutput> {
-                return Ok("hello".into())
-            }
-        };
-
-        let output = build_tool_args(&input).unwrap();
-
-        let expected = quote! {
-            #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-            struct SearchCodeArgs {
-                pub code_query: String,
-                pub other: String
-            }
-        };
-
-        assert_ts_eq!(&output, &expected);
-    }
-
-    #[test]
-    fn test_simple_tool_with_lifetime() {
-        let input: ItemFn = parse_quote! {
-            pub async fn search_code(context: &dyn AgentContext, code_query: &str) -> Result<ToolOutput> {
-                return Ok("hello".into())
-            }
-        };
-
-        let output = build_tool_args(&input).unwrap();
-
-        let expected = quote! {
-            #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-            struct SearchCodeArgs {
-                pub code_query: String,
-            }
-        };
-
-        assert_ts_eq!(&output, &expected);
-    }
-
-    #[test]
-    fn test_simple_tool_without_lifetime() {
-        let input: ItemFn = parse_quote! {
-            pub async fn search_code(context: &dyn AgentContext, code_query: String) -> Result<ToolOutput> {
-                return Ok("hello".into())
-            }
-        };
-
-        let output = build_tool_args(&input).unwrap();
-
-        let expected = quote! {
-            #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-            struct SearchCodeArgs {
-                pub code_query: String,
-            }
-        };
-
-        assert_ts_eq!(&output, &expected);
-    }
-
-    #[test]
-    fn test_no_arguments() {
-        let input: ItemFn = parse_quote! {
-            pub async fn search_code(context: &dyn AgentContext) -> Result<ToolOutput> {
-                return Ok("hello".into())
-            }
-        };
-        let output = build_tool_args(&input).unwrap();
-        let expected = quote! {};
-        assert_ts_eq!(&output, &expected);
-    }
-
-    #[test]
-    fn test_multiple_ty_args() {
-        let input: ItemFn = parse_quote! {
-            pub async fn search_code(context: &dyn AgentContext, code_query: &str, include_private: bool, a_number: usize, a_slice: &[String], a_vec: Vec<String>) -> Result<ToolOutput> {
-                return Ok("hello".into())
-            }
-        };
-
-        let output = build_tool_args(&input).unwrap();
-        let expected = quote! {
-            #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-            struct SearchCodeArgs {
-                pub code_query: String,
-                pub include_private: bool,
-                pub a_number: usize,
-                pub a_slice: Vec<String>,
-                pub a_vec: Vec<String>,
-            }
-        };
-
-        assert_ts_eq!(&output, &expected);
-    }
+    // #[test]
+    // fn test_agent_context_as_first_arg_required() {
+    //     let input: ItemFn = parse_quote! {
+    //         pub async fn search_code(code_query: &str) -> Result<ToolOutput> {
+    //             return Ok("hello".into())
+    //         }
+    //     };
+    //
+    //     let output = build_tool_args(&input).unwrap_err();
+    //
+    //     assert_eq!(
+    //         output.to_string(),
+    //         "The first argument must be `&dyn AgentContext`"
+    //     );
+    // }
+    //
+    // #[test]
+    // fn test_agent_multiple_args() {
+    //     let input: ItemFn = parse_quote! {
+    //         pub async fn search_code(context: &dyn AgentContext, code_query: &str, other: &str) -> Result<ToolOutput> {
+    //             return Ok("hello".into())
+    //         }
+    //     };
+    //
+    //     let output = build_tool_args(&input).unwrap();
+    //
+    //     let expected = quote! {
+    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
+    //         struct SearchCodeArgs {
+    //             pub code_query: String,
+    //             pub other: String
+    //         }
+    //     };
+    //
+    //     assert_ts_eq!(&output, &expected);
+    // }
+    //
+    // #[test]
+    // fn test_simple_tool_with_lifetime() {
+    //     let input: ItemFn = parse_quote! {
+    //         pub async fn search_code(context: &dyn AgentContext, code_query: &str) -> Result<ToolOutput> {
+    //             return Ok("hello".into())
+    //         }
+    //     };
+    //
+    //     let output = build_tool_args(&input).unwrap();
+    //
+    //     let expected = quote! {
+    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
+    //         struct SearchCodeArgs {
+    //             pub code_query: String,
+    //         }
+    //     };
+    //
+    //     assert_ts_eq!(&output, &expected);
+    // }
+    //
+    // #[test]
+    // fn test_simple_tool_without_lifetime() {
+    //     let input: ItemFn = parse_quote! {
+    //         pub async fn search_code(context: &dyn AgentContext, code_query: String) -> Result<ToolOutput> {
+    //             return Ok("hello".into())
+    //         }
+    //     };
+    //
+    //     let output = build_tool_args(&input).unwrap();
+    //
+    //     let expected = quote! {
+    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
+    //         struct SearchCodeArgs {
+    //             pub code_query: String,
+    //         }
+    //     };
+    //
+    //     assert_ts_eq!(&output, &expected);
+    // }
+    //
+    // #[test]
+    // fn test_no_arguments() {
+    //     let input: ItemFn = parse_quote! {
+    //         pub async fn search_code(context: &dyn AgentContext) -> Result<ToolOutput> {
+    //             return Ok("hello".into())
+    //         }
+    //     };
+    //     let output = build_tool_args(&input).unwrap();
+    //     let expected = quote! {};
+    //     assert_ts_eq!(&output, &expected);
+    // }
+    //
+    // #[test]
+    // fn test_multiple_ty_args() {
+    //     let input: ItemFn = parse_quote! {
+    //         pub async fn search_code(context: &dyn AgentContext, code_query: &str, include_private: bool, a_number: usize, a_slice: &[String], a_vec: Vec<String>) -> Result<ToolOutput> {
+    //             return Ok("hello".into())
+    //         }
+    //     };
+    //
+    //     let output = build_tool_args(&input).unwrap();
+    //     let expected = quote! {
+    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
+    //         struct SearchCodeArgs {
+    //             pub code_query: String,
+    //             pub include_private: bool,
+    //             pub a_number: usize,
+    //             pub a_slice: Vec<String>,
+    //             pub a_vec: Vec<String>,
+    //         }
+    //     };
+    //
+    //     assert_ts_eq!(&output, &expected);
+    // }
 
     // TODO: Handle no arguments
     // TODO: Should it only allow &str as arg types?

--- a/swiftide-macros/src/tool/args.rs
+++ b/swiftide-macros/src/tool/args.rs
@@ -39,6 +39,8 @@ pub struct ParamOptions {
     /// The type the parameter should be in Rust
     /// Defaults to what can be derived from `json_type`
     pub rust_type: syn::Type,
+
+    pub required: bool,
 }
 
 impl Default for ParamOptions {
@@ -48,23 +50,12 @@ impl Default for ParamOptions {
             description: String::new(),
             json_type: ParamType::String,
             rust_type: syn::parse_quote! { String },
+            required: true,
         }
     }
 }
 
-impl ParamOptions {
-    #[cfg(test)]
-    pub fn new(name: &str, description: &str, json_type: ParamType, rust_type: syn::Type) -> Self {
-        Self {
-            name: name.into(),
-            description: description.into(),
-            json_type,
-            rust_type,
-        }
-    }
-}
-
-#[derive(Debug, FromMeta, PartialEq, Eq, Default, Clone, Copy)]
+#[derive(Debug, FromMeta, PartialEq, Eq, Default, Clone)]
 #[darling(rename_all = "camelCase")]
 pub enum ParamType {
     #[default]
@@ -72,6 +63,8 @@ pub enum ParamType {
     Number,
     Boolean,
     Array,
+    #[darling(skip)]
+    Option(Box<ParamType>),
 }
 
 impl ParamType {
@@ -81,11 +74,15 @@ impl ParamType {
             ParamType::Number => syn::parse_quote! { usize },
             ParamType::Boolean => syn::parse_quote! { bool },
             ParamType::Array => syn::parse_quote! { Vec<String> },
+            ParamType::Option(t) => {
+                let inner_ty = t.default_rust_type();
+                syn::parse_quote! {Option<#inner_ty>}
+            }
         }
     }
 
     fn try_from_rust_type(ty: &syn::Type) -> Result<ParamType, Error> {
-        rust_type_to_json_type(&ty)
+        rust_type_to_json_type(ty)
     }
 }
 
@@ -142,6 +139,7 @@ impl ToolArgs {
                         .map(|p| {
                             p.json_type = ParamType::try_from_rust_type(&ty)?;
                             p.rust_type = ty;
+                            p.required = !matches!(p.json_type, ParamType::Option(..));
 
                             Ok::<(), Error>(())
                         })
@@ -149,6 +147,7 @@ impl ToolArgs {
                 }
             }
         }
+        args.infer_param_types()?;
 
         validate_spec_and_fn_args_match(&args, input)?;
 
@@ -159,23 +158,84 @@ impl ToolArgs {
 
     pub fn infer_param_types(&mut self) -> Result<(), Error> {
         for param in &mut self.params {
-            if param.json_type == ParamType::String
-                && param.rust_type != syn::parse_quote! { String }
+            // Just be flexible. Might be weird if required is explicitly set to true. But it's
+            // more lenient if the user just provides the rust type.
+            if matches!(param.json_type, ParamType::Option(..))
+                || param
+                    .rust_type
+                    .to_token_stream()
+                    .to_string()
+                    .contains("Option")
             {
-                param.json_type = ParamType::try_from_rust_type(&param.rust_type)?;
-                continue;
+                param.required = false;
             }
 
-            if param.json_type != ParamType::String
-                && param.rust_type == syn::parse_quote! { String }
-            {
-                param.rust_type = param.json_type.default_rust_type();
-                continue;
+            if param.required {
+                if matches!(param.json_type, ParamType::Option(..)) {
+                    return Err(Error::custom(format!(
+                        "The parameter {} is marked as required but is an option",
+                        param.name
+                    )));
+                }
+
+                if param
+                    .rust_type
+                    .to_token_stream()
+                    .to_string()
+                    .contains("Option")
+                {
+                    return Err(Error::custom(format!(
+                        "The parameter {} is marked as required but is an option",
+                        param.name
+                    )));
+                }
+
+                if param.json_type == ParamType::String
+                    && param.rust_type != syn::parse_quote! { String }
+                {
+                    param.json_type = ParamType::try_from_rust_type(&param.rust_type)?;
+                    continue;
+                }
+
+                if param.json_type != ParamType::String
+                    && param.rust_type == syn::parse_quote! { String }
+                {
+                    param.rust_type = param.json_type.default_rust_type();
+                    continue;
+                }
+            } else {
+                // They are the same but no option, so let's wrap them both
+                if param.json_type == ParamType::try_from_rust_type(&param.rust_type)?
+                    && !matches!(param.json_type, ParamType::Option(..))
+                {
+                    let option_param = ParamType::Option(Box::new(param.json_type.clone()));
+                    let rust_ty = param.rust_type.clone();
+                    param.rust_type = parse_quote!(Option<#rust_ty>);
+                    param.json_type = option_param;
+                    continue;
+                }
+
+                if param.json_type == ParamType::String
+                    && param.rust_type != syn::parse_quote! { String }
+                {
+                    param.json_type = ParamType::try_from_rust_type(&param.rust_type)?;
+                    continue;
+                }
+
+                if param.json_type != ParamType::String
+                    && param.rust_type == syn::parse_quote! { String }
+                {
+                    let option_param = ParamType::Option(Box::new(param.json_type.clone()));
+                    let rust_ty = param.rust_type.clone();
+                    param.rust_type = parse_quote!(Option<#rust_ty>);
+                    param.json_type = option_param;
+                    continue;
+                }
             }
 
             if ParamType::try_from_rust_type(&param.rust_type)? != param.json_type {
                 return Err(Error::custom(format!(
-                    "The type of the parameter {} is not compatible with the json type",
+                    "The type of the parameter {} is not compatible with the json type; if it is an option make sure you set `required` to false in the param attribute",
                     param.name
                 )));
             }
@@ -369,51 +429,35 @@ fn as_owned_ty(ty: &syn::Type) -> syn::Type {
             if p.path.is_ident("Vec") {
                 if let syn::PathArguments::AngleBracketed(args) = &p.path.segments[0].arguments {
                     if let syn::GenericArgument::Type(ty) = args.args.first().unwrap() {
-                        return as_owned_ty(ty);
+                        let inner = as_owned_ty(ty);
+                        return parse_quote!(Vec<#inner>);
                     }
                 }
             }
+
+            if let Some(last_segment) = p.path.segments.last() {
+                if last_segment.ident.to_string().as_str() == "Option" {
+                    if let syn::PathArguments::AngleBracketed(generics) = &last_segment.arguments {
+                        if let Some(syn::GenericArgument::Type(inner_ty)) = generics.args.first() {
+                            let inner_ty = as_owned_ty(inner_ty);
+                            return parse_quote!(Option<#inner_ty>);
+                        }
+                    }
+                }
+            }
+
+            return parse_quote!(String);
         }
         if let syn::Type::Slice(slice_type) = &*r.elem {
             // slice_type.elem is T. We'll replace with Vec<T>.
             let elem = &slice_type.elem;
             return parse_quote!(Vec<#elem>);
         }
-        parse_quote!(String)
+        panic!("Unsupported reference type");
     } else {
         ty.to_owned()
     }
 }
-
-/// Builds the parse-able arg struct
-// pub(crate) fn build_tool_args(input: &ItemFn) -> Result<TokenStream> {
-//     validate_first_argument_is_agent_context(input)?;
-//
-//     let args = &input.sig.inputs;
-//     let mut struct_fields = Vec::new();
-//
-//     for arg in args.iter().skip(1) {
-//         if let syn::FnArg::Typed(PatType { pat, ty, .. }) = arg {
-//             if let syn::Pat::Ident(ident) = &**pat {
-//                 let ty = as_owned_ty(ty);
-//                 struct_fields.push(quote! { pub #ident: #ty });
-//             }
-//         }
-//     }
-//
-//     if struct_fields.is_empty() {
-//         return Ok(quote! {});
-//     }
-//
-//     let struct_name = args_struct_name(input);
-//
-//     Ok(quote! {
-//         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-//         struct #struct_name {
-//             #(#struct_fields),*
-//         }
-//     })
-// }
 
 fn validate_first_argument_is_agent_context(input_fn: &ItemFn) -> Result<(), Error> {
     let expected_first_arg = quote! { &dyn AgentContext };
@@ -428,128 +472,4 @@ fn validate_first_argument_is_agent_context(input_fn: &ItemFn) -> Result<(), Err
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::assert_ts_eq;
-
-    use super::*;
-    use quote::quote;
-    use syn::{parse_quote, ItemFn};
-
-    // #[test]
-    // fn test_agent_context_as_first_arg_required() {
-    //     let input: ItemFn = parse_quote! {
-    //         pub async fn search_code(code_query: &str) -> Result<ToolOutput> {
-    //             return Ok("hello".into())
-    //         }
-    //     };
-    //
-    //     let output = build_tool_args(&input).unwrap_err();
-    //
-    //     assert_eq!(
-    //         output.to_string(),
-    //         "The first argument must be `&dyn AgentContext`"
-    //     );
-    // }
-    //
-    // #[test]
-    // fn test_agent_multiple_args() {
-    //     let input: ItemFn = parse_quote! {
-    //         pub async fn search_code(context: &dyn AgentContext, code_query: &str, other: &str) -> Result<ToolOutput> {
-    //             return Ok("hello".into())
-    //         }
-    //     };
-    //
-    //     let output = build_tool_args(&input).unwrap();
-    //
-    //     let expected = quote! {
-    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-    //         struct SearchCodeArgs {
-    //             pub code_query: String,
-    //             pub other: String
-    //         }
-    //     };
-    //
-    //     assert_ts_eq!(&output, &expected);
-    // }
-    //
-    // #[test]
-    // fn test_simple_tool_with_lifetime() {
-    //     let input: ItemFn = parse_quote! {
-    //         pub async fn search_code(context: &dyn AgentContext, code_query: &str) -> Result<ToolOutput> {
-    //             return Ok("hello".into())
-    //         }
-    //     };
-    //
-    //     let output = build_tool_args(&input).unwrap();
-    //
-    //     let expected = quote! {
-    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-    //         struct SearchCodeArgs {
-    //             pub code_query: String,
-    //         }
-    //     };
-    //
-    //     assert_ts_eq!(&output, &expected);
-    // }
-    //
-    // #[test]
-    // fn test_simple_tool_without_lifetime() {
-    //     let input: ItemFn = parse_quote! {
-    //         pub async fn search_code(context: &dyn AgentContext, code_query: String) -> Result<ToolOutput> {
-    //             return Ok("hello".into())
-    //         }
-    //     };
-    //
-    //     let output = build_tool_args(&input).unwrap();
-    //
-    //     let expected = quote! {
-    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-    //         struct SearchCodeArgs {
-    //             pub code_query: String,
-    //         }
-    //     };
-    //
-    //     assert_ts_eq!(&output, &expected);
-    // }
-    //
-    // #[test]
-    // fn test_no_arguments() {
-    //     let input: ItemFn = parse_quote! {
-    //         pub async fn search_code(context: &dyn AgentContext) -> Result<ToolOutput> {
-    //             return Ok("hello".into())
-    //         }
-    //     };
-    //     let output = build_tool_args(&input).unwrap();
-    //     let expected = quote! {};
-    //     assert_ts_eq!(&output, &expected);
-    // }
-    //
-    // #[test]
-    // fn test_multiple_ty_args() {
-    //     let input: ItemFn = parse_quote! {
-    //         pub async fn search_code(context: &dyn AgentContext, code_query: &str, include_private: bool, a_number: usize, a_slice: &[String], a_vec: Vec<String>) -> Result<ToolOutput> {
-    //             return Ok("hello".into())
-    //         }
-    //     };
-    //
-    //     let output = build_tool_args(&input).unwrap();
-    //     let expected = quote! {
-    //         #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize)]
-    //         struct SearchCodeArgs {
-    //             pub code_query: String,
-    //             pub include_private: bool,
-    //             pub a_number: usize,
-    //             pub a_slice: Vec<String>,
-    //             pub a_vec: Vec<String>,
-    //         }
-    //     };
-    //
-    //     assert_ts_eq!(&output, &expected);
-    // }
-
-    // TODO: Handle no arguments
-    // TODO: Should it only allow &str as arg types?
 }

--- a/swiftide-macros/src/tool/mod.rs
+++ b/swiftide-macros/src/tool/mod.rs
@@ -1,8 +1,7 @@
 #![allow(clippy::used_underscore_binding)]
 
 use args::ToolArgs;
-use convert_case::{Case, Casing as _};
-use darling::{ast::NestedMeta, Error, FromDeriveInput, FromMeta};
+use darling::{Error, FromDeriveInput};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, FnArg, ItemFn, Lifetime, Pat, PatType};
@@ -14,7 +13,7 @@ mod wrapped;
 
 #[allow(clippy::too_many_lines)]
 pub(crate) fn tool_attribute_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream {
-    let tool_args = match ToolArgs::try_from_attribute_input(&input, input_args.clone()) {
+    let tool_args = match ToolArgs::try_from_attribute_input(input, input_args.clone()) {
         Ok(args) => args,
         Err(e) => return e.write_errors(),
     };
@@ -116,7 +115,7 @@ pub(crate) fn tool_derive_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
     let struct_ident = &parsed.ident;
 
     let expected_fn_name = parsed.tool.fn_name();
-    let expected_fn_ident = syn::Ident::new(&expected_fn_name, struct_ident.span());
+    let expected_fn_ident = syn::Ident::new(expected_fn_name, struct_ident.span());
 
     let invoke_tool_args = parsed
         .tool

--- a/swiftide-macros/src/tool/mod.rs
+++ b/swiftide-macros/src/tool/mod.rs
@@ -222,6 +222,26 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_single_arg_option() {
+        let args = quote! {
+            description = "Hello world tool",
+            param(
+                name = "code_query",
+                description = "my param description"
+            )
+        };
+        let input: ItemFn = parse_quote! {
+            pub async fn search_code(context: &dyn AgentContext, code_query: &Option<String>) -> Result<ToolOutput, ToolError> {
+                return Ok("hello".into())
+            }
+        };
+
+        let output = tool_attribute_impl(&args, &input);
+
+        insta::assert_snapshot!(crate::test_utils::pretty_macro_output(&output));
+    }
+
+    #[test]
     fn test_snapshot_multiple_args() {
         let args = quote! {
             description = "Hello world tool",
@@ -263,6 +283,20 @@ mod tests {
     fn test_snapshot_derive_with_args() {
         let input: DeriveInput = parse_quote! {
             #[tool(description="Hello derive", param(name="test", description="test param"))]
+            pub struct HelloDerive {
+                my_thing: String
+            }
+        };
+
+        let output = tool_derive_impl(&input).unwrap();
+
+        insta::assert_snapshot!(crate::test_utils::pretty_macro_output(&output));
+    }
+
+    #[test]
+    fn test_snapshot_derive_with_option() {
+        let input: DeriveInput = parse_quote! {
+            #[tool(description="Hello derive", param(name="test", description="test param", required = false))]
             pub struct HelloDerive {
                 my_thing: String
             }

--- a/swiftide-macros/src/tool/mod.rs
+++ b/swiftide-macros/src/tool/mod.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::used_underscore_binding)]
 
+use args::ToolArgs;
 use convert_case::{Case, Casing as _};
 use darling::{ast::NestedMeta, Error, FromDeriveInput, FromMeta};
 use proc_macro2::TokenStream;
@@ -7,128 +8,29 @@ use quote::quote;
 use syn::{DeriveInput, FnArg, ItemFn, Lifetime, Pat, PatType};
 
 mod args;
+mod rust_to_json_type;
 mod tool_spec;
 mod wrapped;
 
-#[derive(FromMeta, Default, Debug)]
-struct ToolArgs {
-    description: Description,
-
-    #[darling(multiple)]
-    param: Vec<ParamOptions>,
-}
-
-#[derive(FromMeta, Debug, Default)]
-#[darling(default)]
-struct ParamOptions {
-    name: String,
-    description: String,
-
-    json_type: ParamType,
-}
-
-#[derive(Debug, FromMeta, PartialEq, Eq, Default, Clone, Copy)]
-#[darling(rename_all = "camelCase")]
-enum ParamType {
-    #[default]
-    String,
-    Number,
-    Boolean,
-    Array,
-}
-
-#[derive(Debug)]
-enum Description {
-    Literal(String),
-    Path(syn::Path),
-}
-
-impl Default for Description {
-    fn default() -> Self {
-        Description::Literal(String::new())
-    }
-}
-
-impl FromMeta for Description {
-    fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
-        match expr {
-            syn::Expr::Lit(lit) => {
-                if let syn::Lit::Str(s) = &lit.lit {
-                    Ok(Description::Literal(s.value()))
-                } else {
-                    Err(Error::unsupported_format(
-                        "expected a string literal or a const",
-                    ))
-                }
-            }
-            syn::Expr::Path(path) => Ok(Description::Path(path.path.clone())),
-            _ => Err(Error::unsupported_format(
-                "expected a string literal or a const",
-            )),
-        }
-    }
-}
-
-// TODO: This should not be used?
-// impl serde::Serialize for ParamOptions {
-//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-//     where
-//         S: serde::Serializer,
-//     {
-//         let mut map = serializer.serialize_map(Some(1))?;
-//         map.serialize_entry(
-//             &self.name,
-//             &serde_json::json!({
-//                 "type": "string",
-//                 "description": self.description
-//             }),
-//         )?;
-//         map.end()
-//     }
-// }
-
 #[allow(clippy::too_many_lines)]
-pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream {
-    let input_tool_args = match parse_args(input_args.clone()) {
+pub(crate) fn tool_attribute_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream {
+    let tool_args = match ToolArgs::try_from_attribute_input(&input, input_args.clone()) {
         Ok(args) => args,
         Err(e) => return e.write_errors(),
     };
 
     let fn_name = &input.sig.ident;
-    let fn_args = &input.sig.inputs;
-    let tool_name = fn_name.to_string();
 
-    let tool_args = args::build_tool_args(input).unwrap_or_else(syn::Error::into_compile_error);
-    let args_struct = args::args_struct_name(input);
-    let tool_struct = wrapped::struct_name(input);
-
-    let wrapped_fn = wrapped::wrap_tool_fn(input);
-
-    let tool_spec = tool_spec::tool_spec(&tool_name, &input_tool_args);
-
-    let mut found_spec_arg_names = input_tool_args
-        .param
-        .iter()
-        .map(|param| param.name.clone())
-        .collect::<Vec<_>>();
-    found_spec_arg_names.sort();
-
-    let mut seen_arg_names = vec![];
-
-    let mut only_strings = true;
-    let arg_names = fn_args
+    let args_struct = tool_args.args_struct();
+    let args_struct_ident = tool_args.args_struct_ident();
+    let arg_names = input
+        .sig
+        .inputs
         .iter()
         .skip(1)
         .filter_map(|arg| {
             if let FnArg::Typed(PatType { pat, ty, .. }) = arg {
                 if let Pat::Ident(ident) = &**pat {
-                    seen_arg_names.push(ident.ident.to_string());
-                    if let syn::Type::Path(p) = &**ty {
-                        if !p.path.is_ident("str") || !p.path.is_ident("String") {
-                            only_strings = false;
-                        }
-                    }
-
                     // If the argument is a reference, we need to reference the quote as well
                     if let syn::Type::Reference(_) = &**ty {
                         Some(quote! { &args.#ident })
@@ -143,55 +45,13 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
             }
         })
         .collect::<Vec<_>>();
-    seen_arg_names.sort();
+    let tool_name = tool_args.tool_name();
 
-    if found_spec_arg_names != seen_arg_names {
-        let missing_args = found_spec_arg_names
-            .iter()
-            .filter(|name| !seen_arg_names.contains(name))
-            .collect::<Vec<_>>();
+    let tool_struct = wrapped::struct_name(input);
 
-        let missing_params = seen_arg_names
-            .iter()
-            .filter(|name| !found_spec_arg_names.contains(name))
-            .collect::<Vec<_>>();
+    let wrapped_fn = wrapped::wrap_tool_fn(input);
 
-        let mut messages = vec![];
-        if !missing_args.is_empty() {
-            messages.push(format!(
-                "The following parameters are missing from the function signature: {missing_args:?}"
-            ));
-        }
-
-        if !missing_params.is_empty() {
-            messages.push(format!(
-                "The following parameters are missing from the spec: {missing_params:?}"
-            ));
-        }
-
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            format!(
-                "Arguments in spec and in function do not match:\n {}",
-                messages.join(", ")
-            ),
-        )
-        .into_compile_error();
-    }
-
-    // Crude validation that types need to be set if non-string parameters are present
-    if !only_strings
-        && input_tool_args
-            .param
-            .iter()
-            .all(|p| matches!(p.json_type, ParamType::String))
-    {
-        return syn::Error::new(
-            proc_macro2::Span::call_site(),
-            "Params that are not strings need to have their `type` as json spec specified",
-        )
-        .into_compile_error();
-    }
+    let tool_spec = tool_spec::tool_spec(&tool_args);
 
     let invoke_body = if arg_names.is_empty() {
         quote! {
@@ -202,7 +62,7 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
             let Some(args) = raw_args
             else { return Err(::swiftide::chat_completion::errors::ToolError::MissingArguments(format!("No arguments provided for {}", #tool_name))) };
 
-            let args: #args_struct = ::swiftide::reexports::serde_json::from_str(&args)?;
+            let args: #args_struct_ident = ::swiftide::reexports::serde_json::from_str(&args)?;
             return self.#fn_name(agent_context, #(#arg_names),*).await;
         }
     };
@@ -210,7 +70,7 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
     let boxed_from = boxed_from(&tool_struct, &[]);
 
     quote! {
-        #tool_args
+        #args_struct
 
         #wrapped_fn
 
@@ -234,7 +94,7 @@ pub(crate) fn tool_impl(input_args: &TokenStream, input: &ItemFn) -> TokenStream
 }
 
 #[derive(FromDeriveInput)]
-#[darling(attributes(tool), supports(struct_named))]
+#[darling(attributes(tool), supports(struct_any), and_then = ToolDerive::update_defaults)]
 struct ToolDerive {
     ident: syn::Ident,
     #[allow(dead_code)]
@@ -243,59 +103,46 @@ struct ToolDerive {
     tool: ToolArgs,
 }
 
+impl ToolDerive {
+    pub fn update_defaults(mut self) -> Result<Self, Error> {
+        self.tool.with_name_from_ident(&self.ident);
+        self.tool.infer_param_types()?;
+        Ok(self)
+    }
+}
+
 pub(crate) fn tool_derive_impl(input: &DeriveInput) -> syn::Result<TokenStream> {
     let parsed: ToolDerive = ToolDerive::from_derive_input(input)?;
     let struct_ident = &parsed.ident;
 
-    // Build the args struct
-    let args_struct_name = syn::Ident::new(&format!("{struct_ident}Args"), struct_ident.span());
-    let args_struct_fields = parsed
-        .tool
-        .param
-        .iter()
-        .map(|p| {
-            let field_name = syn::Ident::new(&p.name, struct_ident.span());
-            quote! { pub #field_name: String }
-        })
-        .collect::<Vec<_>>();
-
-    let tool_args = if args_struct_fields.is_empty() {
-        quote! {}
-    } else {
-        quote! {
-            #[derive(::swiftide::reexports::serde::Serialize, ::swiftide::reexports::serde::Deserialize, Debug)]
-            pub struct #args_struct_name {
-                #(#args_struct_fields),*
-            }
-        }
-    };
-
-    let arg_names = parsed
-        .tool
-        .param
-        .iter()
-        .map(|param| {
-            let field_name = syn::Ident::new(&param.name, struct_ident.span());
-            quote! { args.#field_name}
-        })
-        .collect::<Vec<_>>();
-
-    // Build the trait impl
-    let expected_fn_name = struct_ident.to_string().to_case(Case::Snake);
+    let expected_fn_name = parsed.tool.fn_name();
     let expected_fn_ident = syn::Ident::new(&expected_fn_name, struct_ident.span());
-    let invoke_body = if arg_names.is_empty() {
+
+    let invoke_tool_args = parsed
+        .tool
+        .arg_names()
+        .into_iter()
+        .map(|name| {
+            let name = syn::Ident::new(name, struct_ident.span());
+            quote! { args.#name }
+        })
+        .collect::<Vec<_>>();
+    let args_struct_ident = parsed.tool.args_struct_ident();
+    let args_struct = parsed.tool.args_struct();
+
+    let invoke_body = if invoke_tool_args.is_empty() {
         quote! { return self.#expected_fn_ident(agent_context).await }
     } else {
         quote! {
             let Some(args) = raw_args
             else { return Err(::swiftide::chat_completion::errors::ToolError::MissingArguments(format!("No arguments provided for {}", #expected_fn_name))) };
 
-            let args: #args_struct_name = ::swiftide::reexports::serde_json::from_str(&args)?;
-            return self.#expected_fn_ident(agent_context, #(&#arg_names),*).await;
+            let args: #args_struct_ident = ::swiftide::reexports::serde_json::from_str(&args)?;
+            return self.#expected_fn_ident(agent_context, #(&#invoke_tool_args),*).await;
         }
     };
 
-    let tool_spec = tool_spec::tool_spec(&expected_fn_name, &parsed.tool);
+    let tool_spec = tool_spec::tool_spec(&parsed.tool);
 
     let struct_lifetimes = input
         .generics
@@ -312,7 +159,7 @@ pub(crate) fn tool_derive_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
     // Arg should be, if empty None, else Some(&args)
     let boxed_from = boxed_from(struct_ident, &struct_lifetimes);
     Ok(quote! {
-        #tool_args
+        #args_struct
 
 
         #[async_trait::async_trait]
@@ -334,15 +181,8 @@ pub(crate) fn tool_derive_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
     })
 }
 
-fn parse_args(args: TokenStream) -> Result<ToolArgs, Error> {
-    let attr_args = NestedMeta::parse_meta_list(args)?;
-
-    ToolArgs::from_list(&attr_args)
-}
-
 fn boxed_from(struct_ident: &syn::Ident, lifetimes: &[&Lifetime]) -> TokenStream {
     if !lifetimes.is_empty() {
-        // TODO: Implement for existing lifetimes
         return quote! {};
     }
 
@@ -376,7 +216,7 @@ mod tests {
             }
         };
 
-        let output = tool_impl(&args, &input);
+        let output = tool_attribute_impl(&args, &input);
 
         insta::assert_snapshot!(crate::test_utils::pretty_macro_output(&output));
     }
@@ -400,7 +240,7 @@ mod tests {
             }
         };
 
-        let output = tool_impl(&args, &input);
+        let output = tool_attribute_impl(&args, &input);
 
         insta::assert_snapshot!(crate::test_utils::pretty_macro_output(&output));
     }

--- a/swiftide-macros/src/tool/rust_to_json_type.rs
+++ b/swiftide-macros/src/tool/rust_to_json_type.rs
@@ -1,5 +1,4 @@
 use darling::Error;
-use quote::ToTokens as _;
 use syn::{GenericArgument, PathArguments, Type, TypePath};
 
 use super::args::ParamType;

--- a/swiftide-macros/src/tool/rust_to_json_type.rs
+++ b/swiftide-macros/src/tool/rust_to_json_type.rs
@@ -1,0 +1,72 @@
+use darling::Error;
+use syn::{Type, TypePath};
+
+use super::args::ParamType;
+
+/// Return a best-guess JSON "type" for a given Rust type.
+/// For demonstration only—real usage often has a simpler map or uses a dedicated crate.
+pub fn rust_type_to_json_type(ty: &Type) -> Result<ParamType, Error> {
+    let pty = match ty {
+        // Arrays like [T; N]
+        Type::Array(_arr) => ParamType::Array,
+
+        // Slices like [T]
+        Type::Slice(_slice) => ParamType::Array,
+
+        // Tuples like (A, B, C)
+        Type::Tuple(_tuple) => ParamType::Array,
+
+        // &T, &mut T
+        Type::Reference(ty_ref) => return rust_type_to_json_type(&ty_ref.elem),
+
+        // Actual paths like `u32`, `String`, `Vec<T>`, `std::collections::HashMap<...>`, etc.
+        Type::Path(type_path) => return classify_path(type_path),
+
+        // Parenthesized type `(T)`
+        Type::Paren(ty_paren) => return rust_type_to_json_type(&ty_paren.elem),
+
+        // Grouped type `Group`
+        Type::Group(ty_group) => return rust_type_to_json_type(&ty_group.elem),
+
+        // Syn may add more variants in the future
+        _ => return Err(Error::unsupported_shape("unsupported type")),
+    };
+
+    Ok(pty)
+}
+
+/// Helper to classify a `Type::Path` (e.g. `u32`, `bool`, `String`, `Vec<T>`, etc.)
+fn classify_path(type_path: &TypePath) -> Result<ParamType, Error> {
+    // Simple case: if the path is just one segment like `u32`, `String`, `bool`, etc.
+    if let Some(ident) = type_path.path.get_ident() {
+        return match ident.to_string().as_str() {
+            // All the builtin numeric types
+            "i8" | "i16" | "i32" | "i64" | "i128" | "u8" | "u16" | "u32" | "u64" | "u128"
+            | "isize" | "usize" | "f32" | "f64" => Ok(ParamType::Number),
+
+            "bool" => Ok(ParamType::Boolean),
+
+            "String" | "str" => Ok(ParamType::String),
+
+            // We *could* add object support here
+            _ => Err(Error::unsupported_shape("unsupported type")),
+        };
+    }
+
+    // If there are multiple segments, e.g. `std::vec::Vec<T>`
+    // or `Option<T>`, etc.
+    if let Some(last_segment) = type_path.path.segments.last() {
+        let seg_str = last_segment.ident.to_string();
+        match seg_str.as_str() {
+            "Vec" => Ok(ParamType::Array),
+            "Option" => {
+                // This would be very nice to support optional arguments
+                Err(Error::unsupported_shape("unsupported type"))
+            }
+            // For real use, you might handle Result<T, E>, HashMap, etc.
+            _ => Err(Error::unsupported_shape("unsupported type")),
+        }
+    } else {
+        Err(Error::unsupported_shape("unsupported type"))
+    }
+}

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
@@ -41,8 +41,8 @@ impl swiftide::chat_completion::Tool for HelloDerive {
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("test")
                     .description("test param")
-                    .ty(::swiftide::chat_completion::ParamType::String).build()
-                    .expect("infallible")
+                    .ty(::swiftide::chat_completion::ParamType::String).required(true)
+                    .build().expect("infallible")
                 ],
             )
             .build()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_option.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_option.snap
@@ -8,10 +8,10 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
     Debug
 )]
 pub struct HelloDeriveArgs {
-    pub test: String,
+    pub test: Option<String>,
 }
 #[async_trait::async_trait]
-impl<'a> swiftide::chat_completion::Tool for HelloDerive<'a> {
+impl swiftide::chat_completion::Tool for HelloDerive {
     async fn invoke(
         &self,
         agent_context: &dyn swiftide::traits::AgentContext,
@@ -41,11 +41,17 @@ impl<'a> swiftide::chat_completion::Tool for HelloDerive<'a> {
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("test")
                     .description("test param")
-                    .ty(::swiftide::chat_completion::ParamType::String).required(true)
+                    .ty(::swiftide::chat_completion::ParamType::String).required(false)
                     .build().expect("infallible")
                 ],
             )
             .build()
             .unwrap()
+    }
+}
+impl<'TOOLBOXED> From<HelloDerive>
+for Box<dyn ::swiftide::chat_completion::Tool + 'TOOLBOXED> {
+    fn from(val: HelloDerive) -> Self {
+        Box::new(val) as Box<dyn ::swiftide::chat_completion::Tool + 'TOOLBOXED>
     }
 }

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
@@ -4,9 +4,10 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 ---
 #[derive(
     ::swiftide::reexports::serde::Serialize,
-    ::swiftide::reexports::serde::Deserialize
+    ::swiftide::reexports::serde::Deserialize,
+    Debug
 )]
-struct SearchCodeArgs {
+pub struct SearchCodeArgs {
     pub code_query: String,
     pub other: String,
 }

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
@@ -4,9 +4,10 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 ---
 #[derive(
     ::swiftide::reexports::serde::Serialize,
-    ::swiftide::reexports::serde::Deserialize
+    ::swiftide::reexports::serde::Deserialize,
+    Debug
 )]
-struct SearchCodeArgs {
+pub struct SearchCodeArgs {
     pub code_query: String,
 }
 #[derive(Clone, Default)]

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
@@ -55,8 +55,8 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("code_query")
                     .description("my param description")
-                    .ty(::swiftide::chat_completion::ParamType::String).build()
-                    .expect("infallible")
+                    .ty(::swiftide::chat_completion::ParamType::String).required(true)
+                    .build().expect("infallible")
                 ],
             )
             .build()

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg_option.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg_option.snap
@@ -8,8 +8,7 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
     Debug
 )]
 pub struct SearchCodeArgs {
-    pub code_query: String,
-    pub other: String,
+    pub code_query: Option<String>,
 }
 #[derive(Clone, Default)]
 pub struct SearchCode {}
@@ -20,9 +19,8 @@ impl SearchCode {
     pub async fn search_code(
         &self,
         context: &dyn AgentContext,
-        code_query: &str,
-        other: &str,
-    ) -> Result<ToolOutput> {
+        code_query: &Option<String>,
+    ) -> Result<ToolOutput, ToolError> {
         return Ok("hello".into());
     }
 }
@@ -44,7 +42,7 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
             )
         };
         let args: SearchCodeArgs = ::swiftide::reexports::serde_json::from_str(&args)?;
-        return self.search_code(agent_context, &args.code_query, &args.other).await;
+        return self.search_code(agent_context, &args.code_query).await;
     }
     fn name<'TOOL>(&'TOOL self) -> std::borrow::Cow<'TOOL, str> {
         "search_code".into()
@@ -57,11 +55,7 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
                 vec![
                     swiftide::chat_completion::ParamSpec::builder().name("code_query")
                     .description("my param description")
-                    .ty(::swiftide::chat_completion::ParamType::String).required(true)
-                    .build().expect("infallible"),
-                    swiftide::chat_completion::ParamSpec::builder().name("other")
-                    .description("my param description")
-                    .ty(::swiftide::chat_completion::ParamType::String).required(true)
+                    .ty(::swiftide::chat_completion::ParamType::String).required(false)
                     .build().expect("infallible")
                 ],
             )

--- a/swiftide-macros/src/tool/tool_spec.rs
+++ b/swiftide-macros/src/tool/tool_spec.rs
@@ -1,21 +1,22 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::tool::ParamType;
+use crate::tool::args::ParamType;
 
-use super::{Description, ToolArgs};
+use super::args::{Description, ToolArgs};
 
-pub fn tool_spec(tool_name: &str, args: &ToolArgs) -> TokenStream {
-    let description = match &args.description {
+pub fn tool_spec(args: &ToolArgs) -> TokenStream {
+    let tool_name = args.tool_name();
+    let description = match &args.tool_description() {
         Description::Literal(description) => quote! { #description },
         Description::Path(path) => quote! { #path },
     };
 
-    if args.param.is_empty() {
+    if args.tool_params().is_empty() {
         quote! { swiftide::chat_completion::ToolSpec::builder().name(#tool_name).description(#description).build().unwrap() }
     } else {
         let params = args
-            .param
+            .tool_params()
             .iter()
             .map(|param| {
                 let name = &param.name;

--- a/swiftide-macros/tests/tool/tool_derive_pass.rs
+++ b/swiftide-macros/tests/tool/tool_derive_pass.rs
@@ -1,3 +1,4 @@
+#![allow(unused_variables)]
 use swiftide::chat_completion::{errors::ToolError, ToolOutput};
 use swiftide::traits::AgentContext;
 use swiftide_macros::Tool;
@@ -81,6 +82,56 @@ impl MyToolConst<'_> {
     async fn my_tool_const(
         &self,
         agent_context: &dyn AgentContext,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(format!("Hello world").into())
+    }
+}
+
+#[derive(Clone, Tool)]
+#[tool(description = DESCRIPTION,
+    param(name = "test", description = "My param", json_type = "number")
+)]
+struct MyToolNumber;
+
+impl MyToolNumber {
+    async fn my_tool_number(
+        &self,
+        agent_context: &dyn AgentContext,
+        test: &usize,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(format!("Hello world").into())
+    }
+}
+
+#[derive(Clone, Tool)]
+#[tool(description = DESCRIPTION,
+    param(name = "test", description = "My param", rust_type = "usize")
+)]
+struct MyToolNumber2;
+
+impl MyToolNumber2 {
+    async fn my_tool_number_2(
+        &self,
+        agent_context: &dyn AgentContext,
+        test: &usize,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(format!("Hello world").into())
+    }
+}
+
+#[derive(Clone, Tool)]
+#[tool(description = DESCRIPTION,
+    name = "my_very_renamed_tool",
+    fn_name = "my_very_renamed_tool",
+    param(name = "test", description = "My param", rust_type = "usize")
+)]
+struct MyRenamedTool;
+
+impl MyRenamedTool {
+    async fn my_very_renamed_tool(
+        &self,
+        agent_context: &dyn AgentContext,
+        test: &usize,
     ) -> Result<ToolOutput, ToolError> {
         Ok(format!("Hello world").into())
     }

--- a/swiftide-macros/tests/tool/tool_derive_pass.rs
+++ b/swiftide-macros/tests/tool/tool_derive_pass.rs
@@ -136,4 +136,36 @@ impl MyRenamedTool {
         Ok(format!("Hello world").into())
     }
 }
+
+#[derive(Clone, Tool)]
+#[tool(description = DESCRIPTION,
+    param(name = "test", description = "My param", required = false)
+)]
+struct MyOptionalTool;
+
+impl MyOptionalTool {
+    async fn my_optional_tool(
+        &self,
+        agent_context: &dyn AgentContext,
+        test: &Option<String>,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(format!("Hello world").into())
+    }
+}
+
+#[derive(Clone, Tool)]
+#[tool(description = DESCRIPTION,
+    param(name = "test", description = "My param", rust_type = "Option<usize>")
+)]
+struct MyOptionalTool2;
+
+impl MyOptionalTool2 {
+    async fn my_optional_tool_2(
+        &self,
+        agent_context: &dyn AgentContext,
+        test: &Option<usize>,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(format!("Hello world").into())
+    }
+}
 fn main() {}

--- a/swiftide-macros/tests/tool/tool_missing_arg_fail.rs
+++ b/swiftide-macros/tests/tool/tool_missing_arg_fail.rs
@@ -1,3 +1,7 @@
+use swiftide::chat_completion::errors::ToolError;
+use swiftide::chat_completion::ToolOutput;
+use swiftide::traits::AgentContext;
+
 #[swiftide_macros::tool(
     description = "My first tool",
     param(name = "msg", description = "A message for testing")
@@ -9,6 +13,8 @@ async fn basic_tool(
 ) -> Result<ToolOutput, ToolError> {
     Ok(format!("Hello {msg}").into())
 }
+
+const READ_FILE: &str = "Read a file";
 
 #[swiftide_macros::tool(
     description = READ_FILE,

--- a/swiftide-macros/tests/tool/tool_missing_arg_fail.stderr
+++ b/swiftide-macros/tests/tool/tool_missing_arg_fail.stderr
@@ -1,22 +1,10 @@
-error: Arguments in spec and in function do not match:
-        The following parameters are missing from the spec: ["other"]
- --> tests/tool/tool_missing_arg_fail.rs:1:1
+error: The following parameters are missing from the spec: ["other"]
+ --> tests/tool/tool_missing_arg_fail.rs:5:1
   |
-1 | / #[swiftide_macros::tool(
-2 | |     description = "My first tool",
-3 | |     param(name = "msg", description = "A message for testing")
-4 | | )]
+5 | / #[swiftide_macros::tool(
+6 | |     description = "My first tool",
+7 | |     param(name = "msg", description = "A message for testing")
+8 | | )]
   | |__^
   |
   = note: this error originates in the attribute macro `swiftide_macros::tool` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: Params that are not strings need to have their `type` as json spec specified
-  --> tests/tool/tool_missing_arg_fail.rs:13:1
-   |
-13 | / #[swiftide_macros::tool(
-14 | |     description = READ_FILE,
-15 | |     param(name = "number", description = "Number to guess")
-16 | | )]
-   | |__^
-   |
-   = note: this error originates in the attribute macro `swiftide_macros::tool` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/swiftide-macros/tests/tool/tool_missing_parameter_fail.stderr
+++ b/swiftide-macros/tests/tool/tool_missing_parameter_fail.stderr
@@ -1,5 +1,15 @@
-error: Arguments in spec and in function do not match:
-        The following parameters are missing from the function signature: ["Message"], The following parameters are missing from the spec: ["msg"]
+error: The following parameters are missing from the function signature: ["Message"]
+ --> tests/tool/tool_missing_parameter_fail.rs:1:1
+  |
+1 | / #[swiftide_macros::tool(
+2 | |     description = "My first tool",
+3 | |     param(name = "Message", description = "A message for testing")
+4 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `swiftide_macros::tool` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: The following parameters are missing from the spec: ["msg"]
  --> tests/tool/tool_missing_parameter_fail.rs:1:1
   |
 1 | / #[swiftide_macros::tool(

--- a/swiftide-macros/tests/tool/tool_single_argument_pass.rs
+++ b/swiftide-macros/tests/tool/tool_single_argument_pass.rs
@@ -25,6 +25,17 @@ async fn basic_tool_num(
 }
 
 #[swiftide_macros::tool(
+    description = "My first num tool",
+    param(name = "msg", description = "A message for testing")
+)]
+async fn basic_tool_num_no_type(
+    _agent_context: &dyn AgentContext,
+    msg: i32,
+) -> Result<ToolOutput, ToolError> {
+    Ok(format!("Hello {msg}").into())
+}
+
+#[swiftide_macros::tool(
     description = "My first array tool",
     param(
         name = "msg",

--- a/swiftide-macros/tests/tool/tool_single_argument_pass.rs
+++ b/swiftide-macros/tests/tool/tool_single_argument_pass.rs
@@ -81,4 +81,15 @@ async fn basic_tool_num_slice(
     Ok(format!("Hello {msg:?}").into())
 }
 
+#[swiftide_macros::tool(
+    description = "My first num slice tool",
+    param(name = "msg", description = "A message for testing")
+)]
+async fn basic_tool_num_optional(
+    _agent_context: &dyn AgentContext,
+    msg: Option<i32>,
+) -> Result<ToolOutput, ToolError> {
+    Ok(format!("Hello {msg:?}").into())
+}
+
 fn main() {}

--- a/swiftide/tests/indexing_pipeline.rs
+++ b/swiftide/tests/indexing_pipeline.rs
@@ -90,7 +90,7 @@ async fn test_indexing_pipeline() {
             .collect::<Vec<String>>()
             .join("\n---\n");
         println!("{received_requests}");
-    };
+    }
 
     result.expect("Indexing pipeline failed");
 


### PR DESCRIPTION
Adds support for `Option` values in tool params. These are marked as not required in the generated json spec.
Reworked the tool macros so that the json_type is no longer required if its not a string, most of the time it can be inferred (at least on attribute macros).
You can now also overwrite the rust type, rename the tool (`name`) or rename the inner function the tool will call (`fn_name`).

This also opens the door for supporting enums, nested objects and other foo. Overall the code is also a lot cleaner, bonus.
