### PR TITLE
chore: release v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,150 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.33.0](https://github.com/bosun-ai/swiftide/compare/v0.32.1...v0.33.0) - 2026-08-06
+
+### New features
+
+- [a94760d](https://github.com/bosun-ai/swiftide/commit/a94760d9cbaed552bf58bc667cc7a67141751fe6) *(indexing)*  Convenience `then_expand` alias for `then_chunk`
+
+- [7ff5a43](https://github.com/bosun-ai/swiftide/commit/7ff5a43c61b3d2298970f9ca11c3a05d876e1148) *(agents)*  Allow fully overwriting agent history via context ([#997](https://github.com/bosun-ai/swiftide/pull/997))
+
+- [5bc2a94](https://github.com/bosun-ai/swiftide/commit/5bc2a949e5a54333497a5b499eac62d793d8f96d) *(agents)*  Pass mutable agent to hooks ([#1112](https://github.com/bosun-ai/swiftide/pull/1112))
+
+- [8ced907](https://github.com/bosun-ai/swiftide/commit/8ced9072fcdae5053df337617333cac6c930031d) *(core)*  [**breaking**] Preserve exact command output ([#1134](https://github.com/bosun-ai/swiftide/pull/1134))
+
+**BREAKING CHANGE**: preserve exact command output ([#1134](https://github.com/bosun-ai/swiftide/pull/1134))
+
+- [2a0cb52](https://github.com/bosun-ai/swiftide/commit/2a0cb5253f2ce93c1021b29508e9eb96dd3b7dc9) *(core)*  [**breaking**] Separate command output streams ([#1146](https://github.com/bosun-ai/swiftide/pull/1146))
+
+**BREAKING CHANGE**: separate command output streams ([#1146](https://github.com/bosun-ai/swiftide/pull/1146))
+
+- [1c1dfc1](https://github.com/bosun-ai/swiftide/commit/1c1dfc1a1f5af56eb2f898132fe670fec191ddd3) *(core)*  [**breaking**] Split command output into stdout and stderr ([#1066](https://github.com/bosun-ai/swiftide/pull/1066))
+
+**BREAKING CHANGE**: split command output into stdout and stderr ([#1066](https://github.com/bosun-ai/swiftide/pull/1066))
+
+- [67998f9](https://github.com/bosun-ai/swiftide/commit/67998f94c6edfe1fa8e49b2804bdef35f66075e6) *(integrations)*  [**breaking**] Support AWS' new converse api ([#1026](https://github.com/bosun-ai/swiftide/pull/1026))
+
+**BREAKING CHANGE**: There is now a new AWS Bedrock integration. Because
+Converse is fundamentally different, it's named as `aws_bedrock_v2`.
+Inner content parts for chat messages now have a more generic structure
+so they are also usable for AWS Bedrock. Additionally, a lifetime is
+introduced for `ChatCompletionRequest` to get some quick wins.
+
+- [360b3af](https://github.com/bosun-ai/swiftide/commit/360b3af86ea85784741089aa72140ab079b5d048) *(integrations/openai)*  [**breaking**] Present and re-use reasoning in responses api ([#988](https://github.com/bosun-ai/swiftide/pull/988))
+
+**BREAKING CHANGE**: Adds a `ChatMessage::Reasoning` that will include both
+the summary and compressed reasoning, so follow up turns in agents can
+use it properly, and users can display the summary in the UI if they
+want.
+
+- [087943e](https://github.com/bosun-ai/swiftide/commit/087943ecc0493548cab019ca7e779c4c3963b4bc) *(openai)*  Support extra request body fields ([#1094](https://github.com/bosun-ai/swiftide/pull/1094))
+
+- [65d44f2](https://github.com/bosun-ai/swiftide/commit/65d44f2c4656eb20545750798a18fb877162f043) *(query)*  Add `original` and `current` question to `answers::Simple`
+
+- [d19fc1d](https://github.com/bosun-ai/swiftide/commit/d19fc1d47c9e555e3d78dc50c226dff711e70c6e) *(scraping)*  Optional Spider Cloud support ([#1125](https://github.com/bosun-ai/swiftide/pull/1125))
+
+- [1ee455d](https://github.com/bosun-ai/swiftide/commit/1ee455d9c4b739eea76505bfc0ec3774088926a3) *(tasks)*  [**breaking**] Add typed fan-out and joins ([#1047](https://github.com/bosun-ai/swiftide/pull/1047))
+
+**BREAKING CHANGE**: Tasks now support typed fan-out and explicit joins,
+which changes task completion, branch inspection, transition
+construction, and finish semantics.
+Update task code to return/match `TaskRunOutcome`, finish with
+`transitions_to_finish()`, build branches with
+
+- [4ff6adf](https://github.com/bosun-ai/swiftide/commit/4ff6adfe423a9442283579b15f2707e2cf8b1a62) *(tokenizer)*  Add default char estimator ([#917](https://github.com/bosun-ai/swiftide/pull/917))
+
+- [d791acd](https://github.com/bosun-ai/swiftide/commit/d791acddb803c9f054eff5a10f4b9e52ab1df7ec)  Add Mistral AI support ([#1082](https://github.com/bosun-ai/swiftide/pull/1082))
+
+- [3bb3a69](https://github.com/bosun-ai/swiftide/commit/3bb3a69379674d9fdfa90547e6c1562e742941fc)  Add pipeline statistics collection for monitoring and observability ([#1038](https://github.com/bosun-ai/swiftide/pull/1038))
+
+- [c3a51ff](https://github.com/bosun-ai/swiftide/commit/c3a51ffcd496b106705fe94082ade2c186787933)  Provider tool schema policies and autofix ([#1054](https://github.com/bosun-ai/swiftide/pull/1054))
+
+- [7a4d61a](https://github.com/bosun-ai/swiftide/commit/7a4d61a14fa4ae5c0cceee14d60bd423dc2afe7b)  Add usage details with normalized view ([#1013](https://github.com/bosun-ai/swiftide/pull/1013))
+
+- [dc48868](https://github.com/bosun-ai/swiftide/commit/dc488683e78fb69735bda5ca46e625b57838fe1f)  [**breaking**] Support images in chat completion ([#1007](https://github.com/bosun-ai/swiftide/pull/1007))
+
+**BREAKING CHANGE**: Adds a new variant to chat messages that for user and image parts.
+
+- [283fbcf](https://github.com/bosun-ai/swiftide/commit/283fbcfa9b161f99e216b2627301814e279c8c49)  Add `scoped_owned` variant for owned executors with working dir
+
+- [849ebf9](https://github.com/bosun-ai/swiftide/commit/849ebf9a2a7e8faa1061b64d21061b70ee8d0dac)  Add Bedrock Claude reasoning effort support ([#1063](https://github.com/bosun-ai/swiftide/pull/1063))
+
+### Bug fixes
+
+- [7e1e181](https://github.com/bosun-ai/swiftide/commit/7e1e1810ffee745baa032c4f9508827c5b92f6d6) *(agents)*  Always add reasoning items to history ([#1055](https://github.com/bosun-ai/swiftide/pull/1055))
+
+- [0a8dcdf](https://github.com/bosun-ai/swiftide/commit/0a8dcdf89269f39b54cc534b0322545f8205fac6) *(agents)*  Resolve pending tool calls before new user message on restart
+
+- [283b519](https://github.com/bosun-ai/swiftide/commit/283b519ededf9f14b7268cb752dd113d78efdd6f) *(bedrock)*  Trace Langfuse metadata on failures ([#1061](https://github.com/bosun-ai/swiftide/pull/1061))
+
+- [26e6d16](https://github.com/bosun-ai/swiftide/commit/26e6d162914f16517e4e3b0c52e12e97b770af3a) *(ci)*  Restore master checks ([#1132](https://github.com/bosun-ai/swiftide/pull/1132))
+
+- [9c9746c](https://github.com/bosun-ai/swiftide/commit/9c9746cda928f589f2d594e29e1e5a5d79cb8a6b) *(integrations)*  Stop selecting tls providers ([#1079](https://github.com/bosun-ai/swiftide/pull/1079))
+
+- [6b4d920](https://github.com/bosun-ai/swiftide/commit/6b4d920ba9a882f928ed15814a6a830799d15c16) *(integrations)*  Group adjacent tool results for Anthropic providers ([#1057](https://github.com/bosun-ai/swiftide/pull/1057))
+
+- [1dd4417](https://github.com/bosun-ai/swiftide/commit/1dd44173e7c8d0ad7612f6bbcd76f49b21b4d052) *(integrations/openai)*  Properly set default on reasoning features and exclude empty encrypted content ([#992](https://github.com/bosun-ai/swiftide/pull/992))
+
+- [69d1376](https://github.com/bosun-ai/swiftide/commit/69d1376b9475c30d11d3e003cf34c79a121cac28) *(integrations/openai)*  Only log model and usage for langfuse for embeddings ([#1021](https://github.com/bosun-ai/swiftide/pull/1021))
+
+- [d8f44cd](https://github.com/bosun-ai/swiftide/commit/d8f44cdb0f03930713c372e8623dccadd6959593) *(integrations/openai)*  Add reasoning items before all other items on response ([#993](https://github.com/bosun-ai/swiftide/pull/993))
+
+- [60be8ed](https://github.com/bosun-ai/swiftide/commit/60be8ed1731eb5474192df5665db0d34248a9a7b) *(integrations/redis)*  Extend owned should not overwrite history
+
+- [9e4f860](https://github.com/bosun-ai/swiftide/commit/9e4f860ad9f3ea8268d7362a4a83f9c7538da58e) *(macros)*  Expose tool argument descriptions ([#1110](https://github.com/bosun-ai/swiftide/pull/1110))
+
+- [e8503d4](https://github.com/bosun-ai/swiftide/commit/e8503d42c10a04d5fb425861b72e5e812a05817f) *(openai)*  Handle in-band provider errors ([#1150](https://github.com/bosun-ai/swiftide/pull/1150))
+
+- [dd558c6](https://github.com/bosun-ai/swiftide/commit/dd558c6a4cfe7880892a314dc503c761ade70bba) *(openai)*  Send reasoning effort to chat completions ([#1103](https://github.com/bosun-ai/swiftide/pull/1103))
+
+- [b28a1bb](https://github.com/bosun-ai/swiftide/commit/b28a1bb9b0b982165d9f5f641de43a4f147b90a1) *(query)*  Use current query in answers::Simple only if changed post retrieval
+
+- [5d65545](https://github.com/bosun-ai/swiftide/commit/5d65545fa8e8987dc5b7200aa211390438fa029a) *(query)*  Do not clear transformed query after retrieval
+
+- [5ddd8ec](https://github.com/bosun-ai/swiftide/commit/5ddd8ec85b1c6e7b329ce4e8bc4871b4415d0a5c)  Stabilize tool ordering in chat completion requests ([#1058](https://github.com/bosun-ai/swiftide/pull/1058))
+
+- [f81482f](https://github.com/bosun-ai/swiftide/commit/f81482fc166ebdef1795f401ebbd158599968a53)  Should accept str
+
+- [ab17637](https://github.com/bosun-ai/swiftide/commit/ab176378a8f2313a48aad3bd6c821497dc58a5c8)  Bedrock Langfuse request capture and span-close event loss ([#1072](https://github.com/bosun-ai/swiftide/pull/1072))
+
+- [fc72726](https://github.com/bosun-ai/swiftide/commit/fc72726fc7f523e9d8c42bc6828acde5e5370ddb)  Update to 1.x fixing RUSTSEC-2026-0189 ([#1105](https://github.com/bosun-ai/swiftide/pull/1105))
+
+### Miscellaneous
+
+- [a76ff4e](https://github.com/bosun-ai/swiftide/commit/a76ff4e57e21ca0fda48b6778e21bf0c021450d4) *(agents)*  [**breaking**] Use Prompt for system messages ([#1151](https://github.com/bosun-ai/swiftide/pull/1151))
+
+**BREAKING CHANGE**: use Prompt for system messages ([#1151](https://github.com/bosun-ai/swiftide/pull/1151))
+
+- [bcff57e](https://github.com/bosun-ai/swiftide/commit/bcff57e1bf38d8951784d482d1c8c9a3ecb3418a) *(deps)*  [**breaking**] Update dependencies ([#1133](https://github.com/bosun-ai/swiftide/pull/1133))
+
+**BREAKING CHANGE**: Swiftide now requires Rust 1.97. `ReasoningItem.id` is
+now `Option<String>`, and public SQLx, text-splitter, LanceDB, and
+DuckDB types follow their upgraded dependency APIs.
+
+- [3c8d069](https://github.com/bosun-ai/swiftide/commit/3c8d0697fcf97e292d0f754ed5b86c5b50d5c25b) *(deps)*  Update all crates ([#1031](https://github.com/bosun-ai/swiftide/pull/1031))
+
+- [8ffe4de](https://github.com/bosun-ai/swiftide/commit/8ffe4de799b30a707f0fb9013f3f90f61e2e2dc3) *(deps)*  Update all crates ([#984](https://github.com/bosun-ai/swiftide/pull/984))
+
+- [50510a5](https://github.com/bosun-ai/swiftide/commit/50510a530e681dd0a8eca841b1d31b9448760837) *(integrations/openai)*  Update async-openai to 0.31 ([#978](https://github.com/bosun-ai/swiftide/pull/978))
+
+- [55b5b3c](https://github.com/bosun-ai/swiftide/commit/55b5b3c3ba18a29637c4c5bf33d48a653ed474a2) *(integrations/tree-sitter)*  Log parse errors as warning instead of errors
+
+### Docs
+
+- [72d9211](https://github.com/bosun-ai/swiftide/commit/72d9211b9750b9cbe87861033a58ad95f24666b7)  Fix typo in README description ([#1114](https://github.com/bosun-ai/swiftide/pull/1114))
+
+- [e5fb532](https://github.com/bosun-ai/swiftide/commit/e5fb5326f0d737e5f558da94c8e96d1ca0e70600)  Refresh README around agent harness ([#1099](https://github.com/bosun-ai/swiftide/pull/1099))
+
+### Revert
+
+- [c6f1029](https://github.com/bosun-ai/swiftide/commit/c6f102980f91cc39b6c7b8ff82f1b7477508b6e0)  "feat: add Mistral AI support" ([#1083](https://github.com/bosun-ai/swiftide/pull/1083))
+
+
+**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.32.1...0.33.0
+
+
+
 ## [0.32.1](https://github.com/bosun-ai/swiftide/compare/v0.32.0...v0.32.1) - 2025-11-08
 
 ### New features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,7 +1447,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -10057,7 +10057,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swiftide"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arrow-array 58.4.0",
@@ -10089,7 +10089,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-agents"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10121,7 +10121,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-core"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-openai",
@@ -10155,7 +10155,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-examples"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -10179,7 +10179,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-indexing"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10209,7 +10209,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-integrations"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "arrow-array 58.4.0",
@@ -10297,7 +10297,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-langfuse"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10323,7 +10323,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-macros"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10347,7 +10347,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-query"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -10366,7 +10366,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-tasks"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -10381,7 +10381,7 @@ dependencies = [
 
 [[package]]
 name = "swiftide-test-utils"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "async-openai",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ default-members = ["swiftide", "swiftide-*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.32.1"
+version = "0.33.0"
 edition = "2024"
 rust-version = "1.97"
 license = "MIT"

--- a/swiftide-agents/Cargo.toml
+++ b/swiftide-agents/Cargo.toml
@@ -12,9 +12,9 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.32" }
-swiftide-tasks = { path = "../swiftide-tasks", version = "0.32" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.32" }
+swiftide-core = { path = "../swiftide-core", version = "0.33" }
+swiftide-tasks = { path = "../swiftide-tasks", version = "0.33" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.33" }
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.32" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.32" }
+swiftide-core = { path = "../swiftide-core", version = "0.33" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.33" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -12,8 +12,8 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.32" }
-swiftide-macros = { path = "../swiftide-macros", version = "0.32" }
+swiftide-core = { path = "../swiftide-core", version = "0.33" }
+swiftide-macros = { path = "../swiftide-macros", version = "0.33" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/swiftide-langfuse/Cargo.toml
+++ b/swiftide-langfuse/Cargo.toml
@@ -35,7 +35,7 @@ reqwest = { version = "^0.13", default-features = false, features = [
 anyhow.workspace = true
 async-trait.workspace = true
 dyn-clone.workspace = true
-swiftide-core = { path = "../swiftide-core", version = "0.32" }
+swiftide-core = { path = "../swiftide-core", version = "0.33" }
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/swiftide-query/Cargo.toml
+++ b/swiftide-query/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 tera = { workspace = true }
 
 # Internal
-swiftide-core = { path = "../swiftide-core", version = "0.32.1" }
+swiftide-core = { path = "../swiftide-core", version = "0.33.0" }
 
 [dev-dependencies]
 swiftide-core = { path = "../swiftide-core", features = ["test-utils"] }

--- a/swiftide-tasks/Cargo.toml
+++ b/swiftide-tasks/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 homepage.workspace = true
 
 [dependencies]
-swiftide-core = { path = "../swiftide-core", version = "0.32" }
+swiftide-core = { path = "../swiftide-core", version = "0.33" }
 async-trait.workspace = true
 dyn-clone.workspace = true
 futures-util.workspace = true

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -25,14 +25,14 @@ include = [
 document-features = { workspace = true }
 
 # Local dependencies
-swiftide-core = { path = "../swiftide-core", version = "0.32" }
-swiftide-integrations = { path = "../swiftide-integrations", version = "0.32" }
-swiftide-indexing = { path = "../swiftide-indexing", version = "0.32" }
-swiftide-query = { path = "../swiftide-query", version = "0.32" }
-swiftide-tasks = { path = "../swiftide-tasks", version = "0.32", optional = true }
-swiftide-agents = { path = "../swiftide-agents", version = "0.32", optional = true }
-swiftide-macros = { path = "../swiftide-macros", version = "0.32", optional = true }
-swiftide-langfuse = { path = "../swiftide-langfuse", version = "0.32", optional = true }
+swiftide-core = { path = "../swiftide-core", version = "0.33" }
+swiftide-integrations = { path = "../swiftide-integrations", version = "0.33" }
+swiftide-indexing = { path = "../swiftide-indexing", version = "0.33" }
+swiftide-query = { path = "../swiftide-query", version = "0.33" }
+swiftide-tasks = { path = "../swiftide-tasks", version = "0.33", optional = true }
+swiftide-agents = { path = "../swiftide-agents", version = "0.33", optional = true }
+swiftide-macros = { path = "../swiftide-macros", version = "0.33", optional = true }
+swiftide-langfuse = { path = "../swiftide-langfuse", version = "0.33", optional = true }
 
 # Re-exports for macros and ease of use
 anyhow.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `swiftide-core`: 0.32.1 -> 0.33.0 (⚠ API breaking changes)
* `swiftide-macros`: 0.32.1 -> 0.33.0
* `swiftide-indexing`: 0.32.1 -> 0.33.0 (✓ API compatible changes)
* `swiftide-tasks`: 0.32.1 -> 0.33.0
* `swiftide-agents`: 0.32.1 -> 0.33.0 (⚠ API breaking changes)
* `swiftide-integrations`: 0.32.1 -> 0.33.0 (✓ API compatible changes)
* `swiftide-langfuse`: 0.32.1 -> 0.33.0 (⚠ API breaking changes)
* `swiftide-query`: 0.32.1 -> 0.33.0 (✓ API compatible changes)
* `swiftide`: 0.32.1 -> 0.33.0 (✓ API compatible changes)

### ⚠ `swiftide-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Usage.details in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/chat_completion/chat_completion_response.rs:65
  field ChatCompletionResponse.reasoning in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/chat_completion/chat_completion_response.rs:32

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field CommandOutput.chunks in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/command_output.rs:31
  field CommandOutput.chunks in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/command_output.rs:31

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant ChatMessage:UserWithParts in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/chat_completion/chat_message.rs:268
  variant ChatMessage:Reasoning in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/chat_completion/chat_message.rs:271

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_core::chat_completion::ChatCompletionRequestBuilder::tools_spec takes 1 generic types instead of 0, in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/chat_completion/chat_completion_request.rs:61

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod swiftide_core::tokenizer, previously in file /tmp/.tmpsJuxou/swiftide-core/src/tokenizer.rs:1

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field output of struct CommandOutput, previously in file /tmp/.tmpsJuxou/swiftide-core/src/agent_traits.rs:356
  field output of struct CommandOutput, previously in file /tmp/.tmpsJuxou/swiftide-core/src/agent_traits.rs:356

--- failure trait_method_added: pub trait method added ---

Description:
A non-sealed public trait added a new method without a default implementation, which breaks downstream implementations of the trait
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#trait-new-item-no-default
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_method_added.ron

Failed in:
  trait method swiftide_core::agent_traits::ExecutorExt::scoped_owned in file /tmp/.tmpcckWU6/swiftide/swiftide-core/src/tool_executor.rs:126
  trait method swiftide_core::ExecutorExt::scoped_owned in file /tmp/.tmpcckWU6/swiftide/swiftide-core/src/tool_executor.rs:126
  trait method swiftide_core::agent_traits::AgentContext::replace_history in file /tmp/.tmpcckWU6/swiftide/swiftide-core/src/agent_traits.rs:83
  trait method swiftide_core::AgentContext::replace_history in file /tmp/.tmpcckWU6/swiftide/swiftide-core/src/agent_traits.rs:83

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait swiftide_core::tokenizer::Estimatable, previously in file /tmp/.tmpsJuxou/swiftide-core/src/tokenizer.rs:16
  trait swiftide_core::tokenizer::EstimateTokens, previously in file /tmp/.tmpsJuxou/swiftide-core/src/tokenizer.rs:10

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct ChatCompletionRequestBuilder (0 -> 1 lifetime params) in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/chat_completion/chat_completion_request.rs:9
  Struct ChatCompletionRequest (0 -> 1 lifetime params) in /tmp/.tmpcckWU6/swiftide/swiftide-core/src/chat_completion/chat_completion_request.rs:11
```

### ⚠ `swiftide-agents` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum swiftide_agents::tasks::errors::TaskError, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/errors.rs:6
  enum swiftide_agents::tasks::transition::TransitionPayload, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/transition.rs:90
  enum swiftide_agents::system_prompt::SystemPromptBuilderError, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/system_prompt.rs:21

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_added.ron

Failed in:
  variant AgentError:UnfulfilledToolCalls in /tmp/.tmpcckWU6/swiftide/swiftide-agents/src/errors.rs:41

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  swiftide_agents::AgentBuilder::hooks takes 0 generic types instead of 1, in /tmp/.tmpcckWU6/swiftide/swiftide-agents/src/agent.rs:210

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod swiftide_agents::tasks::task, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/task.rs:1
  mod swiftide_agents::tasks::errors, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/errors.rs:1
  mod swiftide_agents::tasks::impls, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/impls.rs:1
  mod swiftide_agents::system_prompt, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/system_prompt.rs:1
  mod swiftide_agents::tasks::closures, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/closures.rs:1
  mod swiftide_agents::tasks::node, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/node.rs:1
  mod swiftide_agents::tasks::transition, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/transition.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct swiftide_agents::tasks::impls::TaskAgent, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/impls.rs:19
  struct swiftide_agents::tasks::errors::NodeError, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/errors.rs:57
  struct swiftide_agents::tasks::transition::MarkedTransitionPayload, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/transition.rs:110
  struct swiftide_agents::tasks::node::NodeId, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/node.rs:97
  struct swiftide_agents::tasks::transition::NextNode, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/transition.rs:63
  struct swiftide_agents::tasks::closures::SyncFn, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/closures.rs:11
  struct swiftide_agents::system_prompt::SystemPromptBuilder, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/system_prompt.rs:21
  struct swiftide_agents::tasks::node::NoopNode, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/node.rs:16
  struct swiftide_agents::system_prompt::SystemPrompt, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/system_prompt.rs:23
  struct swiftide_agents::tasks::task::Task, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/task.rs:24
  struct swiftide_agents::tasks::closures::AsyncFn, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/closures.rs:20

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/trait_missing.ron

Failed in:
  trait swiftide_agents::tasks::node::TaskNode, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/node.rs:47
  trait swiftide_agents::tasks::transition::TransitionFn, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/transition.rs:11
  trait swiftide_agents::tasks::node::NodeArg, previously in file /tmp/.tmpsJuxou/swiftide-agents/src/tasks/node.rs:11
```

### ⚠ `swiftide-langfuse` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/method_parameter_count_changed.ron

Failed in:
  swiftide_langfuse::LangfuseLayer::handle_span_close takes 1 parameters in /tmp/.tmpsJuxou/swiftide-langfuse/src/tracing_layer.rs:271, but now takes 2 parameters in /tmp/.tmpcckWU6/swiftide/swiftide-langfuse/src/tracing_layer.rs:252
  swiftide_langfuse::LangfuseLayer::handle_record takes 2 parameters in /tmp/.tmpsJuxou/swiftide-langfuse/src/tracing_layer.rs:311, but now takes 3 parameters in /tmp/.tmpcckWU6/swiftide/swiftide-langfuse/src/tracing_layer.rs:296
```

<details><summary><i><b>Changelog</b></i></summary><p>









## `swiftide`

<blockquote>

## [0.33.0](https://github.com/bosun-ai/swiftide/compare/v0.32.1...v0.33.0) - 2026-08-10

### New features

- [a94760d](https://github.com/bosun-ai/swiftide/commit/a94760d9cbaed552bf58bc667cc7a67141751fe6) *(indexing)*  Convenience `then_expand` alias for `then_chunk`

- [7ff5a43](https://github.com/bosun-ai/swiftide/commit/7ff5a43c61b3d2298970f9ca11c3a05d876e1148) *(agents)*  Allow fully overwriting agent history via context ([#997](https://github.com/bosun-ai/swiftide/pull/997))

- [5bc2a94](https://github.com/bosun-ai/swiftide/commit/5bc2a949e5a54333497a5b499eac62d793d8f96d) *(agents)*  Pass mutable agent to hooks ([#1112](https://github.com/bosun-ai/swiftide/pull/1112))

- [8ced907](https://github.com/bosun-ai/swiftide/commit/8ced9072fcdae5053df337617333cac6c930031d) *(core)*  [**breaking**] Preserve exact command output ([#1134](https://github.com/bosun-ai/swiftide/pull/1134))

**BREAKING CHANGE**: preserve exact command output ([#1134](https://github.com/bosun-ai/swiftide/pull/1134))

- [2a0cb52](https://github.com/bosun-ai/swiftide/commit/2a0cb5253f2ce93c1021b29508e9eb96dd3b7dc9) *(core)*  [**breaking**] Separate command output streams ([#1146](https://github.com/bosun-ai/swiftide/pull/1146))

**BREAKING CHANGE**: separate command output streams ([#1146](https://github.com/bosun-ai/swiftide/pull/1146))

- [1c1dfc1](https://github.com/bosun-ai/swiftide/commit/1c1dfc1a1f5af56eb2f898132fe670fec191ddd3) *(core)*  [**breaking**] Split command output into stdout and stderr ([#1066](https://github.com/bosun-ai/swiftide/pull/1066))

**BREAKING CHANGE**: split command output into stdout and stderr ([#1066](https://github.com/bosun-ai/swiftide/pull/1066))

- [67998f9](https://github.com/bosun-ai/swiftide/commit/67998f94c6edfe1fa8e49b2804bdef35f66075e6) *(integrations)*  [**breaking**] Support AWS' new converse api ([#1026](https://github.com/bosun-ai/swiftide/pull/1026))

**BREAKING CHANGE**: There is now a new AWS Bedrock integration. Because
Converse is fundamentally different, it's named as `aws_bedrock_v2`.
Inner content parts for chat messages now have a more generic structure
so they are also usable for AWS Bedrock. Additionally, a lifetime is
introduced for `ChatCompletionRequest` to get some quick wins.

- [360b3af](https://github.com/bosun-ai/swiftide/commit/360b3af86ea85784741089aa72140ab079b5d048) *(integrations/openai)*  [**breaking**] Present and re-use reasoning in responses api ([#988](https://github.com/bosun-ai/swiftide/pull/988))

**BREAKING CHANGE**: Adds a `ChatMessage::Reasoning` that will include both
the summary and compressed reasoning, so follow up turns in agents can
use it properly, and users can display the summary in the UI if they
want.

- [087943e](https://github.com/bosun-ai/swiftide/commit/087943ecc0493548cab019ca7e779c4c3963b4bc) *(openai)*  Support extra request body fields ([#1094](https://github.com/bosun-ai/swiftide/pull/1094))

- [65d44f2](https://github.com/bosun-ai/swiftide/commit/65d44f2c4656eb20545750798a18fb877162f043) *(query)*  Add `original` and `current` question to `answers::Simple`

- [d19fc1d](https://github.com/bosun-ai/swiftide/commit/d19fc1d47c9e555e3d78dc50c226dff711e70c6e) *(scraping)*  Optional Spider Cloud support ([#1125](https://github.com/bosun-ai/swiftide/pull/1125))

- [1ee455d](https://github.com/bosun-ai/swiftide/commit/1ee455d9c4b739eea76505bfc0ec3774088926a3) *(tasks)*  [**breaking**] Add typed fan-out and joins ([#1047](https://github.com/bosun-ai/swiftide/pull/1047))

**BREAKING CHANGE**: Tasks now support typed fan-out and explicit joins,
which changes task completion, branch inspection, transition
construction, and finish semantics.
Update task code to return/match `TaskRunOutcome`, finish with
`transitions_to_finish()`, build branches with

- [4ff6adf](https://github.com/bosun-ai/swiftide/commit/4ff6adfe423a9442283579b15f2707e2cf8b1a62) *(tokenizer)*  Add default char estimator ([#917](https://github.com/bosun-ai/swiftide/pull/917))

- [d791acd](https://github.com/bosun-ai/swiftide/commit/d791acddb803c9f054eff5a10f4b9e52ab1df7ec)  Add Mistral AI support ([#1082](https://github.com/bosun-ai/swiftide/pull/1082))

- [3bb3a69](https://github.com/bosun-ai/swiftide/commit/3bb3a69379674d9fdfa90547e6c1562e742941fc)  Add pipeline statistics collection for monitoring and observability ([#1038](https://github.com/bosun-ai/swiftide/pull/1038))

- [c3a51ff](https://github.com/bosun-ai/swiftide/commit/c3a51ffcd496b106705fe94082ade2c186787933)  Provider tool schema policies and autofix ([#1054](https://github.com/bosun-ai/swiftide/pull/1054))

- [7a4d61a](https://github.com/bosun-ai/swiftide/commit/7a4d61a14fa4ae5c0cceee14d60bd423dc2afe7b)  Add usage details with normalized view ([#1013](https://github.com/bosun-ai/swiftide/pull/1013))

- [dc48868](https://github.com/bosun-ai/swiftide/commit/dc488683e78fb69735bda5ca46e625b57838fe1f)  [**breaking**] Support images in chat completion ([#1007](https://github.com/bosun-ai/swiftide/pull/1007))

**BREAKING CHANGE**: Adds a new variant to chat messages that for user and image parts.

- [283fbcf](https://github.com/bosun-ai/swiftide/commit/283fbcfa9b161f99e216b2627301814e279c8c49)  Add `scoped_owned` variant for owned executors with working dir

- [849ebf9](https://github.com/bosun-ai/swiftide/commit/849ebf9a2a7e8faa1061b64d21061b70ee8d0dac)  Add Bedrock Claude reasoning effort support ([#1063](https://github.com/bosun-ai/swiftide/pull/1063))

### Bug fixes

- [7e1e181](https://github.com/bosun-ai/swiftide/commit/7e1e1810ffee745baa032c4f9508827c5b92f6d6) *(agents)*  Always add reasoning items to history ([#1055](https://github.com/bosun-ai/swiftide/pull/1055))

- [0a8dcdf](https://github.com/bosun-ai/swiftide/commit/0a8dcdf89269f39b54cc534b0322545f8205fac6) *(agents)*  Resolve pending tool calls before new user message on restart

- [283b519](https://github.com/bosun-ai/swiftide/commit/283b519ededf9f14b7268cb752dd113d78efdd6f) *(bedrock)*  Trace Langfuse metadata on failures ([#1061](https://github.com/bosun-ai/swiftide/pull/1061))

- [26e6d16](https://github.com/bosun-ai/swiftide/commit/26e6d162914f16517e4e3b0c52e12e97b770af3a) *(ci)*  Restore master checks ([#1132](https://github.com/bosun-ai/swiftide/pull/1132))

- [9c9746c](https://github.com/bosun-ai/swiftide/commit/9c9746cda928f589f2d594e29e1e5a5d79cb8a6b) *(integrations)*  Stop selecting tls providers ([#1079](https://github.com/bosun-ai/swiftide/pull/1079))

- [6b4d920](https://github.com/bosun-ai/swiftide/commit/6b4d920ba9a882f928ed15814a6a830799d15c16) *(integrations)*  Group adjacent tool results for Anthropic providers ([#1057](https://github.com/bosun-ai/swiftide/pull/1057))

- [1dd4417](https://github.com/bosun-ai/swiftide/commit/1dd44173e7c8d0ad7612f6bbcd76f49b21b4d052) *(integrations/openai)*  Properly set default on reasoning features and exclude empty encrypted content ([#992](https://github.com/bosun-ai/swiftide/pull/992))

- [69d1376](https://github.com/bosun-ai/swiftide/commit/69d1376b9475c30d11d3e003cf34c79a121cac28) *(integrations/openai)*  Only log model and usage for langfuse for embeddings ([#1021](https://github.com/bosun-ai/swiftide/pull/1021))

- [d8f44cd](https://github.com/bosun-ai/swiftide/commit/d8f44cdb0f03930713c372e8623dccadd6959593) *(integrations/openai)*  Add reasoning items before all other items on response ([#993](https://github.com/bosun-ai/swiftide/pull/993))

- [60be8ed](https://github.com/bosun-ai/swiftide/commit/60be8ed1731eb5474192df5665db0d34248a9a7b) *(integrations/redis)*  Extend owned should not overwrite history

- [9e4f860](https://github.com/bosun-ai/swiftide/commit/9e4f860ad9f3ea8268d7362a4a83f9c7538da58e) *(macros)*  Expose tool argument descriptions ([#1110](https://github.com/bosun-ai/swiftide/pull/1110))

- [e8503d4](https://github.com/bosun-ai/swiftide/commit/e8503d42c10a04d5fb425861b72e5e812a05817f) *(openai)*  Handle in-band provider errors ([#1150](https://github.com/bosun-ai/swiftide/pull/1150))

- [dd558c6](https://github.com/bosun-ai/swiftide/commit/dd558c6a4cfe7880892a314dc503c761ade70bba) *(openai)*  Send reasoning effort to chat completions ([#1103](https://github.com/bosun-ai/swiftide/pull/1103))

- [b28a1bb](https://github.com/bosun-ai/swiftide/commit/b28a1bb9b0b982165d9f5f641de43a4f147b90a1) *(query)*  Use current query in answers::Simple only if changed post retrieval

- [5d65545](https://github.com/bosun-ai/swiftide/commit/5d65545fa8e8987dc5b7200aa211390438fa029a) *(query)*  Do not clear transformed query after retrieval

- [3736ce7](https://github.com/bosun-ai/swiftide/commit/3736ce790b1d953f0ddbe2258d332d19545a6d47) *(tasks)*  Render node errors with display ([#1154](https://github.com/bosun-ai/swiftide/pull/1154))

- [5ddd8ec](https://github.com/bosun-ai/swiftide/commit/5ddd8ec85b1c6e7b329ce4e8bc4871b4415d0a5c)  Stabilize tool ordering in chat completion requests ([#1058](https://github.com/bosun-ai/swiftide/pull/1058))

- [f81482f](https://github.com/bosun-ai/swiftide/commit/f81482fc166ebdef1795f401ebbd158599968a53)  Should accept str

- [ab17637](https://github.com/bosun-ai/swiftide/commit/ab176378a8f2313a48aad3bd6c821497dc58a5c8)  Bedrock Langfuse request capture and span-close event loss ([#1072](https://github.com/bosun-ai/swiftide/pull/1072))

- [fc72726](https://github.com/bosun-ai/swiftide/commit/fc72726fc7f523e9d8c42bc6828acde5e5370ddb)  Update to 1.x fixing RUSTSEC-2026-0189 ([#1105](https://github.com/bosun-ai/swiftide/pull/1105))

### Miscellaneous

- [a76ff4e](https://github.com/bosun-ai/swiftide/commit/a76ff4e57e21ca0fda48b6778e21bf0c021450d4) *(agents)*  [**breaking**] Use Prompt for system messages ([#1151](https://github.com/bosun-ai/swiftide/pull/1151))

**BREAKING CHANGE**: use Prompt for system messages ([#1151](https://github.com/bosun-ai/swiftide/pull/1151))

- [bcff57e](https://github.com/bosun-ai/swiftide/commit/bcff57e1bf38d8951784d482d1c8c9a3ecb3418a) *(deps)*  [**breaking**] Update dependencies ([#1133](https://github.com/bosun-ai/swiftide/pull/1133))

**BREAKING CHANGE**: Swiftide now requires Rust 1.97. `ReasoningItem.id` is
now `Option<String>`, and public SQLx, text-splitter, LanceDB, and
DuckDB types follow their upgraded dependency APIs.

- [3c8d069](https://github.com/bosun-ai/swiftide/commit/3c8d0697fcf97e292d0f754ed5b86c5b50d5c25b) *(deps)*  Update all crates ([#1031](https://github.com/bosun-ai/swiftide/pull/1031))

- [8ffe4de](https://github.com/bosun-ai/swiftide/commit/8ffe4de799b30a707f0fb9013f3f90f61e2e2dc3) *(deps)*  Update all crates ([#984](https://github.com/bosun-ai/swiftide/pull/984))

- [50510a5](https://github.com/bosun-ai/swiftide/commit/50510a530e681dd0a8eca841b1d31b9448760837) *(integrations/openai)*  Update async-openai to 0.31 ([#978](https://github.com/bosun-ai/swiftide/pull/978))

- [55b5b3c](https://github.com/bosun-ai/swiftide/commit/55b5b3c3ba18a29637c4c5bf33d48a653ed474a2) *(integrations/tree-sitter)*  Log parse errors as warning instead of errors

### Docs

- [72d9211](https://github.com/bosun-ai/swiftide/commit/72d9211b9750b9cbe87861033a58ad95f24666b7)  Fix typo in README description ([#1114](https://github.com/bosun-ai/swiftide/pull/1114))

- [e5fb532](https://github.com/bosun-ai/swiftide/commit/e5fb5326f0d737e5f558da94c8e96d1ca0e70600)  Refresh README around agent harness ([#1099](https://github.com/bosun-ai/swiftide/pull/1099))

### Revert

- [c6f1029](https://github.com/bosun-ai/swiftide/commit/c6f102980f91cc39b6c7b8ff82f1b7477508b6e0)  "feat: add Mistral AI support" ([#1083](https://github.com/bosun-ai/swiftide/pull/1083))


**Full Changelog**: https://github.com/bosun-ai/swiftide/compare/0.32.1...0.33.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).