### PR TITLE
chore: release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.0](https://github.com/bosun-ai/swiftide/compare/v0.31.3...v0.32.0) - 2025-11-05
+
+### New features
+
+- [9ae3331](https://github.com/bosun-ai/swiftide/commit/9ae33317bbcbf5e65e3aa7eb0bf378190b7c33b5) *(agents)*  [**breaking**] Improve toolspec api with schemars and support all possible types ([#940](https://github.com/bosun-ai/swiftide/pull/940))
+
+**BREAKING CHANGE**: macro-level `json_type` overrides beyond the basic
+primitives are no longer enforced; rely on Rust type inference or
+provide an explicit schemars-derived struct/custom schema when specific
+shapes are required
+
+- [a0cc8d7](https://github.com/bosun-ai/swiftide/commit/a0cc8d73a6ce9a82a03a78e8f83957d3c1455584) *(agents)*  Stop with args with optional schema ([#950](https://github.com/bosun-ai/swiftide/pull/950))
+
+- [8ad7d97](https://github.com/bosun-ai/swiftide/commit/8ad7d97b6911bd3c676c79a2d5318c31dad23e9f) *(agents)*  Add configurable timeouts to commands and local executor ([#963](https://github.com/bosun-ai/swiftide/pull/963))
+
+- [29289d3](https://github.com/bosun-ai/swiftide/commit/29289d37cb9c49fba89376c125194fc430c57a37) *(agents)*  [**breaking**] Add working directories for executor and commands ([#941](https://github.com/bosun-ai/swiftide/pull/941))
+
+**BREAKING CHANGE**: Add working directories for executor and commands ([#941](https://github.com/bosun-ai/swiftide/pull/941))
+
+- [ce724e5](https://github.com/bosun-ai/swiftide/commit/ce724e56034d717aafde08bb6c2d9dc163c66caf) *(agents/mcp)*  Prefix mcp tools with the server name ([#958](https://github.com/bosun-ai/swiftide/pull/958))
+
+### Bug fixes
+
+- [04cd88b](https://github.com/bosun-ai/swiftide/commit/04cd88b74c7a0dd962c093181884db0afe7b6d2d) *(docs)*  Replace `feature(doc_auto_cfg)` with `doc(auto_cfg)`
+
+- [7873ce5](https://github.com/bosun-ai/swiftide/commit/7873ce5941a7abf8ed60df4ec2ea8a7a4c1d1316) *(integrations/openai)*  Simplefy responses api and improve chat completion request ergonomics ([#956](https://github.com/bosun-ai/swiftide/pull/956))
+
+- [24328d0](https://github.com/bosun-ai/swiftide/commit/24328d07e61a4f02679ee6b63a38561d12acefd4) *(macros)*  Ensure deny_unknown_attributes is set on generated args ([#948](https://github.com/bosun-ai/swiftide/pull/948))
+
+- [54245d0](https://github.com/bosun-ai/swiftide/commit/54245d0e70aff580d0e12d68e174026edfdb4801)  Update async-openai and fix responses api ([#964](https://github.com/bosun-ai/swiftide/pull/964))
+
+- [72a6c92](https://github.com/bosun-ai/swiftide/commit/72a6c92764aeda4e88a7cf18d26ce600b7ba8a28)  Force additionalProperties properly on completion requests ([#949](https://github.com/bosun-ai/swiftide/pull/949))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.31.3...0.32.0
+
+
+
 ## [0.31.3](https://github.com/bosun-ai/swiftide/compare/v0.31.2...v0.31.3) - 2025-10-06
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "benchmarks"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9455,7 +9455,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9517,7 +9517,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9572,7 +9572,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9602,7 +9602,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9682,7 +9682,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-langfuse"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9708,7 +9708,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9732,7 +9732,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9751,7 +9751,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "async-openai 0.30.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.31.3"
+version = "0.32.0"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.31" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.31" }
+swiftide-core = { path = "../swiftide-core", version = "0.32" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.32" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.31" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.31" }
+swiftide-core = { path = "../swiftide-core", version = "0.32" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.32" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.31" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.31" }
+swiftide-core = { path = "../swiftide-core", version = "0.32" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.32" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-langfuse/Cargo.toml
+++ b/swiftide-langfuse/Cargo.toml
@@ -34,7 +34,7 @@ reqwest = { version = "^0.12", default-features = false, features = [
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true
-swiftide-core = { path = "../swiftide-core", version = "0.31" }
+swiftide-core = { path = "../swiftide-core", version = "0.32" }
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.31.3" }
+swiftide-core = { path = "../swiftide-core", version = "0.32.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -17,13 +17,13 @@ include = ["../README.md", "../images/", "src/", "../examples", "tests/"]
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.31" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.31" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.31" }
-swiftide-query = { path = "../swiftide-query", version = "0.31" }
-swiftide-agents = { path = "../swiftide-agents", version = "0.31", optional = true }
-swiftide-macros = { path = "../swiftide-macros", version = "0.31", optional = true }
-swiftide-langfuse = { path = "../swiftide-langfuse", version = "0.31", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.32" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.32" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.32" }
+swiftide-query = { path = "../swiftide-query", version = "0.32" }
+swiftide-agents = { path = "../swiftide-agents", version = "0.32", optional = true }
+swiftide-macros = { path = "../swiftide-macros", version = "0.32", optional = true }
+swiftide-langfuse = { path = "../swiftide-langfuse", version = "0.32", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.31.3 -> 0.32.0 (✓ API compatible changes)
* `swiftide-macros`: 0.31.3 -> 0.32.0
* `swiftide-indexing`: 0.31.3 -> 0.32.0 (✓ API compatible changes)
* `swiftide-agents`: 0.31.3 -> 0.32.0 (✓ API compatible changes)
* `swiftide-integrations`: 0.31.3 -> 0.32.0 (✓ API compatible changes)
* `swiftide-langfuse`: 0.31.3 -> 0.32.0 (✓ API compatible changes)
* `swiftide-query`: 0.31.3 -> 0.32.0 (✓ API compatible changes)
* `swiftide`: 0.31.3 -> 0.32.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>








## `swiftide`

<blockquote>

## [0.32.0](https://github.com/bosun-ai/swiftide/compare/v0.31.3...v0.32.0) - 2025-11-05

### New features

- [9ae3331](https://github.com/bosun-ai/swiftide/commit/9ae33317bbcbf5e65e3aa7eb0bf378190b7c33b5) *(agents)*  [**breaking**] Improve toolspec api with schemars and support all possible types ([#940](https://github.com/bosun-ai/swiftide/pull/940))

**BREAKING CHANGE**: macro-level `json_type` overrides beyond the basic
primitives are no longer enforced; rely on Rust type inference or
provide an explicit schemars-derived struct/custom schema when specific
shapes are required

- [a0cc8d7](https://github.com/bosun-ai/swiftide/commit/a0cc8d73a6ce9a82a03a78e8f83957d3c1455584) *(agents)*  Stop with args with optional schema ([#950](https://github.com/bosun-ai/swiftide/pull/950))

- [8ad7d97](https://github.com/bosun-ai/swiftide/commit/8ad7d97b6911bd3c676c79a2d5318c31dad23e9f) *(agents)*  Add configurable timeouts to commands and local executor ([#963](https://github.com/bosun-ai/swiftide/pull/963))

- [29289d3](https://github.com/bosun-ai/swiftide/commit/29289d37cb9c49fba89376c125194fc430c57a37) *(agents)*  [**breaking**] Add working directories for executor and commands ([#941](https://github.com/bosun-ai/swiftide/pull/941))

**BREAKING CHANGE**: Add working directories for executor and commands ([#941](https://github.com/bosun-ai/swiftide/pull/941))

- [ce724e5](https://github.com/bosun-ai/swiftide/commit/ce724e56034d717aafde08bb6c2d9dc163c66caf) *(agents/mcp)*  Prefix mcp tools with the server name ([#958](https://github.com/bosun-ai/swiftide/pull/958))

### Bug fixes

- [04cd88b](https://github.com/bosun-ai/swiftide/commit/04cd88b74c7a0dd962c093181884db0afe7b6d2d) *(docs)*  Replace `feature(doc_auto_cfg)` with `doc(auto_cfg)`

- [7873ce5](https://github.com/bosun-ai/swiftide/commit/7873ce5941a7abf8ed60df4ec2ea8a7a4c1d1316) *(integrations/openai)*  Simplefy responses api and improve chat completion request ergonomics ([#956](https://github.com/bosun-ai/swiftide/pull/956))

- [24328d0](https://github.com/bosun-ai/swiftide/commit/24328d07e61a4f02679ee6b63a38561d12acefd4) *(macros)*  Ensure deny_unknown_attributes is set on generated args ([#948](https://github.com/bosun-ai/swiftide/pull/948))

- [54245d0](https://github.com/bosun-ai/swiftide/commit/54245d0e70aff580d0e12d68e174026edfdb4801)  Update async-openai and fix responses api ([#964](https://github.com/bosun-ai/swiftide/pull/964))

- [72a6c92](https://github.com/bosun-ai/swiftide/commit/72a6c92764aeda4e88a7cf18d26ce600b7ba8a28)  Force additionalProperties properly on completion requests ([#949](https://github.com/bosun-ai/swiftide/pull/949))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.31.3...0.32.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).