### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,62 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0](https://github.com/bosun-ai/swiftide/compare/v0.26.0...v0.27.0) - 2025-06-09
+
+### New features
+
+- [c636eba](https://github.com/bosun-ai/swiftide/commit/c636ebaa2eb8d4ace1b5a370698c5f2817fc9c99) *(agents)*  [**breaking**] Context is now generic over its backend ([#810](https://github.com/bosun-ai/swiftide/pull/810))
+
+**BREAKING CHANGE**: The signature is now slightly different for the
+AgentContext. If you have implemented your own for i.e. a persisted
+solution, if it's *just that*, the implementation is now a lot more
+straightforward with the `MessageHistory` trait.
+
+- [3c937a8](https://github.com/bosun-ai/swiftide/commit/3c937a8ed4f7d28798a24b0d893f1613cd298493) *(agents)*  Add helpers for creating tool errors ([#805](https://github.com/bosun-ai/swiftide/pull/805))
+
+- [9e831d3](https://github.com/bosun-ai/swiftide/commit/9e831d3eb072748ebb21c9a16cd7d807b4d42469) *(agents)*  [**breaking**] Easy human-in-the-loop flows by decorating tools ([#790](https://github.com/bosun-ai/swiftide/pull/790))
+
+**BREAKING CHANGE**: The `Tool` trait now receives a `ToolCall` as argument
+instead of an `Option<&str>`. The latter is still accessible via
+`tool_call.args()`.
+
+- [814c217](https://github.com/bosun-ai/swiftide/commit/814c2174c742ff4277246505537070726ce8af92) *(duckdb)*  Hybrid Search ([#807](https://github.com/bosun-ai/swiftide/pull/807))
+
+- [19a2e94](https://github.com/bosun-ai/swiftide/commit/19a2e94d262cc68c629d88b6b02a72bb9b159036) *(integrations)*  Add support for Google Gemini ([#754](https://github.com/bosun-ai/swiftide/pull/754))
+
+- [990fa5e](https://github.com/bosun-ai/swiftide/commit/990fa5e9edffebd9b70da6b57fa454f7318d642d) *(redis)*  Support `MessageHistory` for redis ([#811](https://github.com/bosun-ai/swiftide/pull/811))
+
+### Bug fixes
+
+- [ca119bd](https://github.com/bosun-ai/swiftide/commit/ca119bdc473140437abb1bf14b496bb7bd9378de) *(agents)*  Ensure approved / refused tool calls are in new completions ([#799](https://github.com/bosun-ai/swiftide/pull/799))
+
+- [df6a12d](https://github.com/bosun-ai/swiftide/commit/df6a12dabe855f351acc3e0d104048321cb9bc0e) *(agents)*  Ensure agents with no tools still have the stop tool
+
+- [cd57d12](https://github.com/bosun-ai/swiftide/commit/cd57d1207ced8651a277526d706bc3b7703912c0) *(openai)*  Opt-out streaming accumulated response and only get the delta ([#809](https://github.com/bosun-ai/swiftide/pull/809))
+
+- [da2d604](https://github.com/bosun-ai/swiftide/commit/da2d604e7e6209c83f382cf6de44f5f5c2042596) *(redb)*  Explicit lifetime in table definition
+
+### Miscellaneous
+
+- [7ac92a4](https://github.com/bosun-ai/swiftide/commit/7ac92a4f2ff4b1d1ba7e86c90c4f6c5c025cabc9) *(agents)*  Direct access to executor via context ([#794](https://github.com/bosun-ai/swiftide/pull/794))
+
+- [a21883b](https://github.com/bosun-ai/swiftide/commit/a21883b219a0079c1edc1d3c36d1d06ac906ba18) *(agents)*  [**breaking**] Improved naming for existing messages and message history in default context
+
+**BREAKING CHANGE**: Improved naming for existing messages and message history in default context
+
+- [40bfa9c](https://github.com/bosun-ai/swiftide/commit/40bfa9c2d5685e54f247becb49698f8fdc347172) *(indexing)*  Implement ChunkerTransformer for closures
+
+- [c8d7ab9](https://github.com/bosun-ai/swiftide/commit/c8d7ab90c86e674d5df5f4985121e4e81d1e4a37) *(integrations)*  Improved warning when a qdrant collection exists
+
+- [d6769eb](https://github.com/bosun-ai/swiftide/commit/d6769eba0b87750fd3173ba73315973f720263ec) *(tree-sitter)*  Implement Eq, Hash and AsRefStr for SupportedLanguages
+
+- [04ec29d](https://github.com/bosun-ai/swiftide/commit/04ec29d7240a8542ccd1d530bb9b104bcd57631e)  Consistent logging for indexing pipeline ([#792](https://github.com/bosun-ai/swiftide/pull/792))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.26.0...0.27.0
+
+
+
 ## [0.26.0](https://github.com/bosun-ai/swiftide/compare/v0.25.1...v0.26.0) - 2025-05-06
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9114,7 +9114,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9143,7 +9143,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9171,7 +9171,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9201,7 +9201,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9221,7 +9221,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9251,7 +9251,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9322,7 +9322,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9345,7 +9345,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9364,7 +9364,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "async-openai 0.28.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.26" }
+swiftide-core = { path = "../swiftide-core", version = "0.27" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.26" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.26" }
+swiftide-core = { path = "../swiftide-core", version = "0.27" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.27" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.26" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.26" }
+swiftide-core = { path = "../swiftide-core", version = "0.27" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.27" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.26.0" }
+swiftide-core = { path = "../swiftide-core/", version = "0.27.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.26.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.27.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,12 +16,12 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.26" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.26" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.26" }
-swiftide-query = { path = "../swiftide-query", version = "0.26" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.26", optional = true }
-swiftide-macros = { path = "../swiftide-macros", version = "0.26", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.27" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.27" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.27" }
+swiftide-query = { path = "../swiftide-query", version = "0.27" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.27", optional = true }
+swiftide-macros = { path = "../swiftide-macros", version = "0.27", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.26.0 -> 0.27.0 (⚠ API breaking changes)
* `swiftide-agents`: 0.26.0 -> 0.27.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.26.0 -> 0.27.0
* `swiftide-indexing`: 0.26.0 -> 0.27.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.26.0 -> 0.27.0 (⚠ API breaking changes)
* `swiftide-query`: 0.26.0 -> 0.27.0 (✓ API compatible changes)
* `swiftide`: 0.26.0 -> 0.27.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_added.ron

Failed in:
  trait method swiftide_core::agent_traits::AgentContext::executor in file /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:189
  trait method swiftide_core::agent_traits::AgentContext::has_received_feedback in file /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:201
  trait method swiftide_core::agent_traits::AgentContext::feedback_received in file /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:203
  trait method swiftide_core::AgentContext::executor in file /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:189
  trait method swiftide_core::AgentContext::has_received_feedback in file /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:201
  trait method swiftide_core::AgentContext::feedback_received in file /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:203

--- failure trait_method_marked_deprecated: trait method #[deprecated] added ---

Description:
A trait method is now #[deprecated]. Downstream crates will get a compiler warning when using this method.
        ref: https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-deprecated-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_marked_deprecated.ron

Failed in:
  method exec_cmd in trait swiftide_core::agent_traits::AgentContext in /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:162
  method exec_cmd in trait swiftide_core::AgentContext in /tmp/.tmpNPDvXK/swiftide/swiftide-core/src/agent_traits.rs:162
```

### ⚠ `swiftide-agents` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentError:MessageHistoryError in /tmp/.tmpNPDvXK/swiftide/swiftide-agents/src/errors.rs:38

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_agents::DefaultContext::with_message_history takes 0 generic types instead of 1, in /tmp/.tmpNPDvXK/swiftide/swiftide-agents/src/default_context.rs:94
```

### ⚠ `swiftide-integrations` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_integrations::redis::RedisBuilder::client takes 1 generic types instead of 0, in /tmp/.tmpNPDvXK/swiftide/swiftide-integrations/src/redis/mod.rs:38
  swiftide_integrations::redis::RedisBuilder::cache_key_prefix takes 1 generic types instead of 0, in /tmp/.tmpNPDvXK/swiftide/swiftide-integrations/src/redis/mod.rs:38
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.27.0](https://github.com/bosun-ai/swiftide/compare/v0.26.0...v0.27.0) - 2025-06-09

### New features

- [c636eba](https://github.com/bosun-ai/swiftide/commit/c636ebaa2eb8d4ace1b5a370698c5f2817fc9c99) *(agents)*  [**breaking**] Context is now generic over its backend ([#810](https://github.com/bosun-ai/swiftide/pull/810))

**BREAKING CHANGE**: The signature is now slightly different for the
AgentContext. If you have implemented your own for i.e. a persisted
solution, if it's *just that*, the implementation is now a lot more
straightforward with the `MessageHistory` trait.

- [3c937a8](https://github.com/bosun-ai/swiftide/commit/3c937a8ed4f7d28798a24b0d893f1613cd298493) *(agents)*  Add helpers for creating tool errors ([#805](https://github.com/bosun-ai/swiftide/pull/805))

- [9e831d3](https://github.com/bosun-ai/swiftide/commit/9e831d3eb072748ebb21c9a16cd7d807b4d42469) *(agents)*  [**breaking**] Easy human-in-the-loop flows by decorating tools ([#790](https://github.com/bosun-ai/swiftide/pull/790))

**BREAKING CHANGE**: The `Tool` trait now receives a `ToolCall` as argument
instead of an `Option<&str>`. The latter is still accessible via
`tool_call.args()`.

- [814c217](https://github.com/bosun-ai/swiftide/commit/814c2174c742ff4277246505537070726ce8af92) *(duckdb)*  Hybrid Search ([#807](https://github.com/bosun-ai/swiftide/pull/807))

- [19a2e94](https://github.com/bosun-ai/swiftide/commit/19a2e94d262cc68c629d88b6b02a72bb9b159036) *(integrations)*  Add support for Google Gemini ([#754](https://github.com/bosun-ai/swiftide/pull/754))

- [990fa5e](https://github.com/bosun-ai/swiftide/commit/990fa5e9edffebd9b70da6b57fa454f7318d642d) *(redis)*  Support `MessageHistory` for redis ([#811](https://github.com/bosun-ai/swiftide/pull/811))

### Bug fixes

- [ca119bd](https://github.com/bosun-ai/swiftide/commit/ca119bdc473140437abb1bf14b496bb7bd9378de) *(agents)*  Ensure approved / refused tool calls are in new completions ([#799](https://github.com/bosun-ai/swiftide/pull/799))

- [df6a12d](https://github.com/bosun-ai/swiftide/commit/df6a12dabe855f351acc3e0d104048321cb9bc0e) *(agents)*  Ensure agents with no tools still have the stop tool

- [cd57d12](https://github.com/bosun-ai/swiftide/commit/cd57d1207ced8651a277526d706bc3b7703912c0) *(openai)*  Opt-out streaming accumulated response and only get the delta ([#809](https://github.com/bosun-ai/swiftide/pull/809))

- [da2d604](https://github.com/bosun-ai/swiftide/commit/da2d604e7e6209c83f382cf6de44f5f5c2042596) *(redb)*  Explicit lifetime in table definition

### Miscellaneous

- [7ac92a4](https://github.com/bosun-ai/swiftide/commit/7ac92a4f2ff4b1d1ba7e86c90c4f6c5c025cabc9) *(agents)*  Direct access to executor via context ([#794](https://github.com/bosun-ai/swiftide/pull/794))

- [a21883b](https://github.com/bosun-ai/swiftide/commit/a21883b219a0079c1edc1d3c36d1d06ac906ba18) *(agents)*  [**breaking**] Improved naming for existing messages and message history in default context

**BREAKING CHANGE**: Improved naming for existing messages and message history in default context

- [40bfa9c](https://github.com/bosun-ai/swiftide/commit/40bfa9c2d5685e54f247becb49698f8fdc347172) *(indexing)*  Implement ChunkerTransformer for closures

- [c8d7ab9](https://github.com/bosun-ai/swiftide/commit/c8d7ab90c86e674d5df5f4985121e4e81d1e4a37) *(integrations)*  Improved warning when a qdrant collection exists

- [d6769eb](https://github.com/bosun-ai/swiftide/commit/d6769eba0b87750fd3173ba73315973f720263ec) *(tree-sitter)*  Implement Eq, Hash and AsRefStr for SupportedLanguages

- [04ec29d](https://github.com/bosun-ai/swiftide/commit/04ec29d7240a8542ccd1d530bb9b104bcd57631e)  Consistent logging for indexing pipeline ([#792](https://github.com/bosun-ai/swiftide/pull/792))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.26.0...0.27.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).