### PR TITLE
fix(openai): send reasoning effort to chat completions

### DIFF
--- a/swiftide-integrations/src/openai/chat_completion.rs
+++ b/swiftide-integrations/src/openai/chat_completion.rs
@@ -1211,7 +1211,7 @@ data: [DONE]\n\n";
                 assert_eq!(v["parallel_tool_calls"], true);
                 assert_eq!(v["max_completion_tokens"], 77);
                 assert!((v["temperature"].as_f64().unwrap() - 0.42).abs() < 1e-5);
-                assert_eq!(v["reasoning_effort"], serde_json::Value::Null);
+                assert_eq!(v["reasoning_effort"], "low");
                 assert_eq!(v["seed"], 42);
                 assert!((v["presence_penalty"].as_f64().unwrap() - 1.1).abs() < 1e-5);
 

--- a/swiftide-integrations/src/openai/mod.rs
+++ b/swiftide-integrations/src/openai/mod.rs
@@ -539,6 +539,10 @@ impl<C: async_openai::config::Config + Default> GenericOpenAI<C> {
             args.temperature(temperature);
         }
 
+        if let Some(reasoning_effort) = &options.reasoning_effort {
+            args.reasoning_effort(reasoning_effort.clone());
+        }
+
         if let Some(seed) = options.seed {
             args.seed(seed);
         }
@@ -787,7 +791,7 @@ mod test {
 
     #[test]
     #[allow(deprecated)]
-    fn test_chat_completion_request_defaults_omits_reasoning_effort() {
+    fn test_chat_completion_request_defaults_sends_reasoning_effort() {
         let openai: OpenAI = OpenAI::builder()
             .default_options(
                 Options::builder()
@@ -813,7 +817,7 @@ mod test {
         assert_eq!(built.parallel_tool_calls, Some(true));
         assert_eq!(built.max_completion_tokens, Some(42));
         assert_eq!(built.temperature, Some(0.3));
-        assert_eq!(built.reasoning_effort, None);
+        assert_eq!(built.reasoning_effort, Some(ReasoningEffort::Low));
         assert_eq!(built.seed, Some(7));
         assert_eq!(built.presence_penalty, Some(1.1));
         assert_eq!(


### PR DESCRIPTION
## Summary

- forward `Options::reasoning_effort` into OpenAI-compatible chat completion requests
- update the chat completion request tests to assert the field is sent as `reasoning_effort: "low"`
- keep reasoning item replay scoped to the Responses API path

## Root Cause

Swiftide stored `reasoning_effort` in OpenAI options, but `chat_completion_request_defaults()` never copied it into the `CreateChatCompletionRequestArgs` builder. The underlying async-openai chat completion request type already supports the field.

## Validation

- `cargo test -p swiftide-integrations --features openai test_chat_completion_request_defaults_sends_reasoning_effort`
- `cargo test -p swiftide-integrations --features openai test_complete_with_all_default_settings`
- `git diff --cached --check`