### PR TITLE
feat(core)!: split command output into stdout and stderr

### DIFF
--- a/swiftide-agents/src/tools/local_executor.rs
+++ b/swiftide-agents/src/tools/local_executor.rs
@@ -450,7 +450,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_local_executor_falls_back_to_stderr_when_stdout_is_empty() -> anyhow::Result<()> {
+    async fn test_local_executor_keeps_display_empty_when_stdout_is_empty() -> anyhow::Result<()> {
         let temp_dir = TempDir::new()?;
         let temp_path = temp_dir.path();
 
@@ -466,7 +466,8 @@ mod tests {
             Err(CommandError::NonZeroExit(output)) => {
                 assert!(output.stdout.is_empty());
                 assert_eq!(output.stderr, "boom");
-                assert_eq!(output.to_string(), "boom");
+                assert_eq!(output.to_string(), "");
+                assert_eq!(output.as_ref(), "");
             }
             other => anyhow::bail!("expected non-zero exit, got {other:?}"),
         }

--- a/swiftide-agents/src/tools/local_executor.rs
+++ b/swiftide-agents/src/tools/local_executor.rs
@@ -194,7 +194,7 @@ impl LocalExecutor {
 
                     let (stdout, stderr) =
                         Self::collect_process_output(stdout_task, stderr_task).await;
-                    let cmd_output = Self::merge_output(&stdout, &stderr);
+                    let cmd_output = Self::command_output(&stdout, &stderr);
 
                     return Err(CommandError::TimedOut {
                         timeout: limit,
@@ -209,7 +209,7 @@ impl LocalExecutor {
         };
 
         let (stdout, stderr) = Self::collect_process_output(stdout_task, stderr_task).await;
-        let cmd_output = Self::merge_output(&stdout, &stderr);
+        let cmd_output = Self::command_output(&stdout, &stderr);
 
         if status.success() {
             Ok(cmd_output)
@@ -309,14 +309,8 @@ impl LocalExecutor {
         (stdout, stderr)
     }
 
-    fn merge_output(stdout: &[String], stderr: &[String]) -> CommandOutput {
-        stdout
-            .iter()
-            .chain(stderr.iter())
-            .cloned()
-            .collect::<Vec<_>>()
-            .join("\n")
-            .into()
+    fn command_output(stdout: &[String], stderr: &[String]) -> CommandOutput {
+        CommandOutput::from_parts(stdout.join("\n"), stderr.join("\n"))
     }
 }
 #[async_trait]
@@ -426,6 +420,56 @@ mod tests {
 
         // Verify that the output matches the expected content
         assert_eq!(output.to_string().trim(), "hello world");
+        assert!(output.stderr.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_local_executor_preserves_stdout_and_stderr() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let temp_path = temp_dir.path();
+
+        let executor = LocalExecutor {
+            workdir: temp_path.to_path_buf(),
+            ..Default::default()
+        };
+
+        let output = executor
+            .exec_cmd(&Command::shell(
+                "printf 'hello stdout'; printf 'hello stderr' >&2",
+            ))
+            .await?;
+
+        assert_eq!(output.stdout, "hello stdout");
+        assert_eq!(output.stderr, "hello stderr");
+        assert_eq!(output.to_string(), "hello stdout");
+        assert!(format!("{output:?}").contains("hello stderr"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_local_executor_falls_back_to_stderr_when_stdout_is_empty() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let temp_path = temp_dir.path();
+
+        let executor = LocalExecutor {
+            workdir: temp_path.to_path_buf(),
+            ..Default::default()
+        };
+
+        match executor
+            .exec_cmd(&Command::shell("printf 'boom' >&2; exit 1"))
+            .await
+        {
+            Err(CommandError::NonZeroExit(output)) => {
+                assert!(output.stdout.is_empty());
+                assert_eq!(output.stderr, "boom");
+                assert_eq!(output.to_string(), "boom");
+            }
+            other => anyhow::bail!("expected non-zero exit, got {other:?}"),
+        }
 
         Ok(())
     }
@@ -468,6 +512,7 @@ mod tests {
             Err(CommandError::TimedOut { timeout, output }) => {
                 assert_eq!(timeout, Duration::from_millis(100));
                 assert!(output.to_string().is_empty());
+                assert!(output.stderr.is_empty());
             }
             other => anyhow::bail!("expected default timeout, got {other:?}"),
         }
@@ -661,7 +706,7 @@ print(1 + 2)"#;
         let read_cmd = Command::read_file(file_path.clone());
 
         // Execute the read command
-        let output = executor.exec_cmd(&read_cmd).await?.output;
+        let output = executor.exec_cmd(&read_cmd).await?.stdout;
 
         // Verify that the content read from the file matches the expected content
         assert_eq!(output, file_content);

--- a/swiftide-core/src/agent_traits.rs
+++ b/swiftide-core/src/agent_traits.rs
@@ -360,9 +360,8 @@ impl Command {
 
 /// Output from a `Command`
 ///
-/// String-like accessors such as [`std::fmt::Display`] and [`AsRef<str>`] prefer stdout and only
-/// fall back to stderr when stdout is empty. Use the dedicated fields or accessors when stderr is
-/// needed explicitly.
+/// String-like accessors such as [`std::fmt::Display`] and [`AsRef<str>`] expose stdout only.
+/// Use the dedicated fields or accessors when stderr is needed explicitly.
 #[derive(Debug, Clone, Default)]
 pub struct CommandOutput {
     pub stdout: String,
@@ -398,14 +397,6 @@ impl CommandOutput {
         &self.stderr
     }
 
-    pub fn preferred_output(&self) -> &str {
-        if self.stdout.is_empty() {
-            &self.stderr
-        } else {
-            &self.stdout
-        }
-    }
-
     pub fn is_empty(&self) -> bool {
         self.stdout.is_empty() && self.stderr.is_empty()
     }
@@ -413,7 +404,7 @@ impl CommandOutput {
 
 impl std::fmt::Display for CommandOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.preferred_output().fmt(f)
+        self.stdout.fmt(f)
     }
 }
 
@@ -425,7 +416,7 @@ impl<T: Into<String>> From<T> for CommandOutput {
 
 impl AsRef<str> for CommandOutput {
     fn as_ref(&self) -> &str {
-        self.preferred_output()
+        &self.stdout
     }
 }
 

--- a/swiftide-core/src/agent_traits.rs
+++ b/swiftide-core/src/agent_traits.rs
@@ -359,47 +359,73 @@ impl Command {
 }
 
 /// Output from a `Command`
-#[derive(Debug, Clone)]
+///
+/// String-like accessors such as [`std::fmt::Display`] and [`AsRef<str>`] prefer stdout and only
+/// fall back to stderr when stdout is empty. Use the dedicated fields or accessors when stderr is
+/// needed explicitly.
+#[derive(Debug, Clone, Default)]
 pub struct CommandOutput {
-    pub output: String,
+    pub stdout: String,
+    pub stderr: String,
     // status_code: i32,
     // success: bool,
 }
 
 impl CommandOutput {
     pub fn empty() -> Self {
-        CommandOutput {
-            output: String::new(),
+        Self::default()
+    }
+
+    pub fn new(stdout: impl Into<String>) -> Self {
+        Self {
+            stdout: stdout.into(),
+            stderr: String::new(),
         }
     }
 
-    pub fn new(output: impl Into<String>) -> Self {
-        CommandOutput {
-            output: output.into(),
+    pub fn from_parts(stdout: impl Into<String>, stderr: impl Into<String>) -> Self {
+        Self {
+            stdout: stdout.into(),
+            stderr: stderr.into(),
         }
     }
+
+    pub fn stdout(&self) -> &str {
+        &self.stdout
+    }
+
+    pub fn stderr(&self) -> &str {
+        &self.stderr
+    }
+
+    pub fn preferred_output(&self) -> &str {
+        if self.stdout.is_empty() {
+            &self.stderr
+        } else {
+            &self.stdout
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
-        self.output.is_empty()
+        self.stdout.is_empty() && self.stderr.is_empty()
     }
 }
 
 impl std::fmt::Display for CommandOutput {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.output.fmt(f)
+        self.preferred_output().fmt(f)
     }
 }
 
 impl<T: Into<String>> From<T> for CommandOutput {
     fn from(value: T) -> Self {
-        CommandOutput {
-            output: value.into(),
-        }
+        Self::new(value)
     }
 }
 
 impl AsRef<str> for CommandOutput {
     fn as_ref(&self) -> &str {
-        &self.output
+        self.preferred_output()
     }
 }
 

--- a/swiftide-integrations/src/aws_bedrock_v2/simple_prompt.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/simple_prompt.rs
@@ -343,7 +343,7 @@ mod tests {
         let response = loop {
             attempts += 1;
             let attempt = tokio::time::timeout(
-                std::time::Duration::from_secs(60),
+                std::time::Duration::from_mins(1),
                 bedrock.prompt(prompt.into()),
             )
             .await

--- a/swiftide-integrations/src/pgvector/pgv_table_types.rs
+++ b/swiftide-integrations/src/pgvector/pgv_table_types.rs
@@ -335,9 +335,7 @@ impl PgVector {
 
         let mut columns = Vec::new();
         let mut unnest_params = Vec::new();
-        let mut param_counter = 1;
-
-        for field in &self.fields {
+        for (param_counter, field) in (1..).zip(self.fields.iter()) {
             let name = field.field_name();
             columns.push(name.to_string());
 
@@ -350,8 +348,6 @@ impl PgVector {
                     FieldConfig::Vector(_) => "VECTOR[]",
                 }
             ));
-
-            param_counter += 1;
         }
 
         let update_columns = self


### PR DESCRIPTION
## Summary
- split `swiftide::CommandOutput` into separate `stdout` and `stderr` fields
- keep the string-like trait implementations strictly focused on `stdout`
- update `LocalExecutor` to preserve both streams and add coverage for mixed-stream and stderr-only cases
- clean up follow-up clippy issues in integrations by replacing a manual pgvector SQL parameter counter loop and using more readable duration units in Bedrock tests

## Issue
- none

## API Impact
- `CommandOutput.output` is replaced by `CommandOutput.stdout` and `CommandOutput.stderr`
- `Display` and `AsRef<str>` expose `stdout` only, even when it is empty
- `stderr` remains available explicitly through the field, accessor, and debug output

## Before
```rust
CommandOutput {
    output: "stdout\nstderr".into(),
}
```

## After
```rust
CommandOutput {
    stdout: "stdout".into(),
    stderr: "stderr".into(),
}
```

## Verification
- `cargo +nightly fmt --all`
- `cargo test -p swiftide-agents local_executor --lib`
- `cargo check -p swiftide-core -p swiftide-agents --all-features`
- `cargo check -p swiftide --features swiftide-agents`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

## Notes
- the full workspace clippy pass is now green on this branch
