### PR TITLE
feat: add Mistral AI support

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -27,6 +27,7 @@ swiftide = { path = "../swiftide/", features = [
   "pgvector",
   "swiftide-agents",
   "dashscope",
+  "mistral",
   "mcp",
   "anthropic",
   "gemini",
@@ -141,6 +142,10 @@ path = "index_md_into_pgvector.rs"
 [[example]]
 name = "dashscope"
 path = "dashscope.rs"
+
+[[example]]
+name = "mistral"
+path = "mistral.rs"
 
 [[example]]
 name = "reranking"

--- a/examples/mistral.rs
+++ b/examples/mistral.rs
@@ -1,0 +1,30 @@
+//! Demonstrates prompting Mistral AI's OpenAI-compatible chat completion endpoint.
+//!
+//! Set the `MISTRAL_API_KEY` environment variable before running.
+
+use swiftide::{integrations::mistral::Mistral, traits::SimplePrompt};
+
+const MODELS: &[&str] = &["devstral-latest", "mistral-large-latest"];
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    for model in MODELS {
+        let client = Mistral::builder()
+            .default_prompt_model(*model)
+            .to_owned()
+            .build()?;
+
+        let response = client
+            .prompt(
+                "Reply with one short sentence that names your model family and says Swiftide works."
+                    .into(),
+            )
+            .await?;
+
+        println!("{model}: {response}");
+    }
+
+    Ok(())
+}

--- a/swiftide-integrations/Cargo.toml
+++ b/swiftide-integrations/Cargo.toml
@@ -199,6 +199,8 @@ openai = [
 groq = ["dep:async-openai", "dep:secrecy", "dep:reqwest", "openai"]
 # Goolge Gemini
 gemini = ["dep:async-openai", "dep:secrecy", "dep:reqwest", "openai"]
+# Mistral AI prompting
+mistral = ["dep:async-openai", "dep:secrecy", "dep:reqwest", "openai"]
 # Ollama prompting, embedding, chatcompletion
 ollama = ["dep:async-openai", "dep:secrecy", "dep:reqwest", "openai"]
 # Openrouter prompting, embedding, chatcompletion

--- a/swiftide-integrations/src/lib.rs
+++ b/swiftide-integrations/src/lib.rs
@@ -26,6 +26,8 @@ pub mod groq;
 pub mod kafka;
 #[cfg(feature = "lancedb")]
 pub mod lancedb;
+#[cfg(feature = "mistral")]
+pub mod mistral;
 #[cfg(feature = "ollama")]
 pub mod ollama;
 #[cfg(feature = "open-router")]

--- a/swiftide-integrations/src/mistral/config.rs
+++ b/swiftide-integrations/src/mistral/config.rs
@@ -1,0 +1,55 @@
+use reqwest::header::{AUTHORIZATION, HeaderMap};
+use secrecy::{ExposeSecret as _, SecretString};
+use serde::Deserialize;
+
+const MISTRAL_API_BASE: &str = "https://api.mistral.ai/v1";
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct MistralConfig {
+    api_base: String,
+    api_key: SecretString,
+}
+
+impl Default for MistralConfig {
+    fn default() -> Self {
+        Self {
+            api_base: MISTRAL_API_BASE.to_string(),
+            api_key: std::env::var("MISTRAL_API_KEY")
+                .unwrap_or_else(|_| String::new())
+                .into(),
+        }
+    }
+}
+
+impl async_openai::config::Config for MistralConfig {
+    fn headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+
+        headers.insert(
+            AUTHORIZATION,
+            format!("Bearer {}", self.api_key.expose_secret())
+                .as_str()
+                .parse()
+                .unwrap(),
+        );
+
+        headers
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.api_base, path)
+    }
+
+    fn api_base(&self) -> &str {
+        &self.api_base
+    }
+
+    fn api_key(&self) -> &SecretString {
+        &self.api_key
+    }
+
+    fn query(&self) -> Vec<(&str, &str)> {
+        vec![]
+    }
+}

--- a/swiftide-integrations/src/mistral/mod.rs
+++ b/swiftide-integrations/src/mistral/mod.rs
@@ -1,0 +1,39 @@
+//! This module provides integration with `Mistral AI`'s API, enabling the use of language models
+//! within the Swiftide project. It includes the `Mistral` struct for managing API clients and
+//! default options for prompt models. The module is conditionally compiled based on the "mistral"
+//! feature flag.
+
+use crate::openai;
+
+use self::config::MistralConfig;
+
+mod config;
+
+/// The `Mistral` struct encapsulates a Mistral AI client that implements
+/// [`swiftide_core::SimplePrompt`].
+///
+/// There is also a builder available.
+///
+/// By default it will look for a `MISTRAL_API_KEY` environment variable. Note that a model always
+/// needs to be set, either with [`Mistral::with_default_prompt_model`] or via the builder. You can
+/// find available models in the Mistral AI documentation.
+///
+/// Under the hood it uses [`async_openai`] against Mistral AI's OpenAI-compatible chat completion
+/// endpoint. This means some features might not work as expected. See the Mistral AI documentation
+/// for details.
+pub type Mistral = openai::GenericOpenAI<MistralConfig>;
+pub type MistralBuilder = openai::GenericOpenAIBuilder<MistralConfig>;
+pub type MistralBuilderError = openai::GenericOpenAIBuilderError;
+pub use openai::{Options, OptionsBuilder, OptionsBuilderError};
+
+impl Mistral {
+    pub fn builder() -> MistralBuilder {
+        MistralBuilder::default()
+    }
+}
+
+impl Default for Mistral {
+    fn default() -> Self {
+        Self::builder().build().unwrap()
+    }
+}

--- a/swiftide/Cargo.toml
+++ b/swiftide/Cargo.toml
@@ -57,6 +57,7 @@ all = [
   "scraping",
   "aws-bedrock",
   "groq",
+  "mistral",
   "ollama",
   "pgvector",
 ]
@@ -83,6 +84,9 @@ openai = ["swiftide-integrations/openai"]
 
 ## Groq 
 groq = ["swiftide-integrations/groq"]
+
+## Mistral AI
+mistral = ["swiftide-integrations/mistral"]
 
 ## Google Gemini 
 gemini = ["swiftide-integrations/gemini"]


### PR DESCRIPTION
## Summary

Adds first-class Mistral AI support through the existing OpenAI-compatible integration path.

- Add `swiftide::integrations::mistral::Mistral` with a `MistralConfig` that targets `https://api.mistral.ai/v1` and reads `MISTRAL_API_KEY`.
- Add `mistral` feature flags in `swiftide-integrations` and the top-level `swiftide` crate, and include it in `all`.
- Add `examples/mistral.rs` to exercise `devstral-latest` and `mistral-large-latest`.

## Validation

Ran:

```sh
cargo +nightly fmt --all -- --check
cargo check -p swiftide-integrations --features mistral
cargo check -p swiftide-examples --example mistral
set -a; . ./.env; set +a; cargo run -p swiftide-examples --example mistral
```

Live example output:

```text
devstral-latest: I'm a model from the Mistral family, and Swiftide works.
mistral-large-latest: "Meet the **Swiftide family**—where everything just works!"
```

## Notes

Checked Mistral's official docs while implementing:

- https://docs.mistral.ai/models/model-cards/devstral-2-25-12
- https://docs.mistral.ai/models/model-cards/mistral-large-3-25-12
- https://docs.mistral.ai/resources/changelogs
