### PR TITLE
chore: release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.30.0](https://github.com/bosun-ai/swiftide/compare/v0.29.0...v0.30.0) - 2025-08-15
+
+### New features
+
+- [dc574b4](https://github.com/bosun-ai/swiftide/commit/dc574b41b259f430bb4dc38338416ea1aa9480bb) *(agents)*  Multi agent setup with graph-like Tasks ([#861](https://github.com/bosun-ai/swiftide/pull/861))
+
+- [8740762](https://github.com/bosun-ai/swiftide/commit/87407626ef75c254fae0a677148609738fd64ccc) *(agents)*  Allow mutating an existing system prompt in the builder ([#887](https://github.com/bosun-ai/swiftide/pull/887))
+
+- [4bbf207](https://github.com/bosun-ai/swiftide/commit/4bbf207637a1aebe4e0d5b2d4030c3d1f99d4c1c) *(agents/local-executor)*  Allow clearing, adding and removing env variable ([#875](https://github.com/bosun-ai/swiftide/pull/875))
+
+- [7873493](https://github.com/bosun-ai/swiftide/commit/787349329e34956bcd205b8da64bb241c15c8e65) *(agents/local-executor)*  Support running inline shebang scripts ([#874](https://github.com/bosun-ai/swiftide/pull/874))
+
+### Bug fixes
+
+- [2b8e138](https://github.com/bosun-ai/swiftide/commit/2b8e1389b630283a2e8c55b9997f09322b7378a9) *(openai)*  More gracefully allow handling streaming errors if the client is decorated ([#891](https://github.com/bosun-ai/swiftide/pull/891))
+
+- [f2948b5](https://github.com/bosun-ai/swiftide/commit/f2948b596d7c91c518e700c5d2589fba5a45b649) *(pipeline)*  Revert cache nodes after they've been successfully ran ([#800](https://github.com/bosun-ai/swiftide/pull/800)) ([#852](https://github.com/bosun-ai/swiftide/pull/852))
+
+### Miscellaneous
+
+- [09f421b](https://github.com/bosun-ai/swiftide/commit/09f421bcc934721ab5fcf3dc2808fe5beefcc9a2)  Update rmcp and schemars ([#881](https://github.com/bosun-ai/swiftide/pull/881))
+
+### Docs
+
+- [84ffa45](https://github.com/bosun-ai/swiftide/commit/84ffa4507e57b252f72204f8e0df67191d97fe72)  Minimal updates for tasks
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.29.0...0.30.0
+
+
+
 ## [0.29.0](https://github.com/bosun-ai/swiftide/compare/v0.28.1...v0.29.0) - 2025-07-29
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "benchmarks"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9442,7 +9442,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9471,7 +9471,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9502,7 +9502,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9534,7 +9534,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9555,7 +9555,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9585,7 +9585,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9660,7 +9660,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9683,7 +9683,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9702,7 +9702,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-openai 0.29.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.29" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.29" }
+swiftide-core = { path = "../swiftide-core", version = "0.30" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.30" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.29" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.29" }
+swiftide-core = { path = "../swiftide-core", version = "0.30" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.30" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.29" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.29" }
+swiftide-core = { path = "../swiftide-core", version = "0.30" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.30" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.29.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.30.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,12 +16,12 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.29" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.29" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.29" }
-swiftide-query = { path = "../swiftide-query", version = "0.29" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.29", optional = true }
-swiftide-macros = { path = "../swiftide-macros", version = "0.29", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.30" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.30" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.30" }
+swiftide-query = { path = "../swiftide-query", version = "0.30" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.30", optional = true }
+swiftide-macros = { path = "../swiftide-macros", version = "0.30", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.29.0 -> 0.30.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.29.0 -> 0.30.0
* `swiftide-indexing`: 0.29.0 -> 0.30.0 (✓ API compatible changes)
* `swiftide-agents`: 0.29.0 -> 0.30.0 (⚠ API breaking changes)
* `swiftide-integrations`: 0.29.0 -> 0.30.0 (✓ API compatible changes)
* `swiftide-query`: 0.29.0 -> 0.30.0 (✓ API compatible changes)
* `swiftide`: 0.29.0 -> 0.30.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure enum_unit_variant_changed_kind: An enum unit variant changed kind ---

Description:
A public enum's exhaustive unit variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_unit_variant_changed_kind.ron

Failed in:
  variant ToolOutput::Stop in /tmp/.tmpRc4s4F/swiftide/swiftide-core/src/chat_completion/tools.rs:23

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  NodeBuilder::parent_id, previously in file /tmp/.tmp08p6H9/swiftide-core/src/node.rs:39
  Node::chunking_from, previously in file /tmp/.tmp08p6H9/swiftide-core/src/node.rs:132
  Node::parent_id, previously in file /tmp/.tmp08p6H9/swiftide-core/src/node.rs:249

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field parent_id of struct Node, previously in file /tmp/.tmp08p6H9/swiftide-core/src/node.rs:68

--- failure trait_added_supertrait: non-sealed trait added new supertraits ---

Description:
A non-sealed trait added one or more supertraits, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#generic-bounds-tighten
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_added_supertrait.ron

Failed in:
  trait swiftide_core::agent_traits::ToolExecutor gained DynClone in file /tmp/.tmpRc4s4F/swiftide/swiftide-core/src/agent_traits.rs:28
  trait swiftide_core::ToolExecutor gained DynClone in file /tmp/.tmpRc4s4F/swiftide/swiftide-core/src/agent_traits.rs:28
```

### ⚠ `swiftide-agents` breaking changes

```text
--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant StopReason::RequestedByTool in /tmp/.tmpRc4s4F/swiftide/swiftide-agents/src/state.rs:31
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `swiftide`

<blockquote>

## [0.30.0](https://github.com/bosun-ai/swiftide/compare/v0.29.0...v0.30.0) - 2025-08-15

### New features

- [dc574b4](https://github.com/bosun-ai/swiftide/commit/dc574b41b259f430bb4dc38338416ea1aa9480bb) *(agents)*  Multi agent setup with graph-like Tasks ([#861](https://github.com/bosun-ai/swiftide/pull/861))

- [8740762](https://github.com/bosun-ai/swiftide/commit/87407626ef75c254fae0a677148609738fd64ccc) *(agents)*  Allow mutating an existing system prompt in the builder ([#887](https://github.com/bosun-ai/swiftide/pull/887))

- [4bbf207](https://github.com/bosun-ai/swiftide/commit/4bbf207637a1aebe4e0d5b2d4030c3d1f99d4c1c) *(agents/local-executor)*  Allow clearing, adding and removing env variable ([#875](https://github.com/bosun-ai/swiftide/pull/875))

- [7873493](https://github.com/bosun-ai/swiftide/commit/787349329e34956bcd205b8da64bb241c15c8e65) *(agents/local-executor)*  Support running inline shebang scripts ([#874](https://github.com/bosun-ai/swiftide/pull/874))

### Bug fixes

- [2b8e138](https://github.com/bosun-ai/swiftide/commit/2b8e1389b630283a2e8c55b9997f09322b7378a9) *(openai)*  More gracefully allow handling streaming errors if the client is decorated ([#891](https://github.com/bosun-ai/swiftide/pull/891))

- [f2948b5](https://github.com/bosun-ai/swiftide/commit/f2948b596d7c91c518e700c5d2589fba5a45b649) *(pipeline)*  Revert cache nodes after they've been successfully ran ([#800](https://github.com/bosun-ai/swiftide/pull/800)) ([#852](https://github.com/bosun-ai/swiftide/pull/852))

### Miscellaneous

- [09f421b](https://github.com/bosun-ai/swiftide/commit/09f421bcc934721ab5fcf3dc2808fe5beefcc9a2)  Update rmcp and schemars ([#881](https://github.com/bosun-ai/swiftide/pull/881))

### Docs

- [84ffa45](https://github.com/bosun-ai/swiftide/commit/84ffa4507e57b252f72204f8e0df67191d97fe72)  Minimal updates for tasks


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.29.0...0.30.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).