### PR TITLE
chore: release v0.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.6](https://github.com/bosun-ai/swiftide/compare/v0.22.5...v0.22.6) - 2025-03-27
+
+### New features
+
+- [a05b3c8](https://github.com/bosun-ai/swiftide/commit/a05b3c8e7c4224c060215c34490b2ea7729592bf) *(macros)*  Support optional values and make them even nicer to use ([#703](https://github.com/bosun-ai/swiftide/pull/703))
+
+### Bug fixes
+
+- [1866d5a](https://github.com/bosun-ai/swiftide/commit/1866d5a081f40123e607208d04403fb98f34c057) *(integrations)*  Loosen up duckdb requirements even more and make it more flexible for version requirements ([#706](https://github.com/bosun-ai/swiftide/pull/706))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.5...0.22.6
+
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 ## [0.22.5](https://github.com/bosun-ai/swiftide/compare/v0.22.4...v0.22.5) - 2025-03-23
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8895,7 +8895,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8946,7 +8946,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8974,7 +8974,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -8993,7 +8993,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9092,7 +9092,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9115,7 +9115,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9134,7 +9134,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "async-openai 0.28.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.5"
+version = "0.22.6"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.5" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.6" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.5" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.6" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.5 -> 0.22.6
* `swiftide-agents`: 0.22.5 -> 0.22.6 (✓ API compatible changes)
* `swiftide-macros`: 0.22.5 -> 0.22.6
* `swiftide-indexing`: 0.22.5 -> 0.22.6
* `swiftide-integrations`: 0.22.5 -> 0.22.6 (✓ API compatible changes)
* `swiftide-query`: 0.22.5 -> 0.22.6
* `swiftide`: 0.22.5 -> 0.22.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.6](https://github.com/bosun-ai/swiftide/compare/v0.22.5...v0.22.6) - 2025-03-27

### New features

- [a05b3c8](https://github.com/bosun-ai/swiftide/commit/a05b3c8e7c4224c060215c34490b2ea7729592bf) *(macros)*  Support optional values and make them even nicer to use ([#703](https://github.com/bosun-ai/swiftide/pull/703))

### Bug fixes

- [1866d5a](https://github.com/bosun-ai/swiftide/commit/1866d5a081f40123e607208d04403fb98f34c057) *(integrations)*  Loosen up duckdb requirements even more and make it more flexible for version requirements ([#706](https://github.com/bosun-ai/swiftide/pull/706))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.5...0.22.6
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).