### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.0](https://github.com/bosun-ai/swiftide/compare/v0.22.8...v0.23.0) - 2025-04-08
+
+### New features
+
+- [fca4165](https://github.com/bosun-ai/swiftide/commit/fca4165c5be4b14cdc3d20ed8215ef64c5fd69a9) *(agents)*  Return typed errors and yield error in `on_stop` ([#725](https://github.com/bosun-ai/swiftide/pull/725))
+
+- [29352e6](https://github.com/bosun-ai/swiftide/commit/29352e6d3dc51779f3202e0e9936bf72e0b61605) *(agents)*  Add `on_stop` hook and `stop` now takes a `StopReason` ([#724](https://github.com/bosun-ai/swiftide/pull/724))
+
+- [a85cd8e](https://github.com/bosun-ai/swiftide/commit/a85cd8e2d014f198685ee6bfcfdf17f7f34acf91) *(macros)*  Support generics in Derive for tools ([#720](https://github.com/bosun-ai/swiftide/pull/720))
+
+- [52c44e9](https://github.com/bosun-ai/swiftide/commit/52c44e9b610c0ba4bf144881c36eacc3a0d10e53)  Agent mcp client support  ([#658](https://github.com/bosun-ai/swiftide/pull/658))
+
+````text
+Adds support for agents to use tools from MCP servers. All transports
+  are supported via the `rmcp` crate.
+
+  Additionally adds the possibility to add toolboxes to agents (of which
+  MCP is one). Tool boxes declare their available tools at runtime, like
+  tool box.
+````
+
+### Miscellaneous
+
+- [69706ec](https://github.com/bosun-ai/swiftide/commit/69706ec6630b70ea9d332c151637418736437a99)  [**breaking**] Remove templates ([#716](https://github.com/bosun-ai/swiftide/pull/716))
+
+````text
+Template / prompt interface got confusing and bloated. This removes
+  `Template` fully, and changes Prompt such that it can either ref to a
+  one-off, or to a template named compiled in the swiftide repository.
+````
+
+**BREAKING CHANGE**: This removes `Template` from Swiftide and simplifies
+the whole setup significantly. The internal Swiftide Tera repository can
+still be extended like with Templates. Same behaviour with less code and
+abstractions.
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.8...0.23.0
+
+
+
 ## [0.22.8](https://github.com/bosun-ai/swiftide/compare/v0.22.7...v0.22.8) - 2025-04-02
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1516,7 +1516,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9124,7 +9124,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "arrow-array 54.2.1",
@@ -9152,7 +9152,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9178,7 +9178,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9206,7 +9206,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9226,7 +9226,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9256,7 +9256,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "arrow-array 54.2.1",
@@ -9325,7 +9325,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9348,7 +9348,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9367,7 +9367,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.22.8"
+version = "0.23.0"
 dependencies = [
  "async-openai 0.28.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.8"
+version = "0.23.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.22" }
+swiftide-core = { path = "../swiftide-core", version = "0.23" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.22" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.22" }
+swiftide-core = { path = "../swiftide-core", version = "0.23" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.23" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.22" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.22" }
+swiftide-core = { path = "../swiftide-core", version = "0.23" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.23" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.22.8" }
+swiftide-core = { path = "../swiftide-core/", version = "0.23.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.22.8" }
+swiftide-core = { path = "../swiftide-core", version = "0.23.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.22" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.22" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.22" }
-swiftide-query = { path = "../swiftide-query", version = "0.22" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.22", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.23" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.23" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.23" }
+swiftide-query = { path = "../swiftide-query", version = "0.23" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.23", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.22.8 -> 0.23.0 (⚠ API breaking changes)
* `swiftide-agents`: 0.22.8 -> 0.23.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.22.8 -> 0.23.0
* `swiftide-indexing`: 0.22.8 -> 0.23.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.22.8 -> 0.23.0 (✓ API compatible changes)
* `swiftide-query`: 0.22.8 -> 0.23.0 (✓ API compatible changes)
* `swiftide`: 0.22.8 -> 0.23.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum swiftide_core::prompt::PromptTemplate, previously in file /tmp/.tmpZjQGX3/swiftide-core/src/template.rs:29
  enum swiftide_core::template::Template, previously in file /tmp/.tmpZjQGX3/swiftide-core/src/template.rs:29

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod swiftide_core::template, previously in file /tmp/.tmpZjQGX3/swiftide-core/src/template.rs:1
```

### ⚠ `swiftide-agents` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant Hook:OnStop in /tmp/.tmpDX2JBq/swiftide/swiftide-agents/src/hooks.rs:188
  variant HookTypes:OnStop in /tmp/.tmpDX2JBq/swiftide/swiftide-agents/src/hooks.rs:188

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_parameter_count_changed.ron

Failed in:
  swiftide_agents::Agent::stop now takes 2 parameters instead of 1, in /tmp/.tmpDX2JBq/swiftide/swiftide-agents/src/agent.rs:556
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.23.0](https://github.com/bosun-ai/swiftide/compare/v0.22.8...v0.23.0) - 2025-04-08

### New features

- [fca4165](https://github.com/bosun-ai/swiftide/commit/fca4165c5be4b14cdc3d20ed8215ef64c5fd69a9) *(agents)*  Return typed errors and yield error in `on_stop` ([#725](https://github.com/bosun-ai/swiftide/pull/725))

- [29352e6](https://github.com/bosun-ai/swiftide/commit/29352e6d3dc51779f3202e0e9936bf72e0b61605) *(agents)*  Add `on_stop` hook and `stop` now takes a `StopReason` ([#724](https://github.com/bosun-ai/swiftide/pull/724))

- [a85cd8e](https://github.com/bosun-ai/swiftide/commit/a85cd8e2d014f198685ee6bfcfdf17f7f34acf91) *(macros)*  Support generics in Derive for tools ([#720](https://github.com/bosun-ai/swiftide/pull/720))

- [52c44e9](https://github.com/bosun-ai/swiftide/commit/52c44e9b610c0ba4bf144881c36eacc3a0d10e53)  Agent mcp client support  ([#658](https://github.com/bosun-ai/swiftide/pull/658))

````text
Adds support for agents to use tools from MCP servers. All transports
  are supported via the `rmcp` crate.

  Additionally adds the possibility to add toolboxes to agents (of which
  MCP is one). Tool boxes declare their available tools at runtime, like
  tool box.
````

### Miscellaneous

- [69706ec](https://github.com/bosun-ai/swiftide/commit/69706ec6630b70ea9d332c151637418736437a99)  [**breaking**] Remove templates ([#716](https://github.com/bosun-ai/swiftide/pull/716))

````text
Template / prompt interface got confusing and bloated. This removes
  `Template` fully, and changes Prompt such that it can either ref to a
  one-off, or to a template named compiled in the swiftide repository.
````

**BREAKING CHANGE**: This removes `Template` from Swiftide and simplifies
the whole setup significantly. The internal Swiftide Tera repository can
still be extended like with Templates. Same behaviour with less code and
abstractions.


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.22.8...0.23.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).