### PR TITLE
feat: Add Bedrock Claude reasoning effort support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,13 @@ Swiftide is a Rust workspace driven by the library in `swiftide/`, with supporti
 - `cargo check --workspace --all-features` quickly verifies the entire workspace compiles with all feature flags enabled.
 - `cargo build --workspace --all-features` compiles every crate and surfaces feature-gating issues early.
 - `cargo check -p swiftide-agents` is a fast way to probe agent changes before touching the rest of the workspace.
-- `cargo +nightly fmt --all` applies the repo `rustfmt.toml` (comment wrapping requires nightly).
-- `cargo clippy --workspace --all-targets --all-features -D warnings` keeps us aligned with the pedantic lint profile baked into `Cargo.toml`.
-- `cargo test --workspace` runs unit and integration suites; use `RUST_LOG=info` if you need verbose diagnostics.
+- `cargo +nightly fmt --all` applies the repo `rustfmt.toml` (comment wrapping requires nightly); use `cargo +nightly fmt --all -- --check` to mirror CI formatting validation.
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` mirrors the main lint job and keeps us aligned with the pedantic lint profile baked into `Cargo.toml`.
+- `cargo test -j 2 --tests --all-features --no-fail-fast` mirrors the main CI test job for unit and integration tests.
+- `cargo test --doc --all-features --no-fail-fast` mirrors the docs test job in CI.
+- `cargo hack check --each-feature --no-dev-deps` mirrors the Cargo Hack feature-matrix check run in CI.
+- `typos` mirrors the spelling check run in CI.
+- `cargo test --workspace` is still useful locally when you want a broader default test sweep; use `RUST_LOG=info` if you need verbose diagnostics.
 - Snapshot updates flow through `cargo insta review` after tests rewrite `.snap` files.
 
 ## Coding Style & Naming Conventions
@@ -24,7 +28,7 @@ Prefer focused crate runs such as `cargo test -p swiftide-integrations` when ite
 
 ## Commit & Pull Request Guidelines
 
-Commits follow conventional syntax (`feat(agents): …`, `fix(indexing): …`) with a lowercase imperative summary. Each PR should describe the change, link any GitHub issue, note API or schema impacts, and include before/after traces or logs when behavior changes. Update docs (README, website, or inline rustdoc) and add tests or benchmarks alongside functional work. Before requesting review, run the full lint and test suite listed above.
+Commits follow conventional syntax (`feat(agents): …`, `fix(indexing): …`) with a lowercase imperative summary. Pull request titles are also checked against the conventional commits format in CI, and titles ending in `!` receive the `breaking change` label automatically. Each PR should describe the change, link any GitHub issue, note API or schema impacts, and include before/after traces or logs when behavior changes. Update docs (README, website, or inline rustdoc) and add tests or benchmarks alongside functional work. Before requesting review, run the full lint and test suite listed above.
 
 ## Tooling & Environment Notes
 

--- a/swiftide-integrations/src/aws_bedrock_v2/chat_completion.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/chat_completion.rs
@@ -80,6 +80,20 @@ impl ChatCompletion for AwsBedrock {
                     return Err(error);
                 }
             };
+        let additional_model_request_fields =
+            match super::additional_model_request_fields_from_options(model, &self.default_options)
+            {
+                Ok(fields) => fields,
+                Err(error) => {
+                    Self::track_failure(
+                        model,
+                        tracking_request.as_ref(),
+                        None::<&serde_json::Value>,
+                        &error,
+                    );
+                    return Err(error);
+                }
+            };
 
         tracing::debug!(
             model = model,
@@ -97,7 +111,7 @@ impl ChatCompletion for AwsBedrock {
                 inference_config,
                 tool_config,
                 None,
-                self.default_options.additional_model_request_fields.clone(),
+                additional_model_request_fields,
                 self.default_options
                     .additional_model_response_field_paths
                     .clone(),
@@ -187,6 +201,20 @@ impl ChatCompletion for AwsBedrock {
                     return error.into();
                 }
             };
+        let additional_model_request_fields =
+            match super::additional_model_request_fields_from_options(&model, &self.default_options)
+            {
+                Ok(fields) => fields,
+                Err(error) => {
+                    Self::track_failure(
+                        &model,
+                        tracking_request.as_ref(),
+                        None::<&serde_json::Value>,
+                        &error,
+                    );
+                    return error.into();
+                }
+            };
 
         let stream_output = match self
             .client
@@ -196,7 +224,7 @@ impl ChatCompletion for AwsBedrock {
                 system,
                 inference_config,
                 tool_config,
-                self.default_options.additional_model_request_fields.clone(),
+                additional_model_request_fields,
                 self.default_options
                     .additional_model_response_field_paths
                     .clone(),
@@ -1260,7 +1288,7 @@ mod tests {
     #[cfg(feature = "langfuse")]
     use crate::aws_bedrock_v2::test_utils::run_with_langfuse_event_capture;
     use crate::aws_bedrock_v2::{
-        AwsBedrock, MockBedrockConverse,
+        AwsBedrock, MockBedrockConverse, ReasoningEffort,
         test_utils::{TEST_MODEL_ID, bedrock_client_for_mock_server, converse_stream_event},
     };
 
@@ -1480,6 +1508,83 @@ mod tests {
             .default_options(Options {
                 additional_model_request_fields: Some(request_fields),
                 additional_model_response_field_paths: Some(vec!["/thinking".to_string()]),
+                ..Default::default()
+            })
+            .build()
+            .unwrap();
+
+        let request = ChatCompletionRequest::builder()
+            .messages(vec![ChatMessage::User("Hello".into())])
+            .build()
+            .unwrap();
+
+        let _ = bedrock.complete(&request).await.unwrap();
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_complete_passes_reasoning_effort_for_claude_opus_4_5() {
+        let mut bedrock_mock = MockBedrockConverse::new();
+
+        let mut thinking = HashMap::new();
+        thinking.insert("type".to_string(), Document::String("enabled".to_string()));
+        thinking.insert("budget_tokens".to_string(), Document::from(512_u64));
+        let mut request_fields = HashMap::new();
+        request_fields.insert("thinking".to_string(), Document::Object(thinking));
+        let request_fields = Document::Object(request_fields);
+
+        bedrock_mock
+            .expect_converse()
+            .once()
+            .withf(
+                |model_id,
+                 _,
+                 _,
+                 _,
+                 _,
+                 _,
+                 additional_model_request_fields,
+                 _additional_model_response_field_paths| {
+                    model_id == "anthropic.claude-opus-4-5-20251101-v1:0"
+                        && additional_model_request_fields
+                            .as_ref()
+                            .is_some_and(|fields| {
+                                let Some(fields) = fields.as_object() else {
+                                    return false;
+                                };
+
+                                let effort_matches = fields
+                                    .get("output_config")
+                                    .and_then(Document::as_object)
+                                    .and_then(|output_config| output_config.get("effort"))
+                                    .and_then(Document::as_string)
+                                    == Some("medium");
+                                let thinking_matches = fields
+                                    .get("thinking")
+                                    .and_then(Document::as_object)
+                                    .and_then(|thinking| thinking.get("type"))
+                                    .and_then(Document::as_string)
+                                    == Some("enabled");
+                                let beta_matches = fields
+                                    .get("anthropic_beta")
+                                    .and_then(Document::as_array)
+                                    .is_some_and(|betas| {
+                                        betas.iter().any(|beta| {
+                                            beta.as_string() == Some("effort-2025-11-24")
+                                        })
+                                    });
+
+                                effort_matches && thinking_matches && beta_matches
+                            })
+                },
+            )
+            .returning(|_, _, _, _, _, _, _, _| Ok(response_with_text_and_tool_call()));
+
+        let bedrock = AwsBedrock::builder()
+            .test_client(bedrock_mock)
+            .default_prompt_model("anthropic.claude-opus-4-5-20251101-v1:0")
+            .default_options(Options {
+                reasoning_effort: Some(ReasoningEffort::Medium),
+                additional_model_request_fields: Some(request_fields),
                 ..Default::default()
             })
             .build()

--- a/swiftide-integrations/src/aws_bedrock_v2/mod.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/mod.rs
@@ -76,6 +76,31 @@ impl std::fmt::Debug for AwsBedrock {
     }
 }
 
+/// Anthropic Claude effort guidance for Bedrock model-specific request fields.
+///
+/// Bedrock currently documents the following support:
+/// - Claude Opus 4.5: `low`, `medium`, `high` via the `effort-2025-11-24` beta header.
+/// - Claude Opus 4.6 adaptive thinking: `low`, `medium`, `high`, `max` with no beta header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ReasoningEffort {
+    Low,
+    Medium,
+    High,
+    Max,
+}
+
+impl ReasoningEffort {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Max => "max",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Builder, Default)]
 #[builder(setter(strip_option))]
 pub struct Options {
@@ -104,6 +129,25 @@ pub struct Options {
     /// Defaults to `true` when not set.
     #[builder(default)]
     pub tool_strict: Option<bool>,
+
+    /// Anthropic beta headers forwarded through Bedrock model-specific request fields.
+    ///
+    /// This is useful for Anthropic features on Bedrock that require `anthropic_beta`.
+    #[builder(default, setter(into))]
+    pub anthropic_beta: Option<Vec<String>>,
+
+    /// Anthropic Claude reasoning/token spend guidance forwarded through Bedrock
+    /// `additional_model_request_fields.output_config.effort`.
+    ///
+    /// For Claude Opus 4.5, Bedrock requires the `effort-2025-11-24` beta header. Swiftide adds
+    /// that header automatically when the configured model ID clearly identifies Claude Opus 4.5.
+    /// If you route through an inference profile or ARN, also set `anthropic_beta` explicitly.
+    ///
+    /// For Claude Opus 4.6 adaptive thinking, Bedrock documents `max` in addition to the other
+    /// levels. Use `additional_model_request_fields` to set `thinking.type = "adaptive"` when
+    /// needed.
+    #[builder(default)]
+    pub reasoning_effort: Option<ReasoningEffort>,
 
     /// Provider-specific model request parameters passed to Converse.
     ///
@@ -143,6 +187,12 @@ impl Options {
         }
         if let Some(tool_strict) = other.tool_strict {
             self.tool_strict = Some(tool_strict);
+        }
+        if let Some(anthropic_beta) = other.anthropic_beta {
+            self.anthropic_beta = Some(anthropic_beta);
+        }
+        if let Some(reasoning_effort) = other.reasoning_effort {
+            self.reasoning_effort = Some(reasoning_effort);
         }
         if let Some(additional_model_request_fields) = other.additional_model_request_fields {
             self.additional_model_request_fields = Some(additional_model_request_fields);
@@ -541,6 +591,90 @@ fn inference_config_from_options(options: &Options) -> Option<InferenceConfigura
     has_any_value.then(|| builder.build())
 }
 
+fn additional_model_request_fields_from_options(
+    model: &str,
+    options: &Options,
+) -> Result<Option<Document>, LanguageModelError> {
+    if options.reasoning_effort.is_none() && options.anthropic_beta.is_none() {
+        return Ok(options.additional_model_request_fields.clone());
+    }
+
+    let mut fields = match options.additional_model_request_fields.clone() {
+        Some(Document::Object(fields)) => fields,
+        Some(_) => {
+            return Err(LanguageModelError::permanent(
+                "Bedrock additional_model_request_fields must be an object when using anthropic_beta or reasoning_effort",
+            ));
+        }
+        None => std::collections::HashMap::new(),
+    };
+
+    if let Some(reasoning_effort) = options.reasoning_effort {
+        let mut output_config = match fields.remove("output_config") {
+            Some(Document::Object(output_config)) => output_config,
+            Some(_) => {
+                return Err(LanguageModelError::permanent(
+                    "Bedrock additional_model_request_fields.output_config must be an object when using reasoning_effort",
+                ));
+            }
+            None => std::collections::HashMap::new(),
+        };
+
+        output_config.insert(
+            "effort".to_string(),
+            Document::String(reasoning_effort.as_str().to_string()),
+        );
+        fields.insert("output_config".to_string(), Document::Object(output_config));
+    }
+
+    let mut anthropic_beta = match fields.remove("anthropic_beta") {
+        Some(Document::Array(items)) => items
+            .into_iter()
+            .map(document_string)
+            .collect::<Result<Vec<_>, _>>()?,
+        Some(_) => {
+            return Err(LanguageModelError::permanent(
+                "Bedrock additional_model_request_fields.anthropic_beta must be an array of strings",
+            ));
+        }
+        None => Vec::new(),
+    };
+
+    if let Some(extra_beta_headers) = &options.anthropic_beta {
+        for beta_header in extra_beta_headers {
+            push_unique_string(&mut anthropic_beta, beta_header.clone());
+        }
+    }
+
+    if options.reasoning_effort.is_some() && model.contains("claude-opus-4-5") {
+        push_unique_string(&mut anthropic_beta, "effort-2025-11-24".to_string());
+    }
+
+    if !anthropic_beta.is_empty() {
+        fields.insert(
+            "anthropic_beta".to_string(),
+            Document::Array(anthropic_beta.into_iter().map(Document::String).collect()),
+        );
+    }
+
+    Ok(Some(Document::Object(fields)))
+}
+
+fn document_string(value: Document) -> Result<String, LanguageModelError> {
+    match value {
+        Document::String(value) => Ok(value),
+        _ => Err(LanguageModelError::permanent(
+            "Bedrock anthropic_beta entries must be strings",
+        )),
+    }
+}
+
+fn push_unique_string(values: &mut Vec<String>, value: String) {
+    if !values.iter().any(|existing| existing == &value) {
+        values.push(value);
+    }
+}
+
 fn usage_from_bedrock(usage: &TokenUsage) -> Usage {
     let cached_tokens = usage
         .cache_read_input_tokens()
@@ -698,6 +832,8 @@ mod tests {
             top_p: None,
             stop_sequences: Some(vec!["STOP_B".to_string()]),
             tool_strict: Some(true),
+            anthropic_beta: Some(vec!["context-1m-2025-08-07".to_string()]),
+            reasoning_effort: Some(ReasoningEffort::Medium),
             additional_model_request_fields: Some(Document::Object(request_fields)),
             additional_model_response_field_paths: Some(vec!["/thinking".to_string()]),
         };
@@ -713,6 +849,11 @@ mod tests {
             Some(&["STOP_B".to_string()][..])
         );
         assert_eq!(base.tool_strict, Some(true));
+        assert_eq!(
+            base.anthropic_beta.as_deref(),
+            Some(&["context-1m-2025-08-07".to_string()][..])
+        );
+        assert_eq!(base.reasoning_effort, Some(ReasoningEffort::Medium));
         assert!(base.additional_model_request_fields.is_some());
         assert_eq!(
             base.additional_model_response_field_paths.as_deref(),
@@ -839,6 +980,92 @@ mod tests {
         assert_eq!(config.temperature(), Some(0.2));
         assert_eq!(config.top_p(), Some(0.9));
         assert_eq!(config.stop_sequences(), ["DONE"]);
+    }
+
+    #[test]
+    fn test_additional_model_request_fields_merges_reasoning_effort_and_betas() {
+        let mut thinking = std::collections::HashMap::new();
+        thinking.insert("type".to_string(), Document::String("enabled".to_string()));
+        thinking.insert("budget_tokens".to_string(), Document::from(512_u64));
+
+        let raw_beta_headers = vec![Document::String("context-1m-2025-08-07".to_string())];
+
+        let mut additional_fields = std::collections::HashMap::new();
+        additional_fields.insert("thinking".to_string(), Document::Object(thinking));
+        additional_fields.insert(
+            "anthropic_beta".to_string(),
+            Document::Array(raw_beta_headers),
+        );
+
+        let options = Options {
+            anthropic_beta: Some(vec![
+                "interleaved-thinking-2025-05-14".to_string(),
+                "effort-2025-11-24".to_string(),
+            ]),
+            reasoning_effort: Some(ReasoningEffort::Medium),
+            additional_model_request_fields: Some(Document::Object(additional_fields)),
+            ..Default::default()
+        };
+
+        let merged = additional_model_request_fields_from_options(
+            "anthropic.claude-opus-4-5-20251101-v1:0",
+            &options,
+        )
+        .unwrap()
+        .expect("merged additional fields");
+
+        let fields = merged.as_object().expect("object fields");
+        let output_config = fields
+            .get("output_config")
+            .and_then(Document::as_object)
+            .expect("output_config");
+        assert_eq!(
+            output_config.get("effort").and_then(Document::as_string),
+            Some("medium")
+        );
+
+        let thinking = fields
+            .get("thinking")
+            .and_then(Document::as_object)
+            .expect("thinking");
+        assert_eq!(
+            thinking.get("type").and_then(Document::as_string),
+            Some("enabled")
+        );
+        assert!(thinking.get("budget_tokens").is_some());
+
+        let anthropic_beta = fields
+            .get("anthropic_beta")
+            .and_then(Document::as_array)
+            .expect("anthropic_beta");
+        let anthropic_beta = anthropic_beta
+            .iter()
+            .map(|value| value.as_string().expect("beta header string"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            anthropic_beta,
+            vec![
+                "context-1m-2025-08-07",
+                "interleaved-thinking-2025-05-14",
+                "effort-2025-11-24",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_additional_model_request_fields_requires_object_when_merging_typed_fields() {
+        let options = Options {
+            reasoning_effort: Some(ReasoningEffort::Low),
+            additional_model_request_fields: Some(Document::Bool(true)),
+            ..Default::default()
+        };
+
+        let error = additional_model_request_fields_from_options("model", &options).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("additional_model_request_fields must be an object")
+        );
     }
 
     #[test]

--- a/swiftide-integrations/src/aws_bedrock_v2/simple_prompt.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/simple_prompt.rs
@@ -353,9 +353,10 @@ mod tests {
                 Ok(response) => break response,
                 Err(LanguageModelError::TransientError(error)) => {
                     eprintln!("transient Bedrock error during live smoke test: {error}");
-                    if attempts >= 3 {
-                        panic!("live Bedrock prompt failed after retries: {error}");
-                    }
+                    assert!(
+                        attempts < 3,
+                        "live Bedrock prompt failed after retries: {error}"
+                    );
                     tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                 }
                 Err(error) => panic!("live Bedrock prompt failed: {error:?}"),

--- a/swiftide-integrations/src/aws_bedrock_v2/simple_prompt.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/simple_prompt.rs
@@ -57,7 +57,7 @@ mod tests {
 
     use super::*;
     use crate::aws_bedrock_v2::{
-        AwsBedrock, MockBedrockConverse,
+        AwsBedrock, MockBedrockConverse, ReasoningEffort,
         test_utils::{TEST_MODEL_ID, bedrock_client_for_mock_server},
     };
 
@@ -318,5 +318,56 @@ mod tests {
         let error = bedrock.prompt("Hello".into()).await.unwrap_err();
         assert!(matches!(error, LanguageModelError::PermanentError(_)));
         assert!(error.to_string().contains("No text in response"));
+    }
+
+    #[ignore = "requires live AWS Bedrock access and billable model invocation"]
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn smoke_live_bedrock_reasoning_effort_prompt() {
+        let model = std::env::var("SWIFTIDE_AWS_BEDROCK_LIVE_MODEL")
+            .unwrap_or_else(|_| "anthropic.claude-opus-4-5-20251101-v1:0".to_string());
+        let prompt = "Reply with exactly 'swiftide-bedrock-effort-ok' and nothing else.";
+
+        let bedrock = AwsBedrock::builder()
+            .default_prompt_model(model.clone())
+            .default_options(
+                Options::builder()
+                    .max_tokens(64)
+                    .reasoning_effort(ReasoningEffort::Low)
+                    .build()
+                    .unwrap(),
+            )
+            .build()
+            .unwrap();
+
+        let mut attempts = 0;
+        let response = loop {
+            attempts += 1;
+            let attempt = tokio::time::timeout(
+                std::time::Duration::from_secs(60),
+                bedrock.prompt(prompt.into()),
+            )
+            .await
+            .expect("live Bedrock prompt timed out");
+
+            match attempt {
+                Ok(response) => break response,
+                Err(LanguageModelError::TransientError(error)) => {
+                    eprintln!("transient Bedrock error during live smoke test: {error}");
+                    if attempts >= 3 {
+                        panic!("live Bedrock prompt failed after retries: {error}");
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                }
+                Err(error) => panic!("live Bedrock prompt failed: {error:?}"),
+            }
+        };
+
+        println!("model={model}");
+        println!("response={response}");
+
+        assert!(
+            response.contains("swiftide-bedrock-effort-ok"),
+            "unexpected response: {response}"
+        );
     }
 }

--- a/swiftide-integrations/src/aws_bedrock_v2/structured_prompt.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/structured_prompt.rs
@@ -57,6 +57,8 @@ impl DynStructuredPrompt for AwsBedrock {
                     .map_err(LanguageModelError::permanent)?,
             )
             .build();
+        let additional_model_request_fields =
+            super::additional_model_request_fields_from_options(model, &self.default_options)?;
 
         let response = match self
             .client
@@ -67,7 +69,7 @@ impl DynStructuredPrompt for AwsBedrock {
                 super::inference_config_from_options(&self.default_options),
                 None,
                 Some(output_config),
-                self.default_options.additional_model_request_fields.clone(),
+                additional_model_request_fields,
                 self.default_options
                     .additional_model_response_field_paths
                     .clone(),
@@ -166,7 +168,7 @@ mod tests {
     #[cfg(feature = "langfuse")]
     use crate::aws_bedrock_v2::test_utils::run_with_langfuse_event_capture;
     use crate::aws_bedrock_v2::{
-        AwsBedrock, MockBedrockConverse,
+        AwsBedrock, MockBedrockConverse, Options, ReasoningEffort,
         test_utils::{TEST_MODEL_ID, bedrock_client_for_mock_server},
     };
 
@@ -227,6 +229,93 @@ mod tests {
         let bedrock = AwsBedrock::builder()
             .test_client(bedrock_mock)
             .default_prompt_model("anthropic.claude-3-5-sonnet-20241022-v2:0")
+            .build()
+            .unwrap();
+
+        let value = bedrock
+            .structured_prompt_dyn(
+                "What is two times twenty one?".into(),
+                schema_for!(StructuredOutput),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            serde_json::from_value::<StructuredOutput>(value).unwrap(),
+            StructuredOutput {
+                answer: "42".to_string()
+            }
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_structured_prompt_passes_reasoning_effort_in_additional_model_request_fields() {
+        let mut bedrock_mock = MockBedrockConverse::new();
+
+        bedrock_mock
+            .expect_converse()
+            .once()
+            .withf(
+                |model_id,
+                 _messages,
+                 _system,
+                 _inference_config,
+                 _tool_config,
+                 output_config,
+                 additional_model_request_fields,
+                 _additional_model_response_field_paths| {
+                    model_id == "anthropic.claude-opus-4-5-20251101-v1:0"
+                        && output_config
+                            .as_ref()
+                            .and_then(|config| config.text_format())
+                            .is_some()
+                        && additional_model_request_fields
+                            .as_ref()
+                            .is_some_and(|fields| {
+                                let Some(fields) = fields.as_object() else {
+                                    return false;
+                                };
+
+                                let effort_matches = fields
+                                    .get("output_config")
+                                    .and_then(Document::as_object)
+                                    .and_then(|output_config| output_config.get("effort"))
+                                    .and_then(Document::as_string)
+                                    == Some("low");
+                                let beta_matches = fields
+                                    .get("anthropic_beta")
+                                    .and_then(Document::as_array)
+                                    .is_some_and(|betas| {
+                                        betas.iter().any(|beta| {
+                                            beta.as_string() == Some("effort-2025-11-24")
+                                        })
+                                    });
+
+                                effort_matches && beta_matches
+                            })
+                },
+            )
+            .returning(|_, _, _, _, _, _, _, _| {
+                Ok(ConverseOutput::builder()
+                    .output(ConverseResult::Message(
+                        Message::builder()
+                            .role(ConversationRole::Assistant)
+                            .content(ContentBlock::Text("{\"answer\":\"42\"}".to_string()))
+                            .build()
+                            .unwrap(),
+                    ))
+                    .stop_reason(StopReason::EndTurn)
+                    .build()
+                    .unwrap())
+            });
+
+        let bedrock = AwsBedrock::builder()
+            .test_client(bedrock_mock)
+            .default_prompt_model("anthropic.claude-opus-4-5-20251101-v1:0")
+            .default_options(Options {
+                reasoning_effort: Some(ReasoningEffort::Low),
+                ..Default::default()
+            })
             .build()
             .unwrap();
 


### PR DESCRIPTION
## Summary

This PR adds typed reasoning effort support for Anthropic Claude models on AWS Bedrock in the `aws_bedrock_v2` integration.

It introduces:
- `aws_bedrock_v2::ReasoningEffort` with `Low`, `Medium`, `High`, and `Max`
- `Options::reasoning_effort` and `Options::anthropic_beta`
- provider-specific Bedrock request field merging for Anthropic `output_config.effort` and `anthropic_beta`
- coverage for normal chat completions and structured prompts
- an ignored live smoke test for Bedrock reasoning effort invocations

## Implementation details

Bedrock Claude effort controls are not part of Bedrock's top-level `outputConfig`; they have to be sent via Anthropic model-specific request fields (`additionalModelRequestFields`).

This PR:
- maps `reasoning_effort` to `additional_model_request_fields.output_config.effort`
- merges explicit `anthropic_beta` headers with existing raw `additional_model_request_fields`
- auto-adds `effort-2025-11-24` when the target model ID clearly identifies Claude Opus 4.5
- preserves existing Bedrock-specific fields like `thinking`
- reuses the same merge path for `Converse`, `ConverseStream`, and structured prompt requests so behavior is consistent across request types

A notable Bedrock behavior we observed during validation:
- the direct model ID `anthropic.claude-opus-4-5-20251101-v1:0` was rejected for on-demand throughput in this account/region
- the corresponding inference profile `eu.anthropic.claude-opus-4-5-20251101-v1:0` worked

## Validation

Automated:
- `cargo test -p swiftide-integrations --features aws-bedrock reasoning_effort -- --nocapture`
- `cargo +nightly fmt --all`
- `cargo test -p swiftide-integrations --features aws-bedrock smoke_live_bedrock_reasoning_effort_prompt --no-run`

Live AWS Bedrock validation:
1. Refreshed the local AWS SSO session with `aws sso login --profile default --use-device-code`
2. Verified account and region with `aws sts get-caller-identity` and `aws configure get region --profile default`
3. Confirmed the Claude Opus models available in Bedrock with `aws bedrock list-foundation-models --by-provider anthropic`
4. Confirmed the usable inference profiles with `aws bedrock list-inference-profiles`
5. Ran the real Swiftide smoke test against the EU Opus 4.5 inference profile:

```bash
AWS_PROFILE=default \
AWS_REGION=eu-central-1 \
SWIFTIDE_AWS_BEDROCK_LIVE_MODEL=eu.anthropic.claude-opus-4-5-20251101-v1:0 \
cargo test -p swiftide-integrations --features aws-bedrock smoke_live_bedrock_reasoning_effort_prompt -- --ignored --nocapture
```

Observed live result:

```text
model=eu.anthropic.claude-opus-4-5-20251101-v1:0
response=swiftide-bedrock-effort-ok
```

That confirms Swiftide can send a real Bedrock request with reasoning effort enabled and receive a successful response from Claude Opus 4.5.
