### PR TITLE
feat(agents)!: Context is now generic over its backend

### DIFF
--- a/examples/agents_resume.rs
+++ b/examples/agents_resume.rs
@@ -21,6 +21,7 @@ async fn main() -> Result<()> {
 
     let restored_context = DefaultContext::default()
         .with_message_history(retrieved_history)
+        .await
         .to_owned();
 
     let mut second_agent = agents::Agent::builder()

--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -1294,6 +1294,7 @@ mod tests {
         // Build a context from the history
         let context = DefaultContext::default()
             .with_message_history(history)
+            .await
             .to_owned();
 
         let expected_chat_request = chat_request! {

--- a/swiftide-agents/src/default_context.rs
+++ b/swiftide-agents/src/default_context.rs
@@ -17,7 +17,9 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
-use swiftide_core::{AgentContext, Command, CommandError, CommandOutput, ToolExecutor};
+use swiftide_core::{
+    AgentContext, AgentContextBackend, Command, CommandError, CommandOutput, ToolExecutor,
+};
 use swiftide_core::{
     ToolFeedback,
     chat_completion::{ChatMessage, ToolCall},
@@ -28,7 +30,7 @@ use crate::tools::local_executor::LocalExecutor;
 // TODO: Remove unit as executor and implement a local executor instead
 #[derive(Clone)]
 pub struct DefaultContext {
-    completion_history: Arc<Mutex<Vec<ChatMessage>>>,
+    completion_history: Arc<dyn AgentContextBackend>,
     /// Index in the conversation history where the next completion will start
     completions_ptr: Arc<AtomicUsize>,
 
@@ -86,19 +88,23 @@ impl DefaultContext {
         self
     }
 
+    pub fn with_agent_backend(&mut self, backend: impl AgentContextBackend + 'static) -> &mut Self {
+        self.completion_history = Arc::new(backend) as Arc<dyn AgentContextBackend>;
+        self
+    }
+
     /// Build a context from an existing message history
     ///
     /// # Panics
     ///
     /// Panics if the inner mutex is poisoned
-    pub fn with_message_history<I: IntoIterator<Item = ChatMessage>>(
+    pub async fn with_message_history<I: IntoIterator<Item = ChatMessage>>(
         &mut self,
         message_history: I,
     ) -> &mut Self {
         self.completion_history
-            .lock()
-            .unwrap()
-            .extend(message_history);
+            .extend_owned(message_history.into_iter().collect::<Vec<_>>())
+            .await;
 
         self
     }
@@ -119,7 +125,7 @@ impl DefaultContext {
 impl AgentContext for DefaultContext {
     /// Retrieve messages for the next completion
     async fn next_completion(&self) -> Option<Vec<ChatMessage>> {
-        let history = self.completion_history.lock().unwrap();
+        let history = self.completion_history.history().await;
 
         let current = self.completions_ptr.load(Ordering::SeqCst);
 
@@ -144,14 +150,14 @@ impl AgentContext for DefaultContext {
         let current = self.current_completions_ptr.load(Ordering::SeqCst);
         let end = self.completions_ptr.load(Ordering::SeqCst);
 
-        let history = self.completion_history.lock().unwrap();
+        let history = self.completion_history.history().await;
 
         filter_messages_since_summary(history[current..end].to_vec())
     }
 
     /// Retrieve all messages in the conversation history
     async fn history(&self) -> Vec<ChatMessage> {
-        self.completion_history.lock().unwrap().clone()
+        self.completion_history.history().await
     }
 
     /// Add multiple messages to the conversation history
@@ -163,7 +169,7 @@ impl AgentContext for DefaultContext {
 
     /// Add a single message to the conversation history
     async fn add_message(&self, item: ChatMessage) {
-        self.completion_history.lock().unwrap().push(item);
+        self.completion_history.push_owned(item).await;
     }
 
     /// Execute a command in the tool executor
@@ -180,7 +186,7 @@ impl AgentContext for DefaultContext {
     /// LLMs failing completion for various reasons is unfortunately a common occurrence
     /// This gives a way to redrive the last completion in a generic way
     async fn redrive(&self) {
-        let mut history = self.completion_history.lock().unwrap();
+        let mut history = self.completion_history.history().await;
         let previous = self.current_completions_ptr.load(Ordering::SeqCst);
         let redrive_ptr = self.completions_ptr.swap(previous, Ordering::SeqCst);
 

--- a/swiftide-core/src/agent_traits.rs
+++ b/swiftide-core/src/agent_traits.rs
@@ -1,4 +1,7 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 
 use crate::chat_completion::{ChatMessage, ToolCall};
 use anyhow::Result;
@@ -375,5 +378,43 @@ impl AgentContext for () {
         _feedback: &ToolFeedback,
     ) -> Result<()> {
         Ok(())
+    }
+}
+
+/// A backend for the agent context. A default is provided for Arc<Mutex<Vec<ChatMessage>>>
+///
+/// If you want to use for instance a database, implement this trait and pass it to the agent context
+/// when creating it.
+#[async_trait]
+pub trait AgentContextBackend: Send + Sync + std::fmt::Debug {
+    async fn history(&self) -> Vec<ChatMessage>;
+
+    async fn push_owned(&self, item: ChatMessage);
+
+    async fn push(&self, item: &ChatMessage) {
+        self.push_owned(item.clone()).await;
+    }
+
+    async fn extend(&self, items: &[ChatMessage]) {
+        for item in items {
+            self.push(item).await;
+        }
+    }
+
+    async fn extend_owned(&self, items: Vec<ChatMessage>) {
+        for item in items {
+            self.push_owned(item).await;
+        }
+    }
+}
+
+#[async_trait]
+impl AgentContextBackend for Mutex<Vec<ChatMessage>> {
+    async fn history(&self) -> Vec<ChatMessage> {
+        self.lock().unwrap().clone()
+    }
+
+    async fn push_owned(&self, item: ChatMessage) {
+        self.lock().unwrap().push(item);
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: The signature is now slightly different for the
AgentContext. If you have implemented your own for i.e. a persisted
solution, if it's *just that*, the implementation is now a lot more
straightforward with the `AgentContextBackend` trait.
