### PR TITLE
chore: release v0.31.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.31.3](https://github.com/bosun-ai/swiftide/compare/v0.31.2...v0.31.3) - 2025-10-06
+
+### New features
+
+- [a189ae6](https://github.com/bosun-ai/swiftide/commit/a189ae6de51571810f98cf58f9fdb58e7707f29a) *(integrations/openai)*  Opt-in responses api ([#943](https://github.com/bosun-ai/swiftide/pull/943))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.31.2...0.31.3
+
+
+
 ## [0.31.2](https://github.com/bosun-ai/swiftide/compare/v0.31.1...v0.31.2) - 2025-09-23
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "benchmarks"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9455,7 +9455,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9485,7 +9485,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9516,7 +9516,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9548,7 +9548,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9571,7 +9571,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9601,7 +9601,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9679,7 +9679,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-langfuse"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9705,7 +9705,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9728,7 +9728,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9747,7 +9747,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.31.2"
+version = "0.31.3"
 dependencies = [
  "async-openai 0.29.3",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.31.2"
+version = "0.31.3"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.31.2" }
+swiftide-core = { path = "../swiftide-core", version = "0.31.3" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.31.2 -> 0.31.3 (✓ API compatible changes)
* `swiftide-macros`: 0.31.2 -> 0.31.3
* `swiftide-indexing`: 0.31.2 -> 0.31.3
* `swiftide-agents`: 0.31.2 -> 0.31.3
* `swiftide-integrations`: 0.31.2 -> 0.31.3 (✓ API compatible changes)
* `swiftide-langfuse`: 0.31.2 -> 0.31.3
* `swiftide-query`: 0.31.2 -> 0.31.3
* `swiftide`: 0.31.2 -> 0.31.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>








## `swiftide`

<blockquote>

## [0.31.3](https://github.com/bosun-ai/swiftide/compare/v0.31.2...v0.31.3) - 2025-10-06

### New features

- [a189ae6](https://github.com/bosun-ai/swiftide/commit/a189ae6de51571810f98cf58f9fdb58e7707f29a) *(integrations/openai)*  Opt-in responses api ([#943](https://github.com/bosun-ai/swiftide/pull/943))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.31.2...0.31.3
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).