### PR TITLE
feat(duckdb): Hybrid Search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,7 +3250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4608,7 +4608,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4966,7 +4966,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5678,7 +5678,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7281,7 +7281,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.9",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7976,7 +7976,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7989,7 +7989,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9681,7 +9681,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10988,7 +10988,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/swiftide-integrations/src/duckdb/hybrid_query.sql
+++ b/swiftide-integrations/src/duckdb/hybrid_query.sql
@@ -1,0 +1,52 @@
+with fts as (
+    select 
+        uuid, 
+        chunk, 
+        path,
+        fts_main_movies.match_bm25(
+            uuid,
+            ?1,
+            fields := chunk
+        ) as score
+    from {{table_name}}
+    limit {{top_n}}
+),
+embd as (
+    select 
+        uuid, 
+        chunk, 
+        path,
+        array_cosine_similarity({{embedding_name}}, cast([?2] as float[{{embedding_size}}])) as score
+    from {{table_name}}
+    limit {{top_n}}
+),
+normalized_scores as (
+    select 
+        fts.uuid, 
+        fts.chunk, 
+        fts.path,
+        fts.score as raw_fts_score, 
+        embd.score as raw_embd_score,
+        (fts.score / (select max(score) from fts)) as norm_fts_score,
+        ((embd.score + 1) / (select max(score) + 1 from embd)) as norm_embd_score
+    from 
+        fts
+    inner join
+        embd 
+    on fts.uuid = embd.uuid
+)
+select 
+    uuid,
+    chunk,
+    path,
+    raw_fts_score, 
+    raw_embd_score, 
+    norm_fts_score, 
+    norm_embd_score, 
+    -- (alpha * norm_embd_score + (1-alpha) * norm_fts_score)
+    (0.8*norm_embd_score + 0.2*norm_fts_score) AS score_cc
+from 
+    normalized_scores
+order by 
+    score_cc desc
+limit {{top_k}};

--- a/swiftide-integrations/src/duckdb/persist.rs
+++ b/swiftide-integrations/src/duckdb/persist.rs
@@ -82,11 +82,13 @@ impl Duckdb {
 #[async_trait]
 impl Persist for Duckdb {
     async fn setup(&self) -> Result<()> {
-        self.connection
-            .lock()
-            .unwrap()
-            .execute_batch(&self.schema)
+        tracing::debug!("Setting up duckdb schema");
+
+        let conn = self.connection.lock().unwrap();
+        conn.execute_batch(&self.schema)
             .context("Failed to create indexing table")?;
+
+        tracing::debug!(schema = &self.schema, "Indexing table created");
 
         tracing::info!("Setup completed");
 

--- a/swiftide-integrations/src/duckdb/retrieve.rs
+++ b/swiftide-integrations/src/duckdb/retrieve.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
+use duckdb::params;
 use swiftide_core::{
     Retrieve,
     querying::{
         Document, Query,
-        search_strategies::{CustomStrategy, SimilaritySingleEmbedding},
+        search_strategies::{CustomStrategy, HybridSearch, SimilaritySingleEmbedding},
         states,
     },
 };
@@ -113,6 +114,54 @@ impl Retrieve<CustomStrategy<String>> for Duckdb {
     }
 }
 
+#[async_trait]
+impl Retrieve<HybridSearch> for Duckdb {
+    async fn retrieve(
+        &self,
+        search_strategy: &HybridSearch,
+        query: Query<states::Pending>,
+    ) -> Result<Query<states::Retrieved>> {
+        let Some(embedding) = query.embedding.as_ref() else {
+            return Err(anyhow::Error::msg("Missing embedding in query state"));
+        };
+
+        let sql = self
+            .hybrid_query_sql(search_strategy)
+            .context("Failed to build query")?;
+
+        tracing::debug!("[duckdb] Executing query: {}", sql);
+
+        let conn = self.connection().lock().unwrap();
+        let mut stmt = conn
+            .prepare(&sql)
+            .context("Failed to prepare duckdb statement for persist")?;
+
+        tracing::debug!("[duckdb] Prepared statement");
+
+        let embedding = embedding
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let documents = stmt
+            .query_map(params![query.current(), embedding], |row| {
+                Ok(Document::builder()
+                    .metadata([("id", row.get::<_, String>(0)?), ("path", row.get(2)?)])
+                    .content(row.get::<_, String>(1)?)
+                    .build()
+                    .expect("Failed to build document; should never happen"))
+            })
+            .context("failed to query for documents")?
+            .collect::<Result<Vec<Document>, _>>()
+            .context("failed to build documents")?;
+
+        tracing::debug!("[duckdb] Retrieved documents");
+
+        Ok(query.retrieved_documents(documents))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use indexing::{EmbeddedField, Node};
@@ -146,6 +195,45 @@ mod tests {
 
         let result = client
             .retrieve(&SimilaritySingleEmbedding::default(), query)
+            .await
+            .unwrap();
+
+        assert_eq!(result.documents().len(), 1);
+        let document = result.documents().first().unwrap();
+
+        assert_eq!(document.content(), "Hello duckdb!");
+        assert_eq!(
+            document.metadata().get("id").unwrap().as_str(),
+            Some(node.id().to_string().as_str())
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_duckdb_retrieving_documents_hybrid() {
+        let client = Duckdb::builder()
+            .connection(duckdb::Connection::open_in_memory().unwrap())
+            .table_name("test".to_string())
+            .with_vector(EmbeddedField::Combined, 3)
+            .build()
+            .unwrap();
+
+        let node = Node::new("Hello duckdb!")
+            .with_vectors([(EmbeddedField::Combined, vec![1.0, 2.0, 3.0])])
+            .to_owned();
+
+        client.setup().await.unwrap();
+        client.store(node.clone()).await.unwrap();
+
+        tracing::info!("Stored node");
+
+        let query = Query::<states::Pending>::builder()
+            .embedding(vec![1.0, 2.0, 3.0])
+            .original("Some query")
+            .build()
+            .unwrap();
+
+        let result = client
+            .retrieve(&HybridSearch::default(), query)
             .await
             .unwrap();
 

--- a/swiftide-integrations/src/duckdb/schema.sql
+++ b/swiftide-integrations/src/duckdb/schema.sql
@@ -1,5 +1,8 @@
 INSTALL vss;
 LOAD vss;
+INSTALL fts;
+LOAD fts;
+
 
 CREATE TABLE IF NOT EXISTS {{table_name}} (
   uuid TEXT PRIMARY KEY,
@@ -10,3 +13,7 @@ CREATE TABLE IF NOT EXISTS {{table_name}} (
     {{vector}} FLOAT[{{size}}],
   {% endfor %}
 );
+
+PRAGMA create_fts_index('{{table_name}}', 'uuid', 'chunk', stemmer = 'porter',
+                 stopwords = 'english', ignore = '(\\.|[^a-z])+',
+                 strip_accents = 1, lower = 1, overwrite = 0);


### PR DESCRIPTION
Adds hybrid search as per https://motherduck.com/blog/search-using-duckdb-part-3/.

Unfortunately there are some weird errors (again) with duckdb. Blocked until then.

Would be great to have in Kwaak, so we can drastically reduce the context size, speed things up, and have better grounding for agents.
