### PR TITLE
fix(bedrock): trace Langfuse metadata on failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10224,6 +10224,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-futures",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-c",
  "tree-sitter-c-sharp",

--- a/swiftide-core/src/statistics.rs
+++ b/swiftide-core/src/statistics.rs
@@ -22,9 +22,28 @@
 
 use std::{
     collections::HashMap,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        Mutex, MutexGuard,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{Duration, Instant},
 };
+
+const TWO_POW_32_F64: f64 = 4_294_967_296.0;
+
+fn lock_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn u64_to_f64(value: u64) -> f64 {
+    let upper = u32::try_from(value >> 32).expect("upper 32 bits always fit in u32");
+    let lower =
+        u32::try_from(value & u64::from(u32::MAX)).expect("lower 32 bits always fit in u32");
+
+    f64::from(upper) * TWO_POW_32_F64 + f64::from(lower)
+}
 
 /// Statistics for a single model's usage
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -105,7 +124,7 @@ impl PipelineStats {
         if duration.as_secs_f64() == 0.0 || self.nodes_processed == 0 {
             return None;
         }
-        Some(self.nodes_processed as f64 / duration.as_secs_f64())
+        Some(u64_to_f64(self.nodes_processed) / duration.as_secs_f64())
     }
 
     /// Returns the total number of tokens used across all models
@@ -143,9 +162,9 @@ pub struct StatsCollector {
     nodes_failed: AtomicU64,
     nodes_stored: AtomicU64,
     transformations_applied: AtomicU64,
-    token_usage: std::sync::Mutex<HashMap<String, ModelUsage>>,
-    started_at: std::sync::Mutex<Option<Instant>>,
-    completed_at: std::sync::Mutex<Option<Instant>>,
+    token_usage: Mutex<HashMap<String, ModelUsage>>,
+    started_at: Mutex<Option<Instant>>,
+    completed_at: Mutex<Option<Instant>>,
 }
 
 impl Default for StatsCollector {
@@ -163,21 +182,21 @@ impl StatsCollector {
             nodes_failed: AtomicU64::new(0),
             nodes_stored: AtomicU64::new(0),
             transformations_applied: AtomicU64::new(0),
-            token_usage: std::sync::Mutex::new(HashMap::new()),
-            started_at: std::sync::Mutex::new(None),
-            completed_at: std::sync::Mutex::new(None),
+            token_usage: Mutex::new(HashMap::new()),
+            started_at: Mutex::new(None),
+            completed_at: Mutex::new(None),
         }
     }
 
     /// Marks the pipeline as started
     pub fn start(&self) {
-        let mut started = self.started_at.lock().unwrap();
+        let mut started = lock_recover(&self.started_at);
         *started = Some(Instant::now());
     }
 
     /// Marks the pipeline as completed
     pub fn complete(&self) {
-        let mut completed = self.completed_at.lock().unwrap();
+        let mut completed = lock_recover(&self.completed_at);
         *completed = Some(Instant::now());
     }
 
@@ -217,10 +236,8 @@ impl StatsCollector {
         prompt_tokens: u64,
         completion_tokens: u64,
     ) {
-        let mut usage = self.token_usage.lock().unwrap();
-        let model_usage = usage
-            .entry(model.as_ref().to_string())
-            .or_insert_with(ModelUsage::new);
+        let mut usage = lock_recover(&self.token_usage);
+        let model_usage = usage.entry(model.as_ref().to_string()).or_default();
         model_usage.record(prompt_tokens, completion_tokens);
     }
 
@@ -232,9 +249,9 @@ impl StatsCollector {
             nodes_failed: self.nodes_failed.load(Ordering::Relaxed),
             nodes_stored: self.nodes_stored.load(Ordering::Relaxed),
             transformations_applied: self.transformations_applied.load(Ordering::Relaxed),
-            token_usage: self.token_usage.lock().unwrap().clone(),
-            started_at: *self.started_at.lock().unwrap(),
-            completed_at: *self.completed_at.lock().unwrap(),
+            token_usage: lock_recover(&self.token_usage).clone(),
+            started_at: *lock_recover(&self.started_at),
+            completed_at: *lock_recover(&self.completed_at),
         }
     }
 }
@@ -248,9 +265,9 @@ impl Clone for StatsCollector {
             transformations_applied: AtomicU64::new(
                 self.transformations_applied.load(Ordering::Relaxed),
             ),
-            token_usage: std::sync::Mutex::new(self.token_usage.lock().unwrap().clone()),
-            started_at: std::sync::Mutex::new(*self.started_at.lock().unwrap()),
-            completed_at: std::sync::Mutex::new(*self.completed_at.lock().unwrap()),
+            token_usage: Mutex::new(lock_recover(&self.token_usage).clone()),
+            started_at: Mutex::new(*lock_recover(&self.started_at)),
+            completed_at: Mutex::new(*lock_recover(&self.completed_at)),
         }
     }
 }

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -669,11 +669,7 @@ impl<T: Chunk> Pipeline<T> {
 
         if let Some(duration) = elapsed {
             let elapsed_secs = duration.as_secs_f64();
-            let nodes_per_sec = if elapsed_secs > 0.0 {
-                total_nodes as f64 / elapsed_secs
-            } else {
-                0.0
-            };
+            let nodes_per_sec = stats.nodes_per_second().unwrap_or(0.0);
 
             tracing::info!(
                 nodes_processed = total_nodes,

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -151,6 +151,7 @@ wiremock = { workspace = true }
 tokio-stream = { workspace = true }
 eventsource-stream.workspace = true
 aws-smithy-eventstream = "0.60.19"
+tracing-subscriber = { workspace = true }
 
 
 [features]

--- a/swiftide-integrations/src/aws_bedrock_v2/chat_completion.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/chat_completion.rs
@@ -68,7 +68,18 @@ impl ChatCompletion for AwsBedrock {
         let tracking_request: Option<serde_json::Value> = None;
 
         let (messages, system, inference_config, tool_config) =
-            build_converse_input(request, &self.default_options)?;
+            match build_converse_input(request, &self.default_options) {
+                Ok(parts) => parts,
+                Err(error) => {
+                    Self::track_failure(
+                        model,
+                        tracking_request.as_ref(),
+                        None::<&serde_json::Value>,
+                        &error,
+                    );
+                    return Err(error);
+                }
+            };
 
         tracing::debug!(
             model = model,
@@ -77,7 +88,7 @@ impl ChatCompletion for AwsBedrock {
             "[ChatCompletion] Request to bedrock converse"
         );
 
-        let response = self
+        let response = match self
             .client
             .converse(
                 model,
@@ -91,11 +102,34 @@ impl ChatCompletion for AwsBedrock {
                     .additional_model_response_field_paths
                     .clone(),
             )
-            .await?;
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                Self::track_failure(
+                    model,
+                    tracking_request.as_ref(),
+                    None::<&serde_json::Value>,
+                    &error,
+                );
+                return Err(error);
+            }
+        };
 
         tracing::debug!(response = ?response, "[ChatCompletion] Response from bedrock converse");
 
-        let completion = response_to_chat_completion(&response)?;
+        let completion = match response_to_chat_completion(&response) {
+            Ok(completion) => completion,
+            Err(error) => {
+                Self::track_failure(
+                    model,
+                    tracking_request.as_ref(),
+                    None::<&serde_json::Value>,
+                    &error,
+                );
+                return Err(error);
+            }
+        };
 
         if let Some(error) = super::context_length_exceeded_if_empty(
             completion.message.is_some(),
@@ -106,6 +140,7 @@ impl ChatCompletion for AwsBedrock {
                 .is_some_and(|reasoning| !reasoning.is_empty()),
             Some(response.stop_reason()),
         ) {
+            Self::track_failure(model, tracking_request.as_ref(), Some(&completion), &error);
             return Err(error);
         }
 
@@ -142,7 +177,15 @@ impl ChatCompletion for AwsBedrock {
         let (messages, system, inference_config, tool_config) =
             match build_converse_input(request, &self.default_options) {
                 Ok(parts) => parts,
-                Err(error) => return error.into(),
+                Err(error) => {
+                    Self::track_failure(
+                        &model,
+                        tracking_request.as_ref(),
+                        None::<&serde_json::Value>,
+                        &error,
+                    );
+                    return error.into();
+                }
             };
 
         let stream_output = match self
@@ -161,7 +204,15 @@ impl ChatCompletion for AwsBedrock {
             .await
         {
             Ok(stream_output) => stream_output,
-            Err(error) => return error.into(),
+            Err(error) => {
+                Self::track_failure(
+                    &model,
+                    tracking_request.as_ref(),
+                    None::<&serde_json::Value>,
+                    &error,
+                );
+                return error.into();
+            }
         };
 
         let self_for_stream = self.clone();
@@ -215,6 +266,12 @@ impl ChatCompletion for AwsBedrock {
                                     .is_some_and(|reasoning| !reasoning.is_empty()),
                                 stop_reason.as_ref(),
                             ) {
+                                Self::track_failure(
+                                    &model,
+                                    tracking_request.as_ref(),
+                                    Some(&response),
+                                    &error,
+                                );
                                 return Some((
                                     Err(error),
                                     (
@@ -262,19 +319,27 @@ impl ChatCompletion for AwsBedrock {
                                 ),
                             ))
                         }
-                        Err(error) => Some((
-                            Err(super::converse_stream_output_error_to_language_model_error(
-                                error,
-                            )),
-                            (
-                                event_stream,
-                                response,
-                                stop_reason,
-                                true,
-                                model,
-                                tracking_request,
-                            ),
-                        )),
+                        Err(error) => {
+                            let error =
+                                super::converse_stream_output_error_to_language_model_error(error);
+                            Self::track_failure(
+                                &model,
+                                tracking_request.as_ref(),
+                                Some(&response),
+                                &error,
+                            );
+                            Some((
+                                Err(error),
+                                (
+                                    event_stream,
+                                    response,
+                                    stop_reason,
+                                    true,
+                                    model,
+                                    tracking_request,
+                                ),
+                            ))
+                        }
                     }
                 }
             },
@@ -1192,6 +1257,8 @@ mod tests {
     };
 
     use super::*;
+    #[cfg(feature = "langfuse")]
+    use crate::aws_bedrock_v2::test_utils::run_with_langfuse_event_capture;
     use crate::aws_bedrock_v2::{
         AwsBedrock, MockBedrockConverse,
         test_utils::{TEST_MODEL_ID, bedrock_client_for_mock_server, converse_stream_event},
@@ -1311,6 +1378,58 @@ mod tests {
             serde_json::json!({"location":"Amsterdam"})
         );
         assert_eq!(response.usage.unwrap().total_tokens, 18);
+    }
+
+    #[cfg(feature = "langfuse")]
+    #[test]
+    fn test_complete_tracks_langfuse_failure_metadata_on_converse_error() {
+        let mut bedrock_mock = MockBedrockConverse::new();
+
+        bedrock_mock
+            .expect_converse()
+            .once()
+            .returning(|_, _, _, _, _, _, _, _| {
+                Err(LanguageModelError::permanent("bedrock request failed"))
+            });
+
+        let bedrock = AwsBedrock::builder()
+            .test_client(bedrock_mock)
+            .default_prompt_model("anthropic.claude-3-5-sonnet-20241022-v2:0")
+            .build()
+            .unwrap();
+
+        let request = ChatCompletionRequest::builder()
+            .messages(vec![ChatMessage::User("Trace this failure".into())])
+            .build()
+            .unwrap();
+
+        let (result, events) =
+            run_with_langfuse_event_capture(|| async { bedrock.complete(&request).await });
+
+        let error = result.expect_err("request should fail");
+        assert!(error.to_string().contains("bedrock request failed"));
+
+        let failure_event = events
+            .iter()
+            .find(|event| event.contains_key("langfuse.status_message"))
+            .expect("langfuse failure event");
+
+        assert_eq!(
+            failure_event
+                .get("langfuse.model")
+                .map(std::string::String::as_str),
+            Some("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        );
+        assert!(
+            failure_event
+                .get("langfuse.input")
+                .is_some_and(|input| input.contains("Trace this failure"))
+        );
+        assert!(
+            failure_event
+                .get("langfuse.status_message")
+                .is_some_and(|message| message.contains("bedrock request failed"))
+        );
     }
 
     #[test_log::test(tokio::test)]
@@ -1447,6 +1566,54 @@ mod tests {
         let first = stream.next().await.expect("stream should yield one item");
         assert!(matches!(first, Err(LanguageModelError::PermanentError(_))));
         assert!(stream.next().await.is_none());
+    }
+
+    #[cfg(feature = "langfuse")]
+    #[test]
+    fn test_complete_stream_tracks_langfuse_failure_metadata_on_stream_error() {
+        let mut bedrock_mock = MockBedrockConverse::new();
+
+        bedrock_mock
+            .expect_converse_stream()
+            .once()
+            .returning(|_, _, _, _, _, _, _| {
+                Err(LanguageModelError::transient("bedrock stream failed"))
+            });
+
+        let bedrock = AwsBedrock::builder()
+            .test_client(bedrock_mock)
+            .default_prompt_model("anthropic.claude-3-5-sonnet-20241022-v2:0")
+            .build()
+            .unwrap();
+
+        let request = ChatCompletionRequest::builder()
+            .messages(vec![ChatMessage::new_user("Stream this failure")])
+            .build()
+            .unwrap();
+
+        let (first_item, events) = run_with_langfuse_event_capture(|| async {
+            let mut stream = bedrock.complete_stream(&request).await;
+            stream.next().await.expect("stream should yield an error")
+        });
+
+        let error = first_item.expect_err("stream should fail");
+        assert!(error.to_string().contains("bedrock stream failed"));
+
+        let failure_event = events
+            .iter()
+            .find(|event| event.contains_key("langfuse.status_message"))
+            .expect("langfuse failure event");
+
+        assert!(
+            failure_event
+                .get("langfuse.input")
+                .is_some_and(|input| input.contains("Stream this failure"))
+        );
+        assert!(
+            failure_event
+                .get("langfuse.status_message")
+                .is_some_and(|message| message.contains("bedrock stream failed"))
+        );
     }
 
     #[test_log::test(tokio::test)]

--- a/swiftide-integrations/src/aws_bedrock_v2/mod.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/mod.rs
@@ -226,6 +226,25 @@ impl AwsBedrock {
 
         Ok(())
     }
+
+    #[allow(unused_variables)]
+    fn track_failure<R, S>(
+        model: &str,
+        request: Option<&R>,
+        response: Option<&S>,
+        error: &LanguageModelError,
+    ) where
+        R: Serialize + ?Sized,
+        S: Serialize + ?Sized,
+    {
+        #[cfg(feature = "langfuse")]
+        tracing::debug!(
+            langfuse.model = model,
+            langfuse.input = request.and_then(langfuse_json_redacted).unwrap_or_default(),
+            langfuse.output = response.and_then(langfuse_json).unwrap_or_default(),
+            langfuse.status_message = error.to_string(),
+        );
+    }
 }
 
 impl AwsBedrockBuilder {

--- a/swiftide-integrations/src/aws_bedrock_v2/structured_prompt.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/structured_prompt.rs
@@ -58,7 +58,7 @@ impl DynStructuredPrompt for AwsBedrock {
             )
             .build();
 
-        let response = self
+        let response = match self
             .client
             .converse(
                 model,
@@ -72,9 +72,32 @@ impl DynStructuredPrompt for AwsBedrock {
                     .additional_model_response_field_paths
                     .clone(),
             )
-            .await?;
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                Self::track_failure(
+                    model,
+                    tracking_request.as_ref(),
+                    None::<&serde_json::Value>,
+                    &error,
+                );
+                return Err(error);
+            }
+        };
 
-        let completion = super::chat_completion::response_to_chat_completion(&response)?;
+        let completion = match super::chat_completion::response_to_chat_completion(&response) {
+            Ok(completion) => completion,
+            Err(error) => {
+                Self::track_failure(
+                    model,
+                    tracking_request.as_ref(),
+                    None::<&serde_json::Value>,
+                    &error,
+                );
+                return Err(error);
+            }
+        };
 
         self.track_completion(
             model,
@@ -84,7 +107,7 @@ impl DynStructuredPrompt for AwsBedrock {
         )
         .await?;
 
-        let Some(response_text) = completion.message else {
+        let Some(ref response_text) = completion.message else {
             if let Some(error) = super::context_length_exceeded_if_empty(
                 false,
                 completion.tool_calls.is_some(),
@@ -94,17 +117,24 @@ impl DynStructuredPrompt for AwsBedrock {
                     .is_some_and(|reasoning| !reasoning.is_empty()),
                 Some(response.stop_reason()),
             ) {
+                Self::track_failure(model, tracking_request.as_ref(), Some(&completion), &error);
                 return Err(error);
             }
 
-            return Err(LanguageModelError::permanent("No text in response"));
+            let error = LanguageModelError::permanent("No text in response");
+            Self::track_failure(model, tracking_request.as_ref(), Some(&completion), &error);
+            return Err(error);
         };
 
-        serde_json::from_str(response_text.trim()).map_err(|error| {
-            LanguageModelError::permanent(anyhow::anyhow!(
-                "Failed to parse model response as JSON: {error}"
-            ))
-        })
+        serde_json::from_str(response_text.trim())
+            .map_err(|error| {
+                LanguageModelError::permanent(anyhow::anyhow!(
+                    "Failed to parse model response as JSON: {error}"
+                ))
+            })
+            .inspect_err(|error| {
+                Self::track_failure(model, tracking_request.as_ref(), Some(&completion), error);
+            })
     }
 }
 
@@ -133,6 +163,8 @@ mod tests {
     };
 
     use super::*;
+    #[cfg(feature = "langfuse")]
+    use crate::aws_bedrock_v2::test_utils::run_with_langfuse_event_capture;
     use crate::aws_bedrock_v2::{
         AwsBedrock, MockBedrockConverse,
         test_utils::{TEST_MODEL_ID, bedrock_client_for_mock_server},
@@ -211,6 +243,59 @@ mod tests {
             StructuredOutput {
                 answer: "42".to_string()
             }
+        );
+    }
+
+    #[cfg(feature = "langfuse")]
+    #[test]
+    fn test_structured_prompt_tracks_langfuse_failure_metadata_on_converse_error() {
+        let mut bedrock_mock = MockBedrockConverse::new();
+
+        bedrock_mock
+            .expect_converse()
+            .once()
+            .returning(|_, _, _, _, _, _, _, _| {
+                Err(LanguageModelError::permanent("structured prompt failed"))
+            });
+
+        let bedrock = AwsBedrock::builder()
+            .test_client(bedrock_mock)
+            .default_prompt_model("anthropic.claude-3-5-sonnet-20241022-v2:0")
+            .build()
+            .unwrap();
+
+        let (result, events) = run_with_langfuse_event_capture(|| async {
+            bedrock
+                .structured_prompt_dyn(
+                    "Summarize this failure".into(),
+                    schema_for!(StructuredOutput),
+                )
+                .await
+        });
+
+        let error = result.expect_err("request should fail");
+        assert!(error.to_string().contains("structured prompt failed"));
+
+        let failure_event = events
+            .iter()
+            .find(|event| event.contains_key("langfuse.status_message"))
+            .expect("langfuse failure event");
+
+        assert_eq!(
+            failure_event
+                .get("langfuse.model")
+                .map(std::string::String::as_str),
+            Some("anthropic.claude-3-5-sonnet-20241022-v2:0")
+        );
+        assert!(
+            failure_event
+                .get("langfuse.input")
+                .is_some_and(|input| input.contains("Summarize this failure"))
+        );
+        assert!(
+            failure_event
+                .get("langfuse.status_message")
+                .is_some_and(|message| message.contains("structured prompt failed"))
         );
     }
 

--- a/swiftide-integrations/src/aws_bedrock_v2/test_utils.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/test_utils.rs
@@ -37,3 +37,90 @@ pub(crate) fn converse_stream_event(event_type: &str, payload: &Value) -> Vec<u8
         .expect("encode event stream frame");
     bytes
 }
+
+#[cfg(feature = "langfuse")]
+pub(crate) type RecordedTracingEvent = std::collections::HashMap<String, String>;
+
+#[cfg(feature = "langfuse")]
+#[derive(Clone)]
+struct EventCaptureLayer {
+    events: std::sync::Arc<std::sync::Mutex<Vec<RecordedTracingEvent>>>,
+}
+
+#[cfg(feature = "langfuse")]
+#[derive(Default)]
+struct EventFieldVisitor {
+    fields: RecordedTracingEvent,
+}
+
+#[cfg(feature = "langfuse")]
+impl tracing::field::Visit for EventFieldVisitor {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields
+            .insert(field.name().to_string(), format!("{value:?}"));
+    }
+}
+
+#[cfg(feature = "langfuse")]
+impl<S> tracing_subscriber::Layer<S> for EventCaptureLayer
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = EventFieldVisitor::default();
+        event.record(&mut visitor);
+        self.events.lock().unwrap().push(visitor.fields);
+    }
+}
+
+#[cfg(feature = "langfuse")]
+pub(crate) fn run_with_langfuse_event_capture<F, Fut, T>(
+    future_factory: F,
+) -> (T, Vec<RecordedTracingEvent>)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    use tracing_subscriber::prelude::*;
+
+    let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let subscriber = tracing_subscriber::registry().with(EventCaptureLayer {
+        events: events.clone(),
+    });
+    let dispatch = tracing::Dispatch::new(subscriber);
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("test runtime");
+
+    let result =
+        tracing::dispatcher::with_default(&dispatch, || runtime.block_on(future_factory()));
+
+    let recorded_events = events.lock().expect("event capture mutex").clone();
+
+    (result, recorded_events)
+}


### PR DESCRIPTION
## Summary
- emit Langfuse failure metadata for Bedrock chat completions, streaming starts, and structured prompts
- preserve the original Bedrock/model error while attaching `langfuse.input`, `langfuse.output` when available, and `langfuse.status_message`
- add regression tests that capture tracing events for failed Bedrock requests under the `langfuse` feature

## Testing
- cargo +nightly fmt --all
- cargo +stable test -p swiftide-integrations --features "aws-bedrock langfuse" aws_bedrock_v2::
- cargo +stable clippy -p swiftide-integrations --tests --no-deps --features "aws-bedrock langfuse" -- -D warnings
- cargo clippy --all-targets --all-features --workspace
