### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.0](https://github.com/bosun-ai/swiftide/compare/v0.24.0...v0.25.0) - 2025-04-16
+
+### New features
+
+- [4959ddf](https://github.com/bosun-ai/swiftide/commit/4959ddfe00e0424215dd9bd3e8a6acb579cc056c) *(agents)*  Restore agents from an existing message history ([#742](https://github.com/bosun-ai/swiftide/pull/742))
+
+- [6efd15b](https://github.com/bosun-ai/swiftide/commit/6efd15bf7b88d8f8656c4017676baf03a3bb510e) *(agents)*  Agents now take an Into<Prompt> when queried ([#743](https://github.com/bosun-ai/swiftide/pull/743))
+
+### Bug fixes
+
+- [5db4de2](https://github.com/bosun-ai/swiftide/commit/5db4de2f0deb2028f5ffaf28b4d26336840e908c) *(agents)*  Properly support nullable types for MCP tools ([#740](https://github.com/bosun-ai/swiftide/pull/740))
+
+````text
+Makes me wonder if using i.e schemars for the tool_spec across swiftide
+  is a better option. Writing custom serializers is time consuming.
+````
+
+- [dd2ca86](https://github.com/bosun-ai/swiftide/commit/dd2ca86b214e8268262075a513711d6b9c793115) *(agents)*  Do not log twice if mcp failed to stop
+
+### Miscellaneous
+
+- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies
+
+- [0f2605a](https://github.com/bosun-ai/swiftide/commit/0f2605a61240d2c99e10ce6f5a91e6568343a78b)  Pretty print RAGAS output ([#745](https://github.com/bosun-ai/swiftide/pull/745))
+
+````text
+It's a bit unreadable without the formatting.
+````
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.24.0...0.25.0
+
+
+
 ## [0.24.0](https://github.com/bosun-ai/swiftide/compare/v0.23.0...v0.24.0) - 2025-04-11
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1372,7 +1372,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -8999,7 +8999,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9027,7 +9027,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9053,7 +9053,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9083,7 +9083,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9103,7 +9103,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9133,7 +9133,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9202,7 +9202,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9225,7 +9225,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9244,7 +9244,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "async-openai 0.28.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.24.0"
+version = "0.25.0"
 edition = "2021"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.24" }
+swiftide-core = { path = "../swiftide-core", version = "0.25" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.24" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.24" }
+swiftide-core = { path = "../swiftide-core", version = "0.25" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.25" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.24" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.24" }
+swiftide-core = { path = "../swiftide-core", version = "0.25" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.25" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.24.0" }
+swiftide-core = { path = "../swiftide-core/", version = "0.25.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.24.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.25.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,11 +16,11 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.24" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.24" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.24" }
-swiftide-query = { path = "../swiftide-query", version = "0.24" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.24", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.25" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.25" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.25" }
+swiftide-query = { path = "../swiftide-query", version = "0.25" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.25", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.24.0 -> 0.25.0 (⚠ API breaking changes)
* `swiftide-agents`: 0.24.0 -> 0.25.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.24.0 -> 0.25.0
* `swiftide-indexing`: 0.24.0 -> 0.25.0
* `swiftide-integrations`: 0.24.0 -> 0.25.0 (✓ API compatible changes)
* `swiftide-query`: 0.24.0 -> 0.25.0 (✓ API compatible changes)
* `swiftide`: 0.24.0 -> 0.25.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure enum_discriminants_undefined_non_unit_variant: enum's variants no longer have defined discriminants due to non-unit variant ---

Description:
An enum's variants no longer have well-defined discriminant values due to a tuple or struct variant in the enum. This breaks downstream code that accesses discriminants via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_discriminants_undefined_non_unit_variant.ron

Failed in:
  enum ParamType in /tmp/.tmp7xy0JR/swiftide/swiftide-core/src/chat_completion/tools.rs:118

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant ParamType:Nullable in /tmp/.tmp7xy0JR/swiftide/swiftide-core/src/chat_completion/tools.rs:124
```

### ⚠ `swiftide-agents` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentError:FailedToRenderPrompt in /tmp/.tmp7xy0JR/swiftide/swiftide-agents/src/errors.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.25.0](https://github.com/bosun-ai/swiftide/compare/v0.24.0...v0.25.0) - 2025-04-16

### New features

- [4959ddf](https://github.com/bosun-ai/swiftide/commit/4959ddfe00e0424215dd9bd3e8a6acb579cc056c) *(agents)*  Restore agents from an existing message history ([#742](https://github.com/bosun-ai/swiftide/pull/742))

- [6efd15b](https://github.com/bosun-ai/swiftide/commit/6efd15bf7b88d8f8656c4017676baf03a3bb510e) *(agents)*  Agents now take an Into<Prompt> when queried ([#743](https://github.com/bosun-ai/swiftide/pull/743))

### Bug fixes

- [5db4de2](https://github.com/bosun-ai/swiftide/commit/5db4de2f0deb2028f5ffaf28b4d26336840e908c) *(agents)*  Properly support nullable types for MCP tools ([#740](https://github.com/bosun-ai/swiftide/pull/740))

````text
Makes me wonder if using i.e schemars for the tool_spec across swiftide
  is a better option. Writing custom serializers is time consuming.
````

- [dd2ca86](https://github.com/bosun-ai/swiftide/commit/dd2ca86b214e8268262075a513711d6b9c793115) *(agents)*  Do not log twice if mcp failed to stop

### Miscellaneous

- [0000000](https://github.com/bosun-ai/swiftide/commit/0000000)  Update Cargo.toml dependencies

- [0f2605a](https://github.com/bosun-ai/swiftide/commit/0f2605a61240d2c99e10ce6f5a91e6568343a78b)  Pretty print RAGAS output ([#745](https://github.com/bosun-ai/swiftide/pull/745))

````text
It's a bit unreadable without the formatting.
````


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.24.0...0.25.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).