### PR TITLE
chore: release v0.22.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.7](https://github.com/bosun-ai/swiftide/compare/v0.22.6...v0.22.7) - 2025-03-30
+
+### Bug fixes
+
+- [b0001fb](https://github.com/bosun-ai/swiftide/commit/b0001fbb12cf6bb85fc4d5a8ef0968219e8c78db) *(duckdb)*  Upsert is now opt in as it requires duckdb >= 1.2 ([#708](https://github.com/bosun-ai/swiftide/pull/708))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.6...0.22.7
+
+
+
 ## [0.22.6](https://github.com/bosun-ai/swiftide/compare/v0.22.5...v0.22.6) - 2025-03-27
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9057,7 +9057,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "arrow-array 54.2.1",
@@ -9085,7 +9085,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9108,7 +9108,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9136,7 +9136,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9155,7 +9155,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9185,7 +9185,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "arrow-array 54.2.1",
@@ -9254,7 +9254,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9277,7 +9277,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9296,7 +9296,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "async-openai 0.28.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.6"
+version = "0.22.7"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.6" }
+swiftide-core = { path = "../swiftide-core/", version = "0.22.7" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.6" }
+swiftide-core = { path = "../swiftide-core", version = "0.22.7" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.6 -> 0.22.7
* `swiftide-agents`: 0.22.6 -> 0.22.7
* `swiftide-macros`: 0.22.6 -> 0.22.7
* `swiftide-indexing`: 0.22.6 -> 0.22.7
* `swiftide-integrations`: 0.22.6 -> 0.22.7 (✓ API compatible changes)
* `swiftide-query`: 0.22.6 -> 0.22.7
* `swiftide`: 0.22.6 -> 0.22.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.22.7](https://github.com/bosun-ai/swiftide/compare/v0.22.6...v0.22.7) - 2025-03-30

### Bug fixes

- [b0001fb](https://github.com/bosun-ai/swiftide/commit/b0001fbb12cf6bb85fc4d5a8ef0968219e8c78db) *(duckdb)*  Upsert is now opt in as it requires duckdb >= 1.2 ([#708](https://github.com/bosun-ai/swiftide/pull/708))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.6...0.22.7
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).