### PR TITLE
feat: Proper streaming backoff for Chat Completion

### DIFF
--- a/swiftide-core/Cargo.toml
+++ b/swiftide-core/Cargo.toml
@@ -43,6 +43,8 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 [dev-dependencies]
 test-case = { workspace = true }
 test-log = { workspace = true }
+tokio = { workspace = true, features = ["time", "test-util"] }
+tokio-stream = { workspace = true }
 
 [features]
 defaults = ["truncate-debug"]

--- a/swiftide-core/src/chat_completion/traits.rs
+++ b/swiftide-core/src/chat_completion/traits.rs
@@ -4,7 +4,7 @@ use dyn_clone::DynClone;
 use futures_util::Stream;
 use std::{borrow::Cow, pin::Pin, sync::Arc};
 
-use crate::{AgentContext, LanguageModelWithBackOff};
+use crate::AgentContext;
 
 use super::{
     ToolCall, ToolOutput, ToolSpec,
@@ -12,35 +12,6 @@ use super::{
     chat_completion_response::ChatCompletionResponse,
     errors::{LanguageModelError, ToolError},
 };
-
-#[async_trait]
-impl<LLM: ChatCompletion + Clone> ChatCompletion for LanguageModelWithBackOff<LLM> {
-    async fn complete(
-        &self,
-        request: &ChatCompletionRequest,
-    ) -> Result<ChatCompletionResponse, LanguageModelError> {
-        let strategy = self.strategy();
-
-        let op = || {
-            let request = request.clone();
-            async move {
-                self.inner.complete(&request).await.map_err(|e| match e {
-                    LanguageModelError::ContextLengthExceeded(e) => {
-                        backoff::Error::Permanent(LanguageModelError::ContextLengthExceeded(e))
-                    }
-                    LanguageModelError::PermanentError(e) => {
-                        backoff::Error::Permanent(LanguageModelError::PermanentError(e))
-                    }
-                    LanguageModelError::TransientError(e) => {
-                        backoff::Error::transient(LanguageModelError::TransientError(e))
-                    }
-                })
-            }
-        };
-
-        backoff::future::retry(strategy, op).await
-    }
-}
 
 pub type ChatCompletionStream =
     Pin<Box<dyn Stream<Item = Result<ChatCompletionResponse, LanguageModelError>> + Send>>;
@@ -113,172 +84,6 @@ where
 }
 
 dyn_clone::clone_trait_object!(ChatCompletion);
-
-#[cfg(test)]
-mod tests {
-    use uuid::Uuid;
-
-    use super::*;
-    use crate::BackoffConfiguration;
-    use std::{
-        collections::HashSet,
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-    };
-
-    #[derive(Clone)]
-    enum MockErrorType {
-        Transient,
-        Permanent,
-        ContextLengthExceeded,
-    }
-
-    #[derive(Clone)]
-    struct MockChatCompletion {
-        call_count: Arc<AtomicUsize>,
-        should_fail_count: usize,
-        error_type: MockErrorType,
-    }
-
-    #[async_trait]
-    impl ChatCompletion for MockChatCompletion {
-        async fn complete(
-            &self,
-            _request: &ChatCompletionRequest,
-        ) -> Result<ChatCompletionResponse, LanguageModelError> {
-            let count = self.call_count.fetch_add(1, Ordering::SeqCst);
-
-            if count < self.should_fail_count {
-                match self.error_type {
-                    MockErrorType::Transient => Err(LanguageModelError::TransientError(Box::new(
-                        std::io::Error::new(std::io::ErrorKind::ConnectionReset, "Transient error"),
-                    ))),
-                    MockErrorType::Permanent => Err(LanguageModelError::PermanentError(Box::new(
-                        std::io::Error::new(std::io::ErrorKind::InvalidData, "Permanent error"),
-                    ))),
-                    MockErrorType::ContextLengthExceeded => Err(
-                        LanguageModelError::ContextLengthExceeded(Box::new(std::io::Error::new(
-                            std::io::ErrorKind::InvalidInput,
-                            "Context length exceeded",
-                        ))),
-                    ),
-                }
-            } else {
-                Ok(ChatCompletionResponse {
-                    id: Uuid::new_v4(),
-                    message: Some("Success response".to_string()),
-                    tool_calls: None,
-                    delta: None,
-                    usage: None,
-                })
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn test_language_model_with_backoff_retries_chat_completion_transient_errors() {
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let mock_chat = MockChatCompletion {
-            call_count: call_count.clone(),
-            should_fail_count: 2, // Fail twice, succeed on third attempt
-            error_type: MockErrorType::Transient,
-        };
-
-        let config = BackoffConfiguration {
-            initial_interval_sec: 1,
-            max_elapsed_time_sec: 10,
-            multiplier: 1.5,
-            randomization_factor: 0.5,
-        };
-
-        let model_with_backoff = LanguageModelWithBackOff::new(mock_chat, config);
-
-        let request = ChatCompletionRequest {
-            messages: vec![],
-            tools_spec: HashSet::default(),
-        };
-
-        let result = model_with_backoff.complete(&request).await;
-
-        assert!(result.is_ok());
-        assert_eq!(call_count.load(Ordering::SeqCst), 3);
-        assert_eq!(
-            result.unwrap().message,
-            Some("Success response".to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn test_language_model_with_backoff_does_not_retry_chat_completion_permanent_errors() {
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let mock_chat = MockChatCompletion {
-            call_count: call_count.clone(),
-            should_fail_count: 2, // Would fail twice if retried
-            error_type: MockErrorType::Permanent,
-        };
-
-        let config = BackoffConfiguration {
-            initial_interval_sec: 1,
-            max_elapsed_time_sec: 10,
-            multiplier: 1.5,
-            randomization_factor: 0.5,
-        };
-
-        let model_with_backoff = LanguageModelWithBackOff::new(mock_chat, config);
-
-        let request = ChatCompletionRequest {
-            messages: vec![],
-            tools_spec: HashSet::default(),
-        };
-
-        let result = model_with_backoff.complete(&request).await;
-
-        assert!(result.is_err());
-        assert_eq!(call_count.load(Ordering::SeqCst), 1); // Should only be called once
-
-        match result {
-            Err(LanguageModelError::PermanentError(_)) => {} // Expected
-            _ => panic!("Expected PermanentError, got {result:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_language_model_with_backoff_does_not_retry_chat_completion_context_length_errors()
-    {
-        let call_count = Arc::new(AtomicUsize::new(0));
-        let mock_chat = MockChatCompletion {
-            call_count: call_count.clone(),
-            should_fail_count: 2, // Would fail twice if retried
-            error_type: MockErrorType::ContextLengthExceeded,
-        };
-
-        let config = BackoffConfiguration {
-            initial_interval_sec: 1,
-            max_elapsed_time_sec: 10,
-            multiplier: 1.5,
-            randomization_factor: 0.5,
-        };
-
-        let model_with_backoff = LanguageModelWithBackOff::new(mock_chat, config);
-
-        let request = ChatCompletionRequest {
-            messages: vec![],
-            tools_spec: HashSet::default(),
-        };
-
-        let result = model_with_backoff.complete(&request).await;
-
-        assert!(result.is_err());
-        assert_eq!(call_count.load(Ordering::SeqCst), 1); // Should only be called once
-
-        match result {
-            Err(LanguageModelError::ContextLengthExceeded(_)) => {} // Expected
-            _ => panic!("Expected ContextLengthExceeded, got {result:?}"),
-        }
-    }
-}
 
 /// The `Tool` trait is the main interface for chat completion and agent tools.
 ///

--- a/swiftide-core/src/lib.rs
+++ b/swiftide-core/src/lib.rs
@@ -16,6 +16,7 @@ mod query;
 mod query_stream;
 pub mod query_traits;
 mod search_strategies;
+mod stream_backoff;
 pub mod tokenizer;
 pub mod type_aliases;
 

--- a/swiftide-core/src/stream_backoff.rs
+++ b/swiftide-core/src/stream_backoff.rs
@@ -10,8 +10,8 @@ use pin_project::pin_project;
 // /// After any [`Err`] is emitted, the stream is paused for [`Backoff::next_backoff`]. The
 // /// [`Backoff`] is [`reset`](`Backoff::reset`) on any [`Ok`] value.
 // ///
-// /// If [`Backoff::next_backoff`] returns [`None`] then the backing stream is given up on, and closed.
-// pub fn backoff<S: TryStream, B: Backoff>(
+// /// If [`Backoff::next_backoff`] returns [`None`] then the backing stream is given up on, and
+// closed. pub fn backoff<S: TryStream, B: Backoff>(
 //     stream: S,
 //     backoff: B,
 // ) -> StreamBackoff<S, B, impl Sleeper> {
@@ -72,7 +72,8 @@ where
         match this.state.as_mut().project() {
             StateProj::BackingOff { mut backoff_sleep } => match backoff_sleep.as_mut().poll(cx) {
                 Poll::Ready(()) => {
-                    // tracing::debug!(deadline = ?backoff_sleep.deadline(), "Backoff complete, waking up");
+                    // tracing::debug!(deadline = ?backoff_sleep.deadline(), "Backoff complete,
+                    // waking up");
                     this.state.set(State::Awake);
                 }
                 Poll::Pending => {

--- a/swiftide-core/src/stream_backoff.rs
+++ b/swiftide-core/src/stream_backoff.rs
@@ -1,0 +1,215 @@
+// Credits go to https://github.com/ihrwein/backoff/pull/50
+use std::{pin::Pin, task::Poll, time::Duration};
+
+use backoff::{backoff::Backoff, future::Sleeper};
+use futures_util::{Stream, TryStream};
+use pin_project::pin_project;
+
+// /// Applies a [`Backoff`] policy to a [`Stream`]
+// ///
+// /// After any [`Err`] is emitted, the stream is paused for [`Backoff::next_backoff`]. The
+// /// [`Backoff`] is [`reset`](`Backoff::reset`) on any [`Ok`] value.
+// ///
+// /// If [`Backoff::next_backoff`] returns [`None`] then the backing stream is given up on, and closed.
+// pub fn backoff<S: TryStream, B: Backoff>(
+//     stream: S,
+//     backoff: B,
+// ) -> StreamBackoff<S, B, impl Sleeper> {
+//     StreamBackoff::new(stream, backoff, TokioSleeper)
+// }
+
+pub(crate) struct TokioSleeper;
+impl Sleeper for TokioSleeper {
+    type Sleep = ::tokio::time::Sleep;
+    fn sleep(&self, dur: Duration) -> Self::Sleep {
+        ::tokio::time::sleep(dur)
+    }
+}
+
+/// See [`backoff`]
+#[pin_project]
+pub struct StreamBackoff<S, B, Sl: Sleeper> {
+    #[pin]
+    stream: S,
+    backoff: B,
+    sleeper: Sl,
+    #[pin]
+    state: State<Sl>,
+}
+
+#[pin_project(project = StateProj)]
+enum State<Sl: Sleeper> {
+    BackingOff {
+        #[pin]
+        backoff_sleep: Sl::Sleep,
+    },
+    GivenUp,
+    Awake,
+}
+
+impl<S: TryStream, B: Backoff, Sl: Sleeper> StreamBackoff<S, B, Sl> {
+    pub fn new(stream: S, backoff: B, sleeper: Sl) -> Self {
+        Self {
+            stream,
+            backoff,
+            sleeper,
+            state: State::Awake,
+        }
+    }
+}
+
+impl<S: TryStream, B: Backoff, Sl: Sleeper> Stream for StreamBackoff<S, B, Sl>
+where
+    Sl::Sleep: Future,
+{
+    type Item = Result<S::Ok, S::Error>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        match this.state.as_mut().project() {
+            StateProj::BackingOff { mut backoff_sleep } => match backoff_sleep.as_mut().poll(cx) {
+                Poll::Ready(()) => {
+                    // tracing::debug!(deadline = ?backoff_sleep.deadline(), "Backoff complete, waking up");
+                    this.state.set(State::Awake);
+                }
+                Poll::Pending => {
+                    // let deadline = backoff_sleep.deadline();
+                    // tracing::trace!(
+                    //     ?deadline,
+                    //     remaining_duration = ?deadline.saturating_duration_since(Instant::now()),
+                    //     "Still waiting for backoff sleep to complete"
+                    // );
+                    return Poll::Pending;
+                }
+            },
+            StateProj::GivenUp => {
+                // tracing::debug!("Backoff has given up, stream is closed");
+                return Poll::Ready(None);
+            }
+            StateProj::Awake => {}
+        }
+
+        let next_item = this.stream.try_poll_next(cx);
+        match &next_item {
+            Poll::Ready(Some(Err(_))) => {
+                if let Some(backoff_duration) = this.backoff.next_backoff() {
+                    let backoff_sleep = this.sleeper.sleep(backoff_duration);
+                    // tracing::debug!(
+                    //     deadline = ?backoff_sleep.deadline(),
+                    //     duration = ?backoff_duration,
+                    //     "Error received, backing off"
+                    // );
+                    this.state.set(State::BackingOff { backoff_sleep });
+                } else {
+                    // tracing::debug!("Error received, giving up");
+                    this.state.set(State::GivenUp);
+                }
+            }
+            Poll::Ready(_) => {
+                // tracing::trace!("Non-error received, resetting backoff");
+                this.backoff.reset();
+            }
+            Poll::Pending => {}
+        }
+        next_item
+    }
+}
+
+// Tokio clock is required to be able to freeze time during marble tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use futures_util::{StreamExt, pin_mut, poll, stream};
+    use std::{task::Poll, time::Duration};
+    use tokio::{self, sync::mpsc};
+
+    #[tokio::test]
+    async fn stream_should_back_off() {
+        tokio::time::pause();
+        let tick = Duration::from_secs(1);
+        let rx = stream::iter([Ok(0), Ok(1), Err(2), Ok(3), Ok(4)]);
+        let rx = StreamBackoff::new(rx, backoff::backoff::Constant::new(tick), TokioSleeper);
+        pin_mut!(rx);
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(0))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(1))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Err(2))));
+        assert_eq!(poll!(rx.next()), Poll::Pending);
+        tokio::time::advance(tick * 2).await;
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(3))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(4))));
+        assert_eq!(poll!(rx.next()), Poll::Ready(None));
+    }
+
+    #[tokio::test]
+    async fn backoff_time_should_update() {
+        tokio::time::pause();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rx = tokio_stream::wrappers::UnboundedReceiverStream::new(rx);
+        let rx = StreamBackoff::new(rx, LinearBackoff::new(Duration::from_secs(2)), TokioSleeper);
+        pin_mut!(rx);
+        tx.send(Ok(0)).unwrap();
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(0))));
+        tx.send(Ok(1)).unwrap();
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(1))));
+        tx.send(Err(2)).unwrap();
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Err(2))));
+        assert_eq!(poll!(rx.next()), Poll::Pending);
+        tokio::time::advance(Duration::from_secs(3)).await;
+        assert_eq!(poll!(rx.next()), Poll::Pending);
+        tx.send(Err(3)).unwrap();
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Err(3))));
+        tx.send(Ok(4)).unwrap();
+        assert_eq!(poll!(rx.next()), Poll::Pending);
+        tokio::time::advance(Duration::from_secs(3)).await;
+        assert_eq!(poll!(rx.next()), Poll::Pending);
+        tokio::time::advance(Duration::from_secs(2)).await;
+        assert_eq!(poll!(rx.next()), Poll::Ready(Some(Ok(4))));
+        assert_eq!(poll!(rx.next()), Poll::Pending);
+        drop(tx);
+        assert_eq!(poll!(rx.next()), Poll::Ready(None));
+    }
+
+    #[tokio::test]
+    async fn backoff_should_close_when_requested() {
+        assert_eq!(
+            StreamBackoff::new(
+                stream::iter([Ok(0), Ok(1), Err(2), Ok(3)]),
+                backoff::backoff::Stop {},
+                TokioSleeper
+            )
+            .collect::<Vec<_>>()
+            .await,
+            vec![Ok(0), Ok(1), Err(2)]
+        );
+    }
+
+    /// Dynamic backoff policy that is still deterministic and testable
+    struct LinearBackoff {
+        interval: Duration,
+        current_duration: Duration,
+    }
+
+    impl LinearBackoff {
+        fn new(interval: Duration) -> Self {
+            Self {
+                interval,
+                current_duration: Duration::ZERO,
+            }
+        }
+    }
+
+    impl Backoff for LinearBackoff {
+        fn next_backoff(&mut self) -> Option<Duration> {
+            self.current_duration += self.interval;
+            Some(self.current_duration)
+        }
+
+        fn reset(&mut self) {
+            self.current_duration = Duration::ZERO;
+        }
+    }
+}


### PR DESCRIPTION
- **fix(openai): More gracefully allow handling streaming errors if the client is decorated**
- **feat: Proper streaming backoff for ChatCompletion**
