### PR TITLE
chore: release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.0](https://github.com/bosun-ai/swiftide/compare/v0.27.2...v0.28.0) - 2025-06-30
+
+### New features
+
+- [9d11386](https://github.com/bosun-ai/swiftide/commit/9d11386c155773fcc77a60591cd57bc366044c71)  Token usage metrics for embeddings, SimplePrompt and ChatCompletion with metric-rs ([#813](https://github.com/bosun-ai/swiftide/pull/813))
+
+- [59c8b9c](https://github.com/bosun-ai/swiftide/commit/59c8b9cef721c3861a9d352c7fbef28e27d2f649)  Stream files from tool executor for indexing ([#835](https://github.com/bosun-ai/swiftide/pull/835))
+
+### Bug fixes
+
+- [ba6ec04](https://github.com/bosun-ai/swiftide/commit/ba6ec0485dc950e83e91e6a8102becc0e8a13158) *(pipeline)*  Cache nodes after they've been successfully ran ([#800](https://github.com/bosun-ai/swiftide/pull/800))
+
+- [275efcd](https://github.com/bosun-ai/swiftide/commit/275efcdf91e85ed4327ffa948dcebe5903b178fa)  Mark Loader as Send + Sync
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.27.2...0.28.0
+
+
+
 ## [0.27.2](https://github.com/bosun-ai/swiftide/compare/v0.27.1...v0.27.2) - 2025-06-26
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "benchmarks"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9188,7 +9188,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9219,7 +9219,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9248,7 +9248,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9279,7 +9279,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9300,7 +9300,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9331,7 +9331,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9405,7 +9405,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9428,7 +9428,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9447,7 +9447,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.27.2"
+version = "0.28.0"
 dependencies = [
  "async-openai 0.28.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.27.2"
+version = "0.28.0"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.27" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.27" }
+swiftide-core = { path = "../swiftide-core", version = "0.28" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.28" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.27" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.27" }
+swiftide-core = { path = "../swiftide-core", version = "0.28" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.28" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.27" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.27" }
+swiftide-core = { path = "../swiftide-core", version = "0.28" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.28" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-macros/Cargo.toml
+++ b/swiftide-macros/Cargo.toml
@@ -14,7 +14,7 @@ homepage.workspace = true
 proc-macro = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core/", version = "0.27.2" }
+swiftide-core = { path = "../swiftide-core/", version = "0.28.0" }
 
 quote = { workspace = true }
 syn = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.27.2" }
+swiftide-core = { path = "../swiftide-core", version = "0.28.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,12 +16,12 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.27" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.27" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.27" }
-swiftide-query = { path = "../swiftide-query", version = "0.27" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.27", optional = true }
-swiftide-macros = { path = "../swiftide-macros", version = "0.27", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.28" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.28" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.28" }
+swiftide-query = { path = "../swiftide-query", version = "0.28" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.28", optional = true }
+swiftide-macros = { path = "../swiftide-macros", version = "0.28", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.27.2 -> 0.28.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.27.2 -> 0.28.0
* `swiftide-indexing`: 0.27.2 -> 0.28.0 (✓ API compatible changes)
* `swiftide-agents`: 0.27.2 -> 0.28.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.27.2 -> 0.28.0 (✓ API compatible changes)
* `swiftide-query`: 0.27.2 -> 0.28.0
* `swiftide`: 0.27.2 -> 0.28.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Node.parent_id in /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/node.rs:68

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Node::build_from_other, previously in file /tmp/.tmpj6c1Gz/swiftide-core/src/node.rs:129

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait swiftide_core::indexing_traits::Loader gained Send in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/indexing_traits.rs:196
  trait swiftide_core::indexing_traits::Loader gained Sync in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/indexing_traits.rs:196
  trait swiftide_core::indexing::Loader gained Send in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/indexing_traits.rs:196
  trait swiftide_core::indexing::Loader gained Sync in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/indexing_traits.rs:196
  trait swiftide_core::Loader gained Send in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/indexing_traits.rs:196
  trait swiftide_core::Loader gained Sync in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/indexing_traits.rs:196

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_added.ron

Failed in:
  trait method swiftide_core::agent_traits::ToolExecutor::stream_files in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/agent_traits.rs:32
  trait method swiftide_core::ToolExecutor::stream_files in file /tmp/.tmpeYXV2q/swiftide/swiftide-core/src/agent_traits.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.28.0](https://github.com/bosun-ai/swiftide/compare/v0.27.2...v0.28.0) - 2025-06-30

### New features

- [9d11386](https://github.com/bosun-ai/swiftide/commit/9d11386c155773fcc77a60591cd57bc366044c71)  Token usage metrics for embeddings, SimplePrompt and ChatCompletion with metric-rs ([#813](https://github.com/bosun-ai/swiftide/pull/813))

- [59c8b9c](https://github.com/bosun-ai/swiftide/commit/59c8b9cef721c3861a9d352c7fbef28e27d2f649)  Stream files from tool executor for indexing ([#835](https://github.com/bosun-ai/swiftide/pull/835))

### Bug fixes

- [ba6ec04](https://github.com/bosun-ai/swiftide/commit/ba6ec0485dc950e83e91e6a8102becc0e8a13158) *(pipeline)*  Cache nodes after they've been successfully ran ([#800](https://github.com/bosun-ai/swiftide/pull/800))

- [275efcd](https://github.com/bosun-ai/swiftide/commit/275efcdf91e85ed4327ffa948dcebe5903b178fa)  Mark Loader as Send + Sync


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.27.2...0.28.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).