### PR TITLE
chore: release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,68 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.31.0](https://github.com/bosun-ai/swiftide/compare/v0.30.1...v0.31.0) - 2025-09-16
+
+### New features
+
+- [ad6655d](https://github.com/bosun-ai/swiftide/commit/ad6655dc448defc3a9ef8401f0528da11e16a256) *(agents)*  Add helper to remove default stop tool from agent builder
+
+- [708ebe4](https://github.com/bosun-ai/swiftide/commit/708ebe436b4d2e9456723cfc95557071f2c636c9) *(agents)*  Implement From<SystemPrompt> for SystemPromptBuilder
+
+- [db79f21](https://github.com/bosun-ai/swiftide/commit/db79f21c323abca462a5f469814c4c03cc949b7e) *(agents/tasks)*  Add helper to create instant transitions from node ids
+
+- [ac7cd22](https://github.com/bosun-ai/swiftide/commit/ac7cd2209e1792b693acbde251a1aa756bb35541) *(indexing)*  [**breaking**] Prepare for multi modal and node transformations with generic indexing ([#899](https://github.com/bosun-ai/swiftide/pull/899))
+
+**BREAKING CHANGE**: Indexing pipelines are now generic over their inner
+type. This is a major change that enables major cool stuff in the
+future. Most of Swiftide still runs on Node<String>, and will be
+migrated when needed/appropriate. A `TextNode` alias is provided and
+most indexing traits now take the node's inner generic parameter as
+Input/Output associated types.
+
+- [4e20804](https://github.com/bosun-ai/swiftide/commit/4e20804cc78a90e61a1c816abe5810b2a34007af) *(integrations)*  More convenient usage reporting via callback ([#897](https://github.com/bosun-ai/swiftide/pull/897))
+
+- [5923532](https://github.com/bosun-ai/swiftide/commit/592353259018b39d4ce43b4a15a9dea1aa1d2904) *(integrations/openai, core)*  Add `StructuredPrompt` and implement for OpenAI ([#912](https://github.com/bosun-ai/swiftide/pull/912))
+
+- [d2681d5](https://github.com/bosun-ai/swiftide/commit/d2681d53ce235439885ace40ac08a6d4a058259a)  Integrate with Langfuse via tracing and make traces consistent and pretty ([#907](https://github.com/bosun-ai/swiftide/pull/907))
+
+- [b3f18cd](https://github.com/bosun-ai/swiftide/commit/b3f18cd00f9019496274142aa89342da115c6843)  Add convenience helpers to get ToolOutput values as ref
+
+### Bug fixes
+
+- [0071b72](https://github.com/bosun-ai/swiftide/commit/0071b721520d585f36d1ec6ff90eb88d669da043) *(agents)*  Replace tools when adding multiple with the same name
+
+- [dab4cf7](https://github.com/bosun-ai/swiftide/commit/dab4cf771cd9a6d90ae0985c83171fd87b213cba) *(integrations)*  Remove sync requirement in future from `on_usage_async`
+
+- [6702314](https://github.com/bosun-ai/swiftide/commit/6702314eb6d937353324ce601f2a35c2a13d4cc1) *(langfuse)*  Ensure all data is on the right generation span ([#913](https://github.com/bosun-ai/swiftide/pull/913))
+
+- [e389c8b](https://github.com/bosun-ai/swiftide/commit/e389c8ba72435ba1c1af109934b2b580fb6be7c1) *(langfuse)*  Set type field correctly on `SimplePrompt`
+
+### Miscellaneous
+
+- [5ba9a7d](https://github.com/bosun-ai/swiftide/commit/5ba9a7db6f844687b04c5fa5d9a2119f456108c6) *(agents)*  Implement default for `AgentCanFail` tool
+
+- [412dacb](https://github.com/bosun-ai/swiftide/commit/412dacb554d2b1478f3286a47352a6daed3079b9) *(agents/tasks)*  Clean up closure api for node registration
+
+- [478d583](https://github.com/bosun-ai/swiftide/commit/478d5830fa194b880595b2c2ef9ef409cc5b34c4) *(openai)*  Remove double `include_usage` in complete_stream
+
+### Docs
+
+- [2117190](https://github.com/bosun-ai/swiftide/commit/211719038d1912f3ee3f165cdb721c216fa48286)  Update blog post links in readme
+
+- [d5e0323](https://github.com/bosun-ai/swiftide/commit/d5e0323691a22a0b413d14d02e3bafb391e9dd7a)  Update readme
+
+- [a574860](https://github.com/bosun-ai/swiftide/commit/a5748604d14e10c4010384e020e09c6082d2a7c1)  Update readme
+
+### Style
+
+- [7081e29](https://github.com/bosun-ai/swiftide/commit/7081e291216491618fb07e1ac3f947a99b140c7f)  Fmt
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.30.1...0.31.0
+
+
+
 ## [0.30.1](https://github.com/bosun-ai/swiftide/compare/v0.30.0...v0.30.1) - 2025-08-19
 
 ### Bug fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "benchmarks"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9455,7 +9455,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9570,7 +9570,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9600,7 +9600,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9677,7 +9677,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-langfuse"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9703,7 +9703,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9726,7 +9726,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9745,7 +9745,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.30.1"
+version = "0.31.0"
 dependencies = [
  "async-openai 0.29.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.30.1"
+version = "0.31.0"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.30" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.30" }
+swiftide-core = { path = "../swiftide-core", version = "0.31" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.31" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.30" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.30" }
+swiftide-core = { path = "../swiftide-core", version = "0.31" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.31" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.30" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.30" }
+swiftide-core = { path = "../swiftide-core", version = "0.31" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.31" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.30.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.31.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -16,13 +16,13 @@ homepage.workspace = true
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.30" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.30" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.30" }
-swiftide-query = { path = "../swiftide-query", version = "0.30" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.30", optional = true }
-swiftide-macros = { path = "../swiftide-macros", version = "0.30", optional = true }
-swiftide-langfuse = { path = "../swiftide-langfuse", version = "0.30", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.31" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.31" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.31" }
+swiftide-query = { path = "../swiftide-query", version = "0.31" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.31", optional = true }
+swiftide-macros = { path = "../swiftide-macros", version = "0.31", optional = true }
+swiftide-langfuse = { path = "../swiftide-langfuse", version = "0.31", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.30.1 -> 0.31.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.30.1 -> 0.31.0
* `swiftide-indexing`: 0.30.1 -> 0.31.0 (⚠ API breaking changes)
* `swiftide-agents`: 0.30.1 -> 0.31.0 (⚠ API breaking changes)
* `swiftide-integrations`: 0.30.1 -> 0.31.0 (✓ API compatible changes)
* `swiftide-langfuse`: 0.30.1 -> 0.31.0 (✓ API compatible changes)
* `swiftide-query`: 0.30.1 -> 0.31.0 (✓ API compatible changes)
* `swiftide`: 0.30.1 -> 0.31.0 (⚠ API breaking changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_core::indexing::Node::builder takes 1 generic types instead of 0, in /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/node.rs:153

--- failure trait_associated_type_added: non-sealed public trait added associated type without default value ---

Description:
A non-sealed trait has gained an associated type without a default value, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_associated_type_added.ron

Failed in:
  trait associated type swiftide_core::indexing_traits::Loader::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:240
  trait associated type swiftide_core::indexing::Loader::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:240
  trait associated type swiftide_core::Loader::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:240
  trait associated type swiftide_core::indexing_traits::NodeCache::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:420
  trait associated type swiftide_core::indexing::NodeCache::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:420
  trait associated type swiftide_core::NodeCache::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:420
  trait associated type swiftide_core::indexing_traits::Persist::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:699
  trait associated type swiftide_core::indexing_traits::Persist::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:700
  trait associated type swiftide_core::indexing::Persist::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:699
  trait associated type swiftide_core::indexing::Persist::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:700
  trait associated type swiftide_core::Persist::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:699
  trait associated type swiftide_core::Persist::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:700
  trait associated type swiftide_core::indexing_traits::BatchableTransformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:131
  trait associated type swiftide_core::indexing_traits::BatchableTransformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:132
  trait associated type swiftide_core::indexing::BatchableTransformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:131
  trait associated type swiftide_core::indexing::BatchableTransformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:132
  trait associated type swiftide_core::BatchableTransformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:131
  trait associated type swiftide_core::BatchableTransformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:132
  trait associated type swiftide_core::indexing_traits::ChunkerTransformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:318
  trait associated type swiftide_core::indexing_traits::ChunkerTransformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:319
  trait associated type swiftide_core::indexing::ChunkerTransformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:318
  trait associated type swiftide_core::indexing::ChunkerTransformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:319
  trait associated type swiftide_core::ChunkerTransformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:318
  trait associated type swiftide_core::ChunkerTransformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:319
  trait associated type swiftide_core::indexing_traits::Transformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:30
  trait associated type swiftide_core::indexing_traits::Transformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:31
  trait associated type swiftide_core::indexing::Transformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:30
  trait associated type swiftide_core::indexing::Transformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:31
  trait associated type swiftide_core::Transformer::Input in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:30
  trait associated type swiftide_core::Transformer::Output in file /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_traits.rs:31

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait NodeBuilder (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/node.rs:47
  trait Node (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/node.rs:49
  trait IndexingStream (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_stream.rs:21

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct NodeBuilder (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/node.rs:47
  Struct Node (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/node.rs:49
  Struct IndexingStream (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-core/src/indexing_stream.rs:21
```

### ⚠ `swiftide-indexing` breaking changes

```text
--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_indexing::Pipeline::then takes 1 generic types instead of 0, in /tmp/.tmpZXuRlV/swiftide/swiftide-indexing/src/pipeline.rs:228
  swiftide_indexing::Pipeline::then_in_batch takes 1 generic types instead of 0, in /tmp/.tmpZXuRlV/swiftide/swiftide-indexing/src/pipeline.rs:272
  swiftide_indexing::Pipeline::then_chunk takes 1 generic types instead of 0, in /tmp/.tmpZXuRlV/swiftide/swiftide-indexing/src/pipeline.rs:318
  swiftide_indexing::Pipeline::then_store_with takes 1 generic types instead of 0, in /tmp/.tmpZXuRlV/swiftide/swiftide-indexing/src/pipeline.rs:361

--- failure trait_requires_more_generic_type_params: trait now requires more generic type parameters ---

Description:
A trait now requires more generic type parameters than it used to. Uses of this trait that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/trait_requires_more_generic_type_params.ron

Failed in:
  trait Pipeline (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-indexing/src/pipeline.rs:72

--- failure type_requires_more_generic_type_params: type now requires more generic type parameters ---

Description:
A type now requires more generic type parameters than it used to. Uses of this type that supplied the previously-required number of generic types will be broken. To fix this, consider supplying default values for newly-added generic types.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-parameter-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/type_requires_more_generic_type_params.ron

Failed in:
  Struct Pipeline (0 -> 1 required generic types) in /tmp/.tmpZXuRlV/swiftide/swiftide-indexing/src/pipeline.rs:72
```

### ⚠ `swiftide-agents` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_missing.ron

Failed in:
  struct swiftide_agents::tasks::closures::SyncClosureTaskNode, previously in file /tmp/.tmpCYAV2Z/swiftide-agents/src/tasks/closures.rs:11
```

### ⚠ `swiftide` breaking changes

```text
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/module_missing.ron

Failed in:
  mod swiftide::chat_completion, previously in file /tmp/.tmpCYAV2Z/swiftide/src/lib.rs:153
```

<details><summary><i><b>Changelog</b></i></summary><p>








## `swiftide`

<blockquote>

## [0.31.0](https://github.com/bosun-ai/swiftide/compare/v0.30.1...v0.31.0) - 2025-09-16

### New features

- [ad6655d](https://github.com/bosun-ai/swiftide/commit/ad6655dc448defc3a9ef8401f0528da11e16a256) *(agents)*  Add helper to remove default stop tool from agent builder

- [708ebe4](https://github.com/bosun-ai/swiftide/commit/708ebe436b4d2e9456723cfc95557071f2c636c9) *(agents)*  Implement From<SystemPrompt> for SystemPromptBuilder

- [db79f21](https://github.com/bosun-ai/swiftide/commit/db79f21c323abca462a5f469814c4c03cc949b7e) *(agents/tasks)*  Add helper to create instant transitions from node ids

- [ac7cd22](https://github.com/bosun-ai/swiftide/commit/ac7cd2209e1792b693acbde251a1aa756bb35541) *(indexing)*  [**breaking**] Prepare for multi modal and node transformations with generic indexing ([#899](https://github.com/bosun-ai/swiftide/pull/899))

**BREAKING CHANGE**: Indexing pipelines are now generic over their inner
type. This is a major change that enables major cool stuff in the
future. Most of Swiftide still runs on Node<String>, and will be
migrated when needed/appropriate. A `TextNode` alias is provided and
most indexing traits now take the node's inner generic parameter as
Input/Output associated types.

- [4e20804](https://github.com/bosun-ai/swiftide/commit/4e20804cc78a90e61a1c816abe5810b2a34007af) *(integrations)*  More convenient usage reporting via callback ([#897](https://github.com/bosun-ai/swiftide/pull/897))

- [5923532](https://github.com/bosun-ai/swiftide/commit/592353259018b39d4ce43b4a15a9dea1aa1d2904) *(integrations/openai, core)*  Add `StructuredPrompt` and implement for OpenAI ([#912](https://github.com/bosun-ai/swiftide/pull/912))

- [d2681d5](https://github.com/bosun-ai/swiftide/commit/d2681d53ce235439885ace40ac08a6d4a058259a)  Integrate with Langfuse via tracing and make traces consistent and pretty ([#907](https://github.com/bosun-ai/swiftide/pull/907))

- [b3f18cd](https://github.com/bosun-ai/swiftide/commit/b3f18cd00f9019496274142aa89342da115c6843)  Add convenience helpers to get ToolOutput values as ref

### Bug fixes

- [0071b72](https://github.com/bosun-ai/swiftide/commit/0071b721520d585f36d1ec6ff90eb88d669da043) *(agents)*  Replace tools when adding multiple with the same name

- [dab4cf7](https://github.com/bosun-ai/swiftide/commit/dab4cf771cd9a6d90ae0985c83171fd87b213cba) *(integrations)*  Remove sync requirement in future from `on_usage_async`

- [6702314](https://github.com/bosun-ai/swiftide/commit/6702314eb6d937353324ce601f2a35c2a13d4cc1) *(langfuse)*  Ensure all data is on the right generation span ([#913](https://github.com/bosun-ai/swiftide/pull/913))

- [e389c8b](https://github.com/bosun-ai/swiftide/commit/e389c8ba72435ba1c1af109934b2b580fb6be7c1) *(langfuse)*  Set type field correctly on `SimplePrompt`

### Miscellaneous

- [5ba9a7d](https://github.com/bosun-ai/swiftide/commit/5ba9a7db6f844687b04c5fa5d9a2119f456108c6) *(agents)*  Implement default for `AgentCanFail` tool

- [412dacb](https://github.com/bosun-ai/swiftide/commit/412dacb554d2b1478f3286a47352a6daed3079b9) *(agents/tasks)*  Clean up closure api for node registration

- [478d583](https://github.com/bosun-ai/swiftide/commit/478d5830fa194b880595b2c2ef9ef409cc5b34c4) *(openai)*  Remove double `include_usage` in complete_stream

### Docs

- [2117190](https://github.com/bosun-ai/swiftide/commit/211719038d1912f3ee3f165cdb721c216fa48286)  Update blog post links in readme

- [d5e0323](https://github.com/bosun-ai/swiftide/commit/d5e0323691a22a0b413d14d02e3bafb391e9dd7a)  Update readme

- [a574860](https://github.com/bosun-ai/swiftide/commit/a5748604d14e10c4010384e020e09c6082d2a7c1)  Update readme

### Style

- [7081e29](https://github.com/bosun-ai/swiftide/commit/7081e291216491618fb07e1ac3f947a99b140c7f)  Fmt


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.30.1...0.31.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).