### PR TITLE
refactor(agents): Direct access to executor via context

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ async fn search_code(
     code_query: &str,
 ) -> Result<ToolOutput, ToolError> {
     let command_output = context
+        .executor()
         .exec_cmd(&Command::shell(format!("rg '{code_query}'")))
         .await?;
 

--- a/examples/hello_agents.rs
+++ b/examples/hello_agents.rs
@@ -33,6 +33,7 @@ async fn search_code(
     code_query: &str,
 ) -> Result<ToolOutput, ToolError> {
     let command_output = context
+        .executor()
         .exec_cmd(&Command::shell(format!("rg '{code_query}'")))
         .await?;
 
@@ -47,6 +48,7 @@ const READ_FILE: &str = "Read a file";
 )]
 async fn read_file(context: &dyn AgentContext, path: &str) -> Result<ToolOutput, ToolError> {
     let command_output = context
+        .executor()
         .exec_cmd(&Command::shell(format!("cat {path}")))
         .await?;
 

--- a/swiftide-agents/src/default_context.rs
+++ b/swiftide-agents/src/default_context.rs
@@ -171,6 +171,10 @@ impl AgentContext for DefaultContext {
         self.tool_executor.exec_cmd(cmd).await
     }
 
+    fn executor(&self) -> &Arc<dyn ToolExecutor> {
+        &self.tool_executor
+    }
+
     /// Pops the last messages up until the previous completion
     ///
     /// LLMs failing completion for various reasons is unfortunately a common occurrence


### PR DESCRIPTION
Current solution leaks information of the executor through the context.
Instead, access the executor directly. This also offers more flexibility
to do more creative stuff in tools and elsewhere.
