### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.26.0](https://github.com/bosun-ai/swiftide/compare/v0.25.1...v0.26.0) - 2025-05-06
+
+### New features
+
+- [11051d5](https://github.com/bosun-ai/swiftide/commit/11051d5a1df6ea158ee84de274767fbdc70cc74e) *(agents)*  `tools` on `Agent` is now public and can be used in hooks
+
+- [ebe68c1](https://github.com/bosun-ai/swiftide/commit/ebe68c104b8198b80ee5ee1f451c3272ce36841c) *(integrations)*  Streaming chat completions for anthropic ([#773](https://github.com/bosun-ai/swiftide/pull/773))
+
+- [7f5b345](https://github.com/bosun-ai/swiftide/commit/7f5b345115a3443afc9b32ca54a292fae3f5d38b) *(integrations)*  Streaming chat completions for OpenAI ([#741](https://github.com/bosun-ai/swiftide/pull/741))
+
+- [e2278fb](https://github.com/bosun-ai/swiftide/commit/e2278fb133e51f15025e114135a2bc29157242ee) *(integrations)*  Customize common default settings for OpenAI requests ([#775](https://github.com/bosun-ai/swiftide/pull/775))
+
+- [c563cf2](https://github.com/bosun-ai/swiftide/commit/c563cf270c60957dbb948113fb2299ec5eb7ed58) *(treesitter)*  Add elixir support ([#776](https://github.com/bosun-ai/swiftide/pull/776))
+
+- [13ae991](https://github.com/bosun-ai/swiftide/commit/13ae991b632cc95d1ae0bc7107146a145af59c74)  Add usage to chat completion response ([#774](https://github.com/bosun-ai/swiftide/pull/774))
+
+### Bug fixes
+
+- [046301d](https://github.com/bosun-ai/swiftide/commit/046301d25d6fe454365de0fe8dbecfa0060cfff4) *(agents)*  Use an RwLock to properly close a running MCP server
+
+- [0831c98](https://github.com/bosun-ai/swiftide/commit/0831c982cd6bb0b442396268c0681c908b6dadc2) *(openai)*  Disable parallel tool calls by default
+
+### Miscellaneous
+
+- [18dc99c](https://github.com/bosun-ai/swiftide/commit/18dc99ca1f597586ffed36e163f04f7c3689d2be) *(integrations)*  Use generics for all openai variants ([#764](https://github.com/bosun-ai/swiftide/pull/764))
+
+- [2a9d062](https://github.com/bosun-ai/swiftide/commit/2a9d062c6e19721c49c6233690ac71e9e28b6a04) *(openai)*  Consistent exports across providers
+
+- [4df6dbf](https://github.com/bosun-ai/swiftide/commit/4df6dbf17fd4b87afc2cf7159c6518fcebc27438)  Export macros from main crate and enable them by default ([#778](https://github.com/bosun-ai/swiftide/pull/778))
+
+- [8b30fde](https://github.com/bosun-ai/swiftide/commit/8b30fde5e20ecbd4f0387c26e441d39f78ddca32)  Rust like its 2024 ([#763](https://github.com/bosun-ai/swiftide/pull/763))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.25.1...0.26.0
+
+
+
 ## [0.25.1](https://github.com/bosun-ai/swiftide/compare/v0.25.0...v0.25.1) - 2025-04-17
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,7 +1380,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9100,7 +9100,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9129,7 +9129,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9157,7 +9157,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9187,7 +9187,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9207,7 +9207,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9237,7 +9237,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9308,7 +9308,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9331,7 +9331,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9350,7 +9350,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "async-openai 0.28.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.1"
+version = "0.26.0"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.25" }
+swiftide-core = { path = "../swiftide-core", version = "0.26" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -15,10 +15,12 @@ use rmcp::transport::IntoTransport;
 use rmcp::{ServiceExt, model::CallToolRequestParam};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use swiftide_core::CommandError;
 use swiftide_core::{
     Tool, ToolBox,
     chat_completion::{ParamSpec, ParamType, ToolSpec, errors::ToolError},
 };
+use tokio::sync::RwLock;
 
 /// A filter to apply to the available tools
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -33,7 +35,7 @@ pub enum ToolFilter {
 /// `ClientInfo` instead, or from the transport and `Swiftide` will handle the rest.
 #[derive(Clone)]
 pub struct McpToolbox {
-    service: Option<Arc<RunningService<RoleClient, InitializeRequestParam>>>,
+    service: Arc<RwLock<Option<RunningService<RoleClient, InitializeRequestParam>>>>,
 
     /// Optional human readable name for the toolbox
     name: Option<String>,
@@ -90,7 +92,7 @@ impl McpToolbox {
         transport: impl IntoTransport<RoleClient, E, A>,
     ) -> Result<Self> {
         let info = Self::default_client_info();
-        let service = Some(Arc::new(info.serve(transport).await?));
+        let service = Arc::new(RwLock::new(Some(info.serve(transport).await?)));
 
         Ok(Self {
             service,
@@ -104,7 +106,7 @@ impl McpToolbox {
         service: RunningService<RoleClient, InitializeRequestParam>,
     ) -> Self {
         Self {
-            service: Some(service.into()),
+            service: Arc::new(RwLock::new(Some(service))),
             filter: None.into(),
             name: None,
         }
@@ -119,6 +121,26 @@ impl McpToolbox {
             ..Default::default()
         }
     }
+
+    /// Disconnects from the MCP server if it is running
+    ///
+    /// If it is not running, an Ok is returned and it logs a tracing message
+    async fn cancel(&mut self) -> Result<()> {
+        let mut lock = self.service.write().await;
+        let Some(service) = std::mem::take(&mut *lock) else {
+            tracing::warn!("mcp server is not running");
+            return Ok(());
+        };
+
+        tracing::debug!(name = self.name(), "Stopping mcp server");
+
+        service
+            .cancel()
+            .await
+            .context("failed to stop mcp server")?;
+
+        Ok(())
+    }
 }
 
 // Stop the service if there are no more references to it
@@ -126,13 +148,8 @@ impl Drop for McpToolbox {
     fn drop(&mut self) {
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                let service = std::mem::take(&mut self.service);
-                if let Some(service) = service.and_then(Arc::into_inner) {
-                    if let Err(err) = service.cancel().await {
-                        tracing::error!(name = self.name(), "Failed to stop mcp server: {err}");
-                        return;
-                    }
-                    tracing::debug!(name = self.name(), "Stopping mcp server");
+                if let Err(err) = self.cancel().await {
+                    tracing::error!(name = self.name(), "Failed to stop mcp server: {err}");
                 }
             });
         });
@@ -152,7 +169,7 @@ struct ToolInputSchema {
 impl ToolBox for McpToolbox {
     #[tracing::instrument(skip_all)]
     async fn available_tools(&self) -> Result<Vec<Box<dyn Tool>>> {
-        let Some(service) = &self.service else {
+        let Some(service) = &*self.service.read().await else {
             anyhow::bail!("No service available");
         };
         tracing::debug!(name = self.name(), "Connecting to mcp server");
@@ -205,7 +222,7 @@ impl ToolBox for McpToolbox {
                 let tool_spec = tool_spec.build().context("Failed to build tool spec")?;
 
                 Ok(Box::new(McpTool {
-                    client: Arc::clone(service),
+                    client: Arc::clone(&self.service),
                     tool_name: t.name.into(),
                     tool_spec,
                 }) as Box<dyn Tool>)
@@ -242,7 +259,7 @@ impl ToolBox for McpToolbox {
 
 #[derive(Clone)]
 struct McpTool {
-    client: Arc<RunningService<RoleClient, InitializeRequestParam>>,
+    client: Arc<RwLock<Option<RunningService<RoleClient, InitializeRequestParam>>>>,
     tool_name: String,
     tool_spec: ToolSpec,
 }
@@ -267,9 +284,14 @@ impl Tool for McpTool {
             arguments: args,
         };
 
+        let Some(service) = &*self.client.read().await else {
+            return Err(
+                CommandError::ExecutorError(anyhow::anyhow!("mcp server is not running")).into(),
+            );
+        };
+
         tracing::debug!(request = ?request, tool = self.name().as_ref(), "Invoking mcp tool");
-        let response = self
-            .client
+        let response = service
             .call_tool(request)
             .await
             .context("Failed to call tool")?;

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -33,6 +33,8 @@ pub enum ToolFilter {
 ///
 /// WARN: The rmcp has a quirky feature to serve from `()`. This does not work; serve from
 /// `ClientInfo` instead, or from the transport and `Swiftide` will handle the rest.
+///
+/// If the toolbox is dropped, the connection to the MCP server will be closed.
 #[derive(Clone)]
 pub struct McpToolbox {
     service: Arc<RwLock<Option<RunningService<RoleClient, InitializeRequestParam>>>>,

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.25" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.25" }
+swiftide-core = { path = "../swiftide-core", version = "0.26" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.26" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.25" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.25" }
+swiftide-core = { path = "../swiftide-core", version = "0.26" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.26" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.25.1" }
+swiftide-core = { path = "../swiftide-core/", version = "0.26.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.25.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.26.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,12 +16,12 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.25" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.25" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.25" }
-swiftide-query = { path = "../swiftide-query", version = "0.25" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.25", optional = true }
-swiftide-macros = { path = "../swiftide-macros", version = "0.25", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.26" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.26" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.26" }
+swiftide-query = { path = "../swiftide-query", version = "0.26" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.26", optional = true }
+swiftide-macros = { path = "../swiftide-macros", version = "0.26", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.25.1 -> 0.26.0 (⚠ API breaking changes)
* `swiftide-agents`: 0.25.1 -> 0.26.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.25.1 -> 0.26.0
* `swiftide-indexing`: 0.25.1 -> 0.26.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.25.1 -> 0.26.0 (⚠ API breaking changes)
* `swiftide-query`: 0.25.1 -> 0.26.0 (✓ API compatible changes)
* `swiftide`: 0.25.1 -> 0.26.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ChatCompletionResponse.id in /tmp/.tmpDi2zUr/swiftide/swiftide-core/src/chat_completion/chat_completion_response.rs:20
  field ChatCompletionResponse.usage in /tmp/.tmpDi2zUr/swiftide/swiftide-core/src/chat_completion/chat_completion_response.rs:29
  field ChatCompletionResponse.delta in /tmp/.tmpDi2zUr/swiftide/swiftide-core/src/chat_completion/chat_completion_response.rs:33
```

### ⚠ `swiftide-agents` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant Hook:OnStream in /tmp/.tmpDi2zUr/swiftide/swiftide-agents/src/hooks.rs:203
  variant HookTypes:OnStream in /tmp/.tmpDi2zUr/swiftide/swiftide-agents/src/hooks.rs:203
  variant AgentError:EmptyStream in /tmp/.tmpDi2zUr/swiftide/swiftide-agents/src/errors.rs:32
```

### ⚠ `swiftide-integrations` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Options.parallel_tool_calls in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:107
  field Options.max_completion_tokens in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:113
  field Options.temperature in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:117
  field Options.reasoning_effort in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:121
  field Options.seed in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:128
  field Options.presence_penalty in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:133
  field Options.metadata in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:137
  field Options.user in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:142
  field Options.parallel_tool_calls in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:107
  field Options.max_completion_tokens in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:113
  field Options.temperature in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:117
  field Options.reasoning_effort in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:121
  field Options.seed in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:128
  field Options.presence_penalty in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:133
  field Options.metadata in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:137
  field Options.user in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:142
  field Options.dimensions in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:147
  field Options.embed_model in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:98
  field Options.parallel_tool_calls in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:107
  field Options.max_completion_tokens in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:113
  field Options.temperature in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:117
  field Options.reasoning_effort in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:121
  field Options.seed in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:128
  field Options.presence_penalty in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:133
  field Options.metadata in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:137
  field Options.user in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:142
  field Options.dimensions in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:147
  field Options.max_completion_tokens in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:113
  field Options.temperature in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:117
  field Options.reasoning_effort in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:121
  field Options.seed in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:128
  field Options.presence_penalty in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:133
  field Options.metadata in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:137
  field Options.user in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:142
  field Options.dimensions in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:147

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_integrations::dashscope::OptionsBuilder::dimensions takes 0 generic types instead of 1, in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:93
  swiftide_integrations::openai::OptionsBuilder::parallel_tool_calls takes 0 generic types instead of 1, in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:93
  swiftide_integrations::openai::GenericOpenAIBuilder::default_options takes 0 generic types instead of 1, in /tmp/.tmpDi2zUr/swiftide/swiftide-integrations/src/openai/mod.rs:308

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/module_missing.ron

Failed in:
  mod swiftide_integrations::ollama::simple_prompt, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/ollama/simple_prompt.rs:1
  mod swiftide_integrations::open_router::chat_completion, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/open_router/chat_completion.rs:1
  mod swiftide_integrations::ollama::embed, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/ollama/embed.rs:1
  mod swiftide_integrations::open_router::simple_prompt, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/open_router/simple_prompt.rs:1
  mod swiftide_integrations::ollama::chat_completion, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/ollama/chat_completion.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_missing.ron

Failed in:
  struct swiftide_integrations::ollama::OllamaBuilder, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/ollama/mod.rs:25
  struct swiftide_integrations::dashscope::DashscopeBuilder, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/dashscope/mod.rs:10
  struct swiftide_integrations::ollama::Ollama, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/ollama/mod.rs:27
  struct swiftide_integrations::open_router::OpenRouterBuilder, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/open_router/mod.rs:24
  struct swiftide_integrations::dashscope::Dashscope, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/dashscope/mod.rs:12
  struct swiftide_integrations::open_router::OpenRouter, previously in file /tmp/.tmpakC8Rx/swiftide-integrations/src/open_router/mod.rs:26
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.26.0](https://github.com/bosun-ai/swiftide/compare/v0.25.1...v0.26.0) - 2025-05-06

### New features

- [11051d5](https://github.com/bosun-ai/swiftide/commit/11051d5a1df6ea158ee84de274767fbdc70cc74e) *(agents)*  `tools` on `Agent` is now public and can be used in hooks

- [ebe68c1](https://github.com/bosun-ai/swiftide/commit/ebe68c104b8198b80ee5ee1f451c3272ce36841c) *(integrations)*  Streaming chat completions for anthropic ([#773](https://github.com/bosun-ai/swiftide/pull/773))

- [7f5b345](https://github.com/bosun-ai/swiftide/commit/7f5b345115a3443afc9b32ca54a292fae3f5d38b) *(integrations)*  Streaming chat completions for OpenAI ([#741](https://github.com/bosun-ai/swiftide/pull/741))

- [e2278fb](https://github.com/bosun-ai/swiftide/commit/e2278fb133e51f15025e114135a2bc29157242ee) *(integrations)*  Customize common default settings for OpenAI requests ([#775](https://github.com/bosun-ai/swiftide/pull/775))

- [c563cf2](https://github.com/bosun-ai/swiftide/commit/c563cf270c60957dbb948113fb2299ec5eb7ed58) *(treesitter)*  Add elixir support ([#776](https://github.com/bosun-ai/swiftide/pull/776))

- [13ae991](https://github.com/bosun-ai/swiftide/commit/13ae991b632cc95d1ae0bc7107146a145af59c74)  Add usage to chat completion response ([#774](https://github.com/bosun-ai/swiftide/pull/774))

### Bug fixes

- [046301d](https://github.com/bosun-ai/swiftide/commit/046301d25d6fe454365de0fe8dbecfa0060cfff4) *(agents)*  Use an RwLock to properly close a running MCP server

- [0831c98](https://github.com/bosun-ai/swiftide/commit/0831c982cd6bb0b442396268c0681c908b6dadc2) *(openai)*  Disable parallel tool calls by default

### Miscellaneous

- [18dc99c](https://github.com/bosun-ai/swiftide/commit/18dc99ca1f597586ffed36e163f04f7c3689d2be) *(integrations)*  Use generics for all openai variants ([#764](https://github.com/bosun-ai/swiftide/pull/764))

- [2a9d062](https://github.com/bosun-ai/swiftide/commit/2a9d062c6e19721c49c6233690ac71e9e28b6a04) *(openai)*  Consistent exports across providers

- [4df6dbf](https://github.com/bosun-ai/swiftide/commit/4df6dbf17fd4b87afc2cf7159c6518fcebc27438)  Export macros from main crate and enable them by default ([#778](https://github.com/bosun-ai/swiftide/pull/778))

- [8b30fde](https://github.com/bosun-ai/swiftide/commit/8b30fde5e20ecbd4f0387c26e441d39f78ddca32)  Rust like its 2024 ([#763](https://github.com/bosun-ai/swiftide/pull/763))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.25.1...0.26.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).