### PR TITLE
chore: release v0.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.32.1](https://github.com/bosun-ai/swiftide/compare/v0.32.0...v0.32.1) - 2025-11-08
+
+### New features
+
+- [8bca0ef](https://github.com/bosun-ai/swiftide/commit/8bca0efa246e6adac061006f5f72cc9dd038cc8f) *(integrations/tree-sitter)*  Add C# support ([#967](https://github.com/bosun-ai/swiftide/pull/967))
+
+- [da35870](https://github.com/bosun-ai/swiftide/commit/da358708c83459c7f990027759fa5c56a2b647b9)  Custom schema for fail tool ([#966](https://github.com/bosun-ai/swiftide/pull/966))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.32.0...0.32.1
+
+
+
 ## [0.32.0](https://github.com/bosun-ai/swiftide/compare/v0.31.3...v0.32.0) - 2025-11-05
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "benchmarks"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -9455,7 +9455,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9486,7 +9486,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9517,7 +9517,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9549,7 +9549,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "fluvio",
@@ -9572,7 +9572,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9602,7 +9602,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -9683,7 +9683,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-langfuse"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9709,7 +9709,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9733,7 +9733,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9752,7 +9752,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "async-openai 0.30.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.32.0"
+version = "0.32.1"
 edition = "2024"
 license = "MIT"
 readme = "README.md"

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -24,7 +24,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.32.0" }
+swiftide-core = { path = "../swiftide-core", version = "0.32.1" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.32.0 -> 0.32.1 (✓ API compatible changes)
* `swiftide-macros`: 0.32.0 -> 0.32.1
* `swiftide-indexing`: 0.32.0 -> 0.32.1
* `swiftide-agents`: 0.32.0 -> 0.32.1 (✓ API compatible changes)
* `swiftide-integrations`: 0.32.0 -> 0.32.1 (✓ API compatible changes)
* `swiftide-langfuse`: 0.32.0 -> 0.32.1
* `swiftide-query`: 0.32.0 -> 0.32.1
* `swiftide`: 0.32.0 -> 0.32.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>








## `swiftide`

<blockquote>

## [0.32.1](https://github.com/bosun-ai/swiftide/compare/v0.32.0...v0.32.1) - 2025-11-08

### New features

- [8bca0ef](https://github.com/bosun-ai/swiftide/commit/8bca0efa246e6adac061006f5f72cc9dd038cc8f) *(integrations/tree-sitter)*  Add C# support ([#967](https://github.com/bosun-ai/swiftide/pull/967))

- [da35870](https://github.com/bosun-ai/swiftide/commit/da358708c83459c7f990027759fa5c56a2b647b9)  Custom schema for fail tool ([#966](https://github.com/bosun-ai/swiftide/pull/966))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.32.0...0.32.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).