### PR TITLE
fix(integrations): Loosen up duckdb requirements even more and make it more flexible for version requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,8 @@ tree-sitter-solidity = { version = "1.2", default-features = false }
 tree-sitter-c = { version = "0.23", default-features = false }
 tree-sitter-cpp = { version = "0.23", default-features = false }
 async-anthropic = { version = "0.3.0", default-features = false }
-duckdb = { version = "1.2", default-features = false }
-libduckdb-sys = { version = "1.2", default-features = false }
+duckdb = { version = "1", default-features = false }
+libduckdb-sys = { version = "1", default-features = false }
 tiktoken-rs = { version = "0.6", default-features = false }
 
 # Testing

--- a/swiftide-integrations/src/duckdb/mod.rs
+++ b/swiftide-integrations/src/duckdb/mod.rs
@@ -121,7 +121,7 @@ impl Duckdb {
             for vector in self.vectors.keys() {
                 tx.execute(
                     &format!(
-                        "CREATE INDEX IF NOT EXISTS idx_{vector} ON {table_name} USING hnsw ({vector})",
+                        "CREATE INDEX IF NOT EXISTS idx_{vector} ON {table_name} USING hnsw ({vector}) WITH (metric = 'cosine')",
                     ),
                     [],
                 )


### PR DESCRIPTION
1.2.1 still has issues on Mac with the vss extension (seems discord
agrees). This loosens up the requirements so people can use the version
that works for them
