### PR TITLE
feat(agents)!: Easy human-in-the-loop flows by decorating tools

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -131,3 +131,7 @@ path = "agents_resume.rs"
 [[example]]
 name = "streaming-agents"
 path = "streaming_agents.rs"
+
+[[example]]
+name = "agents-hitl"
+path = "agents_with_human_in_the_loop.rs"

--- a/examples/agents_with_human_in_the_loop.rs
+++ b/examples/agents_with_human_in_the_loop.rs
@@ -21,14 +21,6 @@ use swiftide::{
     traits::{AgentContext, ToolFeedback},
 };
 
-// The macro supports strings/strs, vectors/slices, booleans and numbers.
-//
-// This is currently only supported for the attribute macro, not the derive macro.
-//
-// If you need more control or need to use full objects, we recommend to implement the `Tool` trait
-// and prove the Json spec yourself. Builders are available.
-//
-// For non-string types, the `json_type` is required to be specified.
 #[swiftide::tool(
     description = "Guess a number",
     param(name = "number", description = "Number to guess")
@@ -74,6 +66,8 @@ async fn main() -> Result<()> {
             Box::pin(async move { Ok(()) })
         })
         .on_stop(move |_agent, reason, _| {
+            // If you implement your own feedback flow, you can ofcourse also do it directly in the
+            // tool.
             if let StopReason::FeedbackRequired { tool_call, .. } = reason {
                 tx.send(tool_call).unwrap();
             }
@@ -90,6 +84,9 @@ async fn main() -> Result<()> {
     let Some(tool_call) = rx.recv().await else {
         panic!("expected a tool call to approve")
     };
+
+    // Alternatively, you can also get the stop reason from the agent state
+    // agent.state().stop_reason().unwrap().feedback_required().unwrap()
 
     // Register that this tool call is ok.
     println!("Approving number guessing");

--- a/examples/agents_with_human_in_the_loop.rs
+++ b/examples/agents_with_human_in_the_loop.rs
@@ -1,0 +1,111 @@
+//! This is an example of how to build a Swiftide agent
+//!
+//! A swiftide agent runs completions in a loop, optionally with tools, to complete a task
+//! autonomously. Agents stop when either the LLM calls the always included `stop` tool, or
+//! (configurable) if the last message in the completion chain was from the assistant.
+//!
+//! Tools can be created by using the `tool` attribute macro as shown here. For more control (i.e.
+//! internal state), there
+//! is also a `Tool` derive macro for convenience. Anything that implements the `Tool` trait can
+//! act as a tool.
+//!
+//! Agents operate on an `AgentContext`, which is responsible for managaging the completion history
+//! and providing access to the outside world. For the latter, the context is expected to have a
+//! `ToolExecutor`, which by default runs locally.
+//!
+//! When building the agent, hooks are available to influence the state, completions, and general
+//! behaviour of the agent. Hooks are also traits.
+//!
+//! Refer to the api documentation for more detailed information.
+use std::pin::Pin;
+
+use anyhow::Result;
+use swiftide::{
+    agents::{self, StopReason, tools::control::ApprovalRequired},
+    chat_completion::{ToolCall, ToolOutput, errors::ToolError},
+    traits::{AgentContext, Command},
+};
+
+// The macro supports strings/strs, vectors/slices, booleans and numbers.
+//
+// This is currently only supported for the attribute macro, not the derive macro.
+//
+// If you need more control or need to use full objects, we recommend to implement the `Tool` trait
+// and prove the Json spec yourself. Builders are available.
+//
+// For non-string types, the `json_type` is required to be specified.
+#[swiftide::tool(
+    description = "Guess a number",
+    param(name = "number", description = "Number to guess")
+)]
+async fn guess_a_number(
+    _context: &dyn AgentContext,
+    number: usize,
+) -> Result<ToolOutput, ToolError> {
+    let actual_number = 42;
+
+    if number == actual_number {
+        Ok("You guessed it!".into())
+    } else {
+        Ok("Try again!".into())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt().compact().init();
+
+    println!("Hello, agents!");
+
+    let openai = swiftide::integrations::openai::OpenAI::builder()
+        .default_prompt_model("gpt-4o-mini")
+        .build()?;
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<ToolCall>();
+
+    // ApprovalRequired is a simple wrapper. You can also implement your own approval
+    // flows by returning a `ToolOutput::FeedbackRequired` in a tool,
+    // you can then use `has_received_feedback` and `received_feedback` on the context
+    // to build your custom workflow.
+    let guess_with_approval = ApprovalRequired(guess_a_number());
+
+    let mut agent = agents::Agent::builder()
+        .llm(&openai)
+        .tools(vec![guess_with_approval])
+        // Every message added by the agent will be printed to stdout
+        .on_new_message(move |_, msg| {
+            println!("{msg}");
+
+            Box::pin(async move { Ok(()) })
+        })
+        .on_stop(move |_agent, reason, _| {
+            if let StopReason::FeedbackRequired { tool_call, .. } = reason {
+                tx.send(tool_call).unwrap();
+            }
+
+            Box::pin(async { Ok(()) })
+        })
+        .limit(5)
+        .build()?;
+
+    // First query the agent, the agent will stop with a reason that feedback is required
+    agent.query("Guess a number between 0 and 100").await?;
+
+    // The agent stopped, lets get the tool call
+    let Some(tool_call) = rx.recv().await else {
+        panic!("expected a tool call to approve")
+    };
+
+    // Register that this tool call is ok.
+    println!("Approving number guessing");
+    agent
+        .context()
+        .feedback_received(&tool_call, None)
+        .await
+        .unwrap();
+
+    // Run the agent again and it will pick up where it stopped.
+    agent.run().await.unwrap();
+
+    Ok(())
+}

--- a/examples/agents_with_human_in_the_loop.rs
+++ b/examples/agents_with_human_in_the_loop.rs
@@ -18,7 +18,7 @@ use anyhow::Result;
 use swiftide::{
     agents::{self, StopReason, tools::control::ApprovalRequired},
     chat_completion::{ToolCall, ToolOutput, errors::ToolError},
-    traits::AgentContext,
+    traits::{AgentContext, ToolFeedback},
 };
 
 // The macro supports strings/strs, vectors/slices, booleans and numbers.
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
     println!("Approving number guessing");
     agent
         .context()
-        .feedback_received(&tool_call, None)
+        .feedback_received(&tool_call, &ToolFeedback::approved())
         .await
         .unwrap();
 

--- a/examples/agents_with_human_in_the_loop.rs
+++ b/examples/agents_with_human_in_the_loop.rs
@@ -5,7 +5,8 @@
 //! In a more realistic example, you can use other rust primitives to make it work for your
 //! usecase. I.e., make an api request with a callback url that will add the feedback.
 //!
-//! Both requesting feedback and providing feedback support an optional payload (as a `serde_json::Value`).
+//! Both requesting feedback and providing feedback support an optional payload (as a
+//! `serde_json::Value`).
 //!
 //! This allows for more custom workflows, to either display or provide more input to the
 //! underlying tool call.

--- a/swiftide-agents/src/default_context.rs
+++ b/swiftide-agents/src/default_context.rs
@@ -11,7 +11,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, AtomicUsize, Ordering},
+        atomic::{AtomicUsize, Ordering},
     },
 };
 

--- a/swiftide-agents/src/lib.rs
+++ b/swiftide-agents/src/lib.rs
@@ -60,6 +60,7 @@ mod util;
 
 pub use agent::{Agent, AgentBuilder, AgentBuilderError};
 pub use default_context::DefaultContext;
+pub use state::{State, StopReason};
 
 #[cfg(test)]
 mod test_utils;

--- a/swiftide-agents/src/state.rs
+++ b/swiftide-agents/src/state.rs
@@ -22,19 +22,26 @@ impl State {
 /// The reason the agent stopped
 ///
 /// `StopReason::Other` has some convenience methods to convert from any `AsRef<str>`
-///
-/// A default is also provided for `StopReason`
 #[non_exhaustive]
 #[derive(Clone, Debug, strum_macros::EnumIs)]
 pub enum StopReason {
+    /// A tool called stop
     RequestedByTool(ToolCall),
+
+    /// A tool repeatedly failed
     ToolCallsOverLimit(ToolCall),
+
+    /// A tool requires feedback before it will continue
     FeedbackRequired {
         tool_call: ToolCall,
         payload: Option<serde_json::Value>,
     },
+    /// There was an error
     Error,
+
+    /// No new messages; stopping completions
     NoNewMessages,
+
     Other(String),
 }
 

--- a/swiftide-agents/src/state.rs
+++ b/swiftide-agents/src/state.rs
@@ -21,6 +21,10 @@ pub(crate) enum State {
 pub enum StopReason {
     RequestedByTool(ToolCall),
     ToolCallsOverLimit(ToolCall),
+    FeedbackRequired {
+        tool_call: ToolCall,
+        payload: Option<serde_json::Value>,
+    },
     Error,
     NoNewMessages,
     Other(String),

--- a/swiftide-agents/src/state.rs
+++ b/swiftide-agents/src/state.rs
@@ -46,7 +46,7 @@ pub enum StopReason {
 }
 
 impl StopReason {
-    pub fn requested_by_tool(&self) -> Option<&ToolCall> {
+    pub fn as_requested_by_tool(&self) -> Option<&ToolCall> {
         if let StopReason::RequestedByTool(t) = self {
             Some(t)
         } else {
@@ -54,7 +54,7 @@ impl StopReason {
         }
     }
 
-    pub fn tool_calls_over_limit(&self) -> Option<&ToolCall> {
+    pub fn as_tool_calls_over_limit(&self) -> Option<&ToolCall> {
         if let StopReason::ToolCallsOverLimit(t) = self {
             Some(t)
         } else {
@@ -62,7 +62,7 @@ impl StopReason {
         }
     }
 
-    pub fn feedback_required(&self) -> Option<(&ToolCall, Option<&serde_json::Value>)> {
+    pub fn as_feedback_required(&self) -> Option<(&ToolCall, Option<&serde_json::Value>)> {
         if let StopReason::FeedbackRequired { tool_call, payload } = self {
             Some((tool_call, payload.as_ref()))
         } else {
@@ -70,7 +70,7 @@ impl StopReason {
         }
     }
 
-    pub fn error(&self) -> Option<()> {
+    pub fn as_error(&self) -> Option<()> {
         if matches!(self, StopReason::Error) {
             Some(())
         } else {
@@ -78,7 +78,7 @@ impl StopReason {
         }
     }
 
-    pub fn no_new_messages(&self) -> Option<()> {
+    pub fn as_no_new_messages(&self) -> Option<()> {
         if matches!(self, StopReason::NoNewMessages) {
             Some(())
         } else {
@@ -86,7 +86,7 @@ impl StopReason {
         }
     }
 
-    pub fn other(&self) -> Option<&str> {
+    pub fn as_other(&self) -> Option<&str> {
         if let StopReason::Other(s) = self {
             Some(s)
         } else {

--- a/swiftide-agents/src/state.rs
+++ b/swiftide-agents/src/state.rs
@@ -3,11 +3,10 @@
 use swiftide_core::chat_completion::ToolCall;
 
 #[derive(Clone, Debug, Default, strum_macros::EnumDiscriminants, strum_macros::EnumIs)]
-pub(crate) enum State {
+pub enum State {
     #[default]
     Pending,
     Running,
-    #[allow(dead_code)]
     Stopped(StopReason),
 }
 

--- a/swiftide-agents/src/test_utils.rs
+++ b/swiftide-agents/src/test_utils.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use swiftide_core::chat_completion::ToolCall;
 use swiftide_core::chat_completion::{Tool, ToolOutput, ToolSpec, errors::ToolError};
 
 use swiftide_core::AgentContext;
@@ -157,12 +158,12 @@ impl Tool for MockTool {
     async fn invoke(
         &self,
         _agent_context: &dyn AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &ToolCall,
     ) -> std::result::Result<ToolOutput, ToolError> {
         tracing::debug!(
             "[MockTool] Invoked `{}` with args: {:?}",
             self.name,
-            raw_args
+            tool_call
         );
         let expectation = self
             .expectations
@@ -171,7 +172,7 @@ impl Tool for MockTool {
             .pop()
             .unwrap_or_else(|| panic!("[MockTool] No expectations left for `{}`", self.name));
 
-        assert_eq!(expectation.1, raw_args);
+        assert_eq!(expectation.1, tool_call.args());
 
         expectation.0
     }

--- a/swiftide-agents/src/tools/control.rs
+++ b/swiftide-agents/src/tools/control.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 use std::borrow::Cow;
 use swiftide_core::{
     AgentContext,
-    chat_completion::{Tool, ToolOutput, ToolSpec, errors::ToolError},
+    chat_completion::{Tool, ToolCall, ToolOutput, ToolSpec, errors::ToolError},
 };
 
-// TODO: Cannot use macros in our own crates because of import shenanigans
+/// `Stop` tool is a default tool used by agents to stop
 #[derive(Clone, Debug, Default)]
 pub struct Stop {}
 
@@ -16,7 +16,7 @@ impl Tool for Stop {
     async fn invoke(
         &self,
         _agent_context: &dyn AgentContext,
-        _raw_args: Option<&str>,
+        _tool_call: &ToolCall,
     ) -> Result<ToolOutput, ToolError> {
         Ok(ToolOutput::Stop)
     }
@@ -37,5 +37,31 @@ impl Tool for Stop {
 impl From<Stop> for Box<dyn Tool> {
     fn from(val: Stop) -> Self {
         Box::new(val)
+    }
+}
+
+#[derive(Clone)]
+pub struct FeedbackRequired(pub Box<dyn Tool>);
+
+#[async_trait]
+impl Tool for FeedbackRequired {
+    async fn invoke(
+        &self,
+        _agent_context: &dyn AgentContext,
+        _tool_call: &ToolCall,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(ToolOutput::Stop)
+    }
+
+    fn name(&self) -> Cow<'_, str> {
+        self.0.name()
+    }
+
+    fn tool_spec(&self) -> ToolSpec {
+        ToolSpec::builder()
+            .name("stop")
+            .description("When you have completed, or cannot complete, your task, call this")
+            .build()
+            .unwrap()
     }
 }

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -395,7 +395,7 @@ mod tests {
             json!(["string", "null"]).to_string()
         );
 
-        let tool_call = builder.build().unwrap();
+        let tool_call = builder.args(r#"{"b": "hello"}"#).build().unwrap();
 
         let result = optional_tool
             .invoke(&(), &tool_call)

--- a/swiftide-agents/src/tools/mcp.rs
+++ b/swiftide-agents/src/tools/mcp.rs
@@ -16,6 +16,7 @@ use rmcp::{ServiceExt, model::CallToolRequestParam};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use swiftide_core::CommandError;
+use swiftide_core::chat_completion::ToolCall;
 use swiftide_core::{
     Tool, ToolBox,
     chat_completion::{ParamSpec, ParamType, ToolSpec, errors::ToolError},
@@ -260,12 +261,12 @@ impl Tool for McpTool {
     async fn invoke(
         &self,
         _agent_context: &dyn swiftide_core::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &ToolCall,
     ) -> Result<
         swiftide_core::chat_completion::ToolOutput,
         swiftide_core::chat_completion::errors::ToolError,
     > {
-        let args = match raw_args {
+        let args = match tool_call.args() {
             Some(args) => Some(serde_json::from_str(args).map_err(ToolError::WrongArguments)?),
             None => None,
         };
@@ -350,9 +351,19 @@ mod tests {
         assert_eq!(names, ["optional", "sub", "sum"]);
 
         let sum_tool = t.iter().find(|t| t.name() == "sum").unwrap();
+        let mut builder = ToolCall::builder()
+            .id("some")
+            .args(r#"{"b": "hello"}"#)
+            .name("test")
+            .name("test")
+            .to_owned();
+
         assert_eq!(sum_tool.tool_spec().name, "sum");
+
+        let tool_call = builder.args(r#"{"a": 10, "b": 20}"#).build().unwrap();
+
         let result = sum_tool
-            .invoke(&(), Some(r#"{"a": 10, "b": 20}"#))
+            .invoke(&(), &tool_call)
             .await
             .unwrap()
             .content()
@@ -362,8 +373,11 @@ mod tests {
 
         let sub_tool = t.iter().find(|t| t.name() == "sub").unwrap();
         assert_eq!(sub_tool.tool_spec().name, "sub");
+
+        let tool_call = builder.args(r#"{"a": 10, "b": 20}"#).build().unwrap();
+
         let result = sub_tool
-            .invoke(&(), Some(r#"{"a": 10, "b": 20}"#))
+            .invoke(&(), &tool_call)
             .await
             .unwrap()
             .content()
@@ -381,8 +395,10 @@ mod tests {
             json!(["string", "null"]).to_string()
         );
 
+        let tool_call = builder.build().unwrap();
+
         let result = optional_tool
-            .invoke(&(), Some(r#"{"b": "hello"}"#))
+            .invoke(&(), &tool_call)
             .await
             .unwrap()
             .content()
@@ -390,8 +406,9 @@ mod tests {
             .to_string();
         assert_eq!(result, "hello");
 
+        let tool_call = builder.args(r#"{"b": null}"#).build().unwrap();
         let result = optional_tool
-            .invoke(&(), Some(r#"{ "b": null }"#))
+            .invoke(&(), &tool_call)
             .await
             .unwrap()
             .content()

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -6,7 +6,7 @@ use serde::ser::{Error as SerError, SerializeSeq, Serializer};
 use serde::{Deserialize, Serialize};
 
 /// Output of a `ToolCall` which will be added as a message for the agent to use.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, strum_macros::EnumIs)]
 #[non_exhaustive]
 pub enum ToolOutput {
     /// Adds the result of the toolcall to messages
@@ -93,6 +93,10 @@ impl ToolCall {
 
     pub fn args(&self) -> Option<&str> {
         self.args.as_deref()
+    }
+
+    pub fn with_args(&mut self, args: Option<String>) {
+        self.args = args;
     }
 }
 

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -12,6 +12,7 @@ pub enum ToolOutput {
     /// Adds the result of the toolcall to messages
     Text(String),
 
+    /// Indicates that the toolcall requires feedback, i.e. in a human-in-the-loop
     FeedbackRequired(Option<serde_json::Value>),
 
     /// Indicates that the toolcall failed, but can be handled by the llm
@@ -21,6 +22,22 @@ pub enum ToolOutput {
 }
 
 impl ToolOutput {
+    pub fn text(text: impl Into<String>) -> Self {
+        ToolOutput::Text(text.into())
+    }
+
+    pub fn feedback_required(feedback: Option<serde_json::Value>) -> Self {
+        ToolOutput::FeedbackRequired(feedback)
+    }
+
+    pub fn stop() -> Self {
+        ToolOutput::Stop
+    }
+
+    pub fn fail(text: impl Into<String>) -> Self {
+        ToolOutput::Fail(text.into())
+    }
+
     pub fn content(&self) -> Option<&str> {
         match self {
             ToolOutput::Fail(s) | ToolOutput::Text(s) => Some(s),

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -12,6 +12,8 @@ pub enum ToolOutput {
     /// Adds the result of the toolcall to messages
     Text(String),
 
+    FeedbackRequired(Option<serde_json::Value>),
+
     /// Indicates that the toolcall failed, but can be handled by the llm
     Fail(String),
     /// Stops an agent
@@ -39,6 +41,9 @@ impl std::fmt::Display for ToolOutput {
             ToolOutput::Text(value) => write!(f, "{value}"),
             ToolOutput::Fail(value) => write!(f, "Tool call failed: {value}"),
             ToolOutput::Stop => write!(f, "Stop"),
+            ToolOutput::FeedbackRequired(_) => {
+                write!(f, "Feedback required")
+            }
         }
     }
 }

--- a/swiftide-core/src/chat_completion/tools.rs
+++ b/swiftide-core/src/chat_completion/tools.rs
@@ -49,7 +49,7 @@ impl std::fmt::Display for ToolOutput {
 }
 
 /// A tool call that can be executed by the executor
-#[derive(Clone, Debug, Builder, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Builder, PartialEq, Serialize, Deserialize, Eq)]
 #[builder(setter(into, strip_option))]
 pub struct ToolCall {
     id: String,
@@ -59,7 +59,7 @@ pub struct ToolCall {
 }
 
 /// Hash is used for finding tool calls that have been retried by agents
-impl std::hash::Hash for &ToolCall {
+impl std::hash::Hash for ToolCall {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);
         self.args.hash(state);

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -7,7 +7,7 @@ use std::{borrow::Cow, pin::Pin, sync::Arc};
 use crate::{AgentContext, CommandOutput, LanguageModelWithBackOff};
 
 use super::{
-    ToolOutput, ToolSpec,
+    ToolCall, ToolOutput, ToolSpec,
     chat_completion_request::ChatCompletionRequest,
     chat_completion_response::ChatCompletionResponse,
     errors::{LanguageModelError, ToolError},
@@ -300,7 +300,7 @@ pub trait Tool: Send + Sync + DynClone {
     async fn invoke(
         &self,
         agent_context: &dyn AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &ToolCall,
     ) -> Result<ToolOutput, ToolError>;
 
     fn name(&self) -> Cow<'_, str>;
@@ -387,9 +387,9 @@ impl Tool for Box<dyn Tool> {
     async fn invoke(
         &self,
         agent_context: &dyn AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &ToolCall,
     ) -> Result<ToolOutput, ToolError> {
-        (**self).invoke(agent_context, raw_args).await
+        (**self).invoke(agent_context, tool_call).await
     }
     fn name(&self) -> Cow<'_, str> {
         (**self).name()

--- a/swiftide-integrations/src/anthropic/chat_completion.rs
+++ b/swiftide-integrations/src/anthropic/chat_completion.rs
@@ -327,7 +327,7 @@ mod tests {
         async fn invoke(
             &self,
             _agent_context: &dyn AgentContext,
-            _raw_args: Option<&str>,
+            _tool_call: &ToolCall,
         ) -> std::result::Result<
             swiftide_core::chat_completion::ToolOutput,
             swiftide_core::chat_completion::errors::ToolError,

--- a/swiftide-macros/src/tool/mod.rs
+++ b/swiftide-macros/src/tool/mod.rs
@@ -58,7 +58,7 @@ pub(crate) fn tool_attribute_impl(input_args: &TokenStream, input: &ItemFn) -> T
         }
     } else {
         quote! {
-            let Some(args) = raw_args
+            let Some(args) = tool_call.args()
             else { return Err(::swiftide::chat_completion::errors::ToolError::MissingArguments(format!("No arguments provided for {}", #tool_name))) };
 
             let args: #args_struct_ident = ::swiftide::reexports::serde_json::from_str(&args)?;
@@ -75,7 +75,7 @@ pub(crate) fn tool_attribute_impl(input_args: &TokenStream, input: &ItemFn) -> T
 
         #[::swiftide::reexports::async_trait::async_trait]
         impl ::swiftide::chat_completion::Tool for #tool_struct {
-            async fn invoke(&self, agent_context: &dyn ::swiftide::traits::AgentContext, raw_args: Option<&str>) -> ::std::result::Result<::swiftide::chat_completion::ToolOutput, ::swiftide::chat_completion::errors::ToolError> {
+            async fn invoke(&self, agent_context: &dyn ::swiftide::traits::AgentContext, tool_call: &swiftide::chat_completion::ToolCall) -> ::std::result::Result<::swiftide::chat_completion::ToolOutput, ::swiftide::chat_completion::errors::ToolError> {
                 #invoke_body
             }
 
@@ -133,7 +133,7 @@ pub(crate) fn tool_derive_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
         quote! { return self.#expected_fn_ident(agent_context).await }
     } else {
         quote! {
-            let Some(args) = raw_args
+            let Some(args) = tool_call.args()
             else { return Err(::swiftide::chat_completion::errors::ToolError::MissingArguments(format!("No arguments provided for {}", #expected_fn_name))) };
 
             let args: #args_struct_ident = ::swiftide::reexports::serde_json::from_str(&args)?;
@@ -153,7 +153,7 @@ pub(crate) fn tool_derive_impl(input: &DeriveInput) -> syn::Result<TokenStream> 
 
         #[async_trait::async_trait]
         impl #impl_generics swiftide::chat_completion::Tool for #struct_ident #ty_generics #where_clause {
-            async fn invoke(&self, agent_context: &dyn swiftide::traits::AgentContext, raw_args: Option<&str>) -> std::result::Result<swiftide::chat_completion::ToolOutput, ::swiftide::chat_completion::errors::ToolError> {
+            async fn invoke(&self, agent_context: &dyn swiftide::traits::AgentContext, tool_call: &swiftide::chat_completion::ToolCall) -> std::result::Result<swiftide::chat_completion::ToolOutput, ::swiftide::chat_completion::errors::ToolError> {
                 #invoke_body
             }
 

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive.snap
@@ -7,7 +7,7 @@ impl swiftide::chat_completion::Tool for HelloDerive {
     async fn invoke(
         &self,
         agent_context: &dyn swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> std::result::Result<
         swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
@@ -15,12 +15,12 @@ impl swiftide::chat_completion::Tool for HelloDerive {
     async fn invoke(
         &self,
         agent_context: &dyn swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> std::result::Result<
         swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,
     > {
-        let Some(args) = raw_args else {
+        let Some(args) = tool_call.args() else {
             return Err(
                 ::swiftide::chat_completion::errors::ToolError::MissingArguments(
                     format!("No arguments provided for {}", "hello_derive"),

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_generics.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_generics.snap
@@ -15,12 +15,12 @@ impl<S: Send + Sync + Clone> swiftide::chat_completion::Tool for HelloDerive<S> 
     async fn invoke(
         &self,
         agent_context: &dyn swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> std::result::Result<
         swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,
     > {
-        let Some(args) = raw_args else {
+        let Some(args) = tool_call.args() else {
             return Err(
                 ::swiftide::chat_completion::errors::ToolError::MissingArguments(
                     format!("No arguments provided for {}", "hello_derive"),

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
@@ -15,12 +15,12 @@ impl<'a> swiftide::chat_completion::Tool for HelloDerive<'a> {
     async fn invoke(
         &self,
         agent_context: &dyn swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> std::result::Result<
         swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,
     > {
-        let Some(args) = raw_args else {
+        let Some(args) = tool_call.args() else {
             return Err(
                 ::swiftide::chat_completion::errors::ToolError::MissingArguments(
                     format!("No arguments provided for {}", "hello_derive"),

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_option.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_option.snap
@@ -15,12 +15,12 @@ impl swiftide::chat_completion::Tool for HelloDerive {
     async fn invoke(
         &self,
         agent_context: &dyn swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> std::result::Result<
         swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,
     > {
-        let Some(args) = raw_args else {
+        let Some(args) = tool_call.args() else {
             return Err(
                 ::swiftide::chat_completion::errors::ToolError::MissingArguments(
                     format!("No arguments provided for {}", "hello_derive"),

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
@@ -31,12 +31,12 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
     async fn invoke(
         &self,
         agent_context: &dyn ::swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> ::std::result::Result<
         ::swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,
     > {
-        let Some(args) = raw_args else {
+        let Some(args) = tool_call.args() else {
             return Err(
                 ::swiftide::chat_completion::errors::ToolError::MissingArguments(
                     format!("No arguments provided for {}", "search_code"),

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
@@ -29,12 +29,12 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
     async fn invoke(
         &self,
         agent_context: &dyn ::swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> ::std::result::Result<
         ::swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,
     > {
-        let Some(args) = raw_args else {
+        let Some(args) = tool_call.args() else {
             return Err(
                 ::swiftide::chat_completion::errors::ToolError::MissingArguments(
                     format!("No arguments provided for {}", "search_code"),

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg_option.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg_option.snap
@@ -29,12 +29,12 @@ impl ::swiftide::chat_completion::Tool for SearchCode {
     async fn invoke(
         &self,
         agent_context: &dyn ::swiftide::traits::AgentContext,
-        raw_args: Option<&str>,
+        tool_call: &swiftide::chat_completion::ToolCall,
     ) -> ::std::result::Result<
         ::swiftide::chat_completion::ToolOutput,
         ::swiftide::chat_completion::errors::ToolError,
     > {
-        let Some(args) = raw_args else {
+        let Some(args) = tool_call.args() else {
             return Err(
                 ::swiftide::chat_completion::errors::ToolError::MissingArguments(
                     format!("No arguments provided for {}", "search_code"),


### PR DESCRIPTION
Tools can now return a FeedbackRequired with an optional Value payload. The agent will stop, with the tool call and optional payload in the reason. Possible to use either the stop reason returned by the agent or a hook to act on this, or use it in your own tools.

Feedback is given on the context of the agent with the tool call and an optional payload. The payload offers flexibility to provide feedback to the tool, or to provide context to the user.

BREAKING CHANGE: The `Tool` trait now receives a `ToolCall` as argument instead of an `Option<&str>`. The latter is still accessible via `tool_call.args()`.