### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.0](https://github.com/bosun-ai/swiftide/compare/v0.23.0...v0.24.0) - 2025-04-11
+
+### New features
+
+- [3117fc6](https://github.com/bosun-ai/swiftide/commit/3117fc62c146b0bf0949adb3cfe4e6c7f40427f7)  Introduce LanguageModelError for LLM traits and an optional backoff decorator ([#630](https://github.com/bosun-ai/swiftide/pull/630))
+
+### Miscellaneous
+
+- [e872c5b](https://github.com/bosun-ai/swiftide/commit/e872c5b24388754b371d9f0c7faad8647ad4733b)  Core test utils available behind feature flag ([#730](https://github.com/bosun-ai/swiftide/pull/730))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.23.0...0.24.0
+
+
+
 ## [0.23.0](https://github.com/bosun-ai/swiftide/compare/v0.22.8...v0.23.0) - 2025-04-08
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,7 +1370,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8995,7 +8995,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9023,7 +9023,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9049,7 +9049,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9098,7 +9098,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9197,7 +9197,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9220,7 +9220,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9239,7 +9239,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-openai 0.28.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.23" }
+swiftide-core = { path = "../swiftide-core", version = "0.24" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.23" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.23" }
+swiftide-core = { path = "../swiftide-core", version = "0.24" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.24" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.23" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.23" }
+swiftide-core = { path = "../swiftide-core", version = "0.24" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.24" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.23.0" }
+swiftide-core = { path = "../swiftide-core/", version = "0.24.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.23.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.24.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.23" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.23" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.23" }
-swiftide-query = { path = "../swiftide-query", version = "0.23" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.23", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.24" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.24" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.24" }
+swiftide-query = { path = "../swiftide-query", version = "0.24" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.24", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.23.0 -> 0.24.0 (⚠ API breaking changes)
* `swiftide-agents`: 0.23.0 -> 0.24.0 (✓ API compatible changes)
* `swiftide-macros`: 0.23.0 -> 0.24.0
* `swiftide-indexing`: 0.23.0 -> 0.24.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.23.0 -> 0.24.0 (✓ API compatible changes)
* `swiftide-query`: 0.23.0 -> 0.24.0
* `swiftide`: 0.23.0 -> 0.24.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_missing.ron

Failed in:
  enum swiftide_core::chat_completion::errors::ChatCompletionError, previously in file /tmp/.tmp11FUPF/swiftide-core/src/chat_completion/errors.rs:24
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.24.0](https://github.com/bosun-ai/swiftide/compare/v0.23.0...v0.24.0) - 2025-04-11

### New features

- [3117fc6](https://github.com/bosun-ai/swiftide/commit/3117fc62c146b0bf0949adb3cfe4e6c7f40427f7)  Introduce LanguageModelError for LLM traits and an optional backoff decorator ([#630](https://github.com/bosun-ai/swiftide/pull/630))

### Miscellaneous

- [e872c5b](https://github.com/bosun-ai/swiftide/commit/e872c5b24388754b371d9f0c7faad8647ad4733b)  Core test utils available behind feature flag ([#730](https://github.com/bosun-ai/swiftide/pull/730))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.23.0...0.24.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).