### PR TITLE
fix(macros): expose tool argument descriptions

### DIFF
--- a/swiftide-integrations/src/anthropic/chat_completion.rs
+++ b/swiftide-integrations/src/anthropic/chat_completion.rs
@@ -430,6 +430,7 @@ mod tests {
 
     #[derive(JsonSchema, serde::Serialize, serde::Deserialize)]
     struct LocationArgs {
+        #[schemars(description = "City or region to retrieve weather for")]
         location: String,
     }
 
@@ -721,6 +722,11 @@ mod tests {
 
         let result = tools_to_anthropic(&tool_spec).unwrap();
         let expected_schema = tool_spec.strict_parameters_schema().unwrap().into_json();
+        assert_eq!(
+            expected_schema["properties"]["location"]["description"],
+            json!("City or region to retrieve weather for")
+        );
+
         let expected = json!({
             "name": "get_weather",
             "description": "Gets the weather",

--- a/swiftide-integrations/src/aws_bedrock_v2/chat_completion.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/chat_completion.rs
@@ -1660,6 +1660,7 @@ mod tests {
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, JsonSchema)]
     struct WeatherArgs {
+        #[schemars(description = "City or region to retrieve weather for")]
         location: String,
     }
 
@@ -2353,6 +2354,23 @@ mod tests {
                 if schema.get("type") == Some(&Document::String("object".to_string()))
                     && schema.get("additionalProperties") == Some(&Document::Bool(false))
         ));
+
+        let Some(ToolInputSchema::Json(Document::Object(schema))) = spec.input_schema() else {
+            panic!("expected JSON object schema");
+        };
+        let Some(Document::Object(properties)) = schema.get("properties") else {
+            panic!("expected schema properties");
+        };
+        let Some(Document::Object(location)) = properties.get("location") else {
+            panic!("expected location property schema");
+        };
+
+        assert_eq!(
+            location.get("description"),
+            Some(&Document::String(
+                "City or region to retrieve weather for".to_string()
+            ))
+        );
     }
 
     #[test]

--- a/swiftide-integrations/src/openai/tool_schema.rs
+++ b/swiftide-integrations/src/openai/tool_schema.rs
@@ -286,6 +286,13 @@ mod tests {
         discussion_id: Option<String>,
     }
 
+    #[derive(serde::Serialize, serde::Deserialize, JsonSchema)]
+    #[serde(deny_unknown_fields)]
+    struct DescribedArgs {
+        #[schemars(description = "Search text used to find matching code")]
+        query: String,
+    }
+
     #[test]
     fn openai_tool_schema_strips_schema_metadata_and_rust_formats() {
         let spec = ToolSpec::builder()
@@ -341,6 +348,23 @@ mod tests {
         assert_eq!(
             schema["$defs"][nested_name]["required"],
             json!(["block_id", "body", "discussion_id", "page_id", "text"])
+        );
+    }
+
+    #[test]
+    fn openai_tool_schema_preserves_property_descriptions() {
+        let spec = ToolSpec::builder()
+            .name("search_code")
+            .description("Searches indexed source code")
+            .parameters_schema(schemars::schema_for!(DescribedArgs))
+            .build()
+            .unwrap();
+
+        let schema = OpenAiToolSchema::try_from(&spec).unwrap().into_value();
+
+        assert_eq!(
+            schema["properties"]["query"]["description"],
+            json!("Search text used to find matching code")
         );
     }
 

--- a/swiftide-macros/src/tool/args.rs
+++ b/swiftide-macros/src/tool/args.rs
@@ -189,8 +189,12 @@ impl ToolArgs {
                 .resolved_type
                 .as_ref()
                 .expect("parameter types should be resolved");
+            let description = &param.description;
             let ident = syn::Ident::new(&param.name, proc_macro2::Span::call_site());
-            fields.push(quote! { pub #ident: #ty });
+            fields.push(quote! {
+                #[schemars(description = #description)]
+                pub #ident: #ty
+            });
         }
 
         let args_struct_ident = self.args_struct_ident();

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_args.snap
@@ -10,6 +10,7 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 )]
 #[schemars(crate = "::swiftide::reexports::schemars", deny_unknown_fields)]
 pub struct HelloDeriveArgs {
+    #[schemars(description = "test param")]
     pub test: String,
 }
 #[async_trait::async_trait]

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_generics.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_generics.snap
@@ -10,6 +10,7 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 )]
 #[schemars(crate = "::swiftide::reexports::schemars", deny_unknown_fields)]
 pub struct HelloDeriveArgs {
+    #[schemars(description = "test param")]
     pub test: String,
 }
 #[async_trait::async_trait]

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_lifetime.snap
@@ -10,6 +10,7 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 )]
 #[schemars(crate = "::swiftide::reexports::schemars", deny_unknown_fields)]
 pub struct HelloDeriveArgs {
+    #[schemars(description = "test param")]
     pub test: String,
 }
 #[async_trait::async_trait]

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_option.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_derive_with_option.snap
@@ -10,6 +10,7 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 )]
 #[schemars(crate = "::swiftide::reexports::schemars", deny_unknown_fields)]
 pub struct HelloDeriveArgs {
+    #[schemars(description = "test param")]
     pub test: Option<String>,
 }
 #[async_trait::async_trait]

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_multiple_args.snap
@@ -10,7 +10,9 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 )]
 #[schemars(crate = "::swiftide::reexports::schemars", deny_unknown_fields)]
 pub struct SearchCodeArgs {
+    #[schemars(description = "my param description")]
     pub code_query: String,
+    #[schemars(description = "my param description")]
     pub other: String,
 }
 #[derive(Clone, Default)]

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg.snap
@@ -10,6 +10,7 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 )]
 #[schemars(crate = "::swiftide::reexports::schemars", deny_unknown_fields)]
 pub struct SearchCodeArgs {
+    #[schemars(description = "my param description")]
     pub code_query: String,
 }
 #[derive(Clone, Default)]

--- a/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg_option.snap
+++ b/swiftide-macros/src/tool/snapshots/swiftide_macros__tool__tests__snapshot_single_arg_option.snap
@@ -10,6 +10,7 @@ expression: "crate::test_utils::pretty_macro_output(&output)"
 )]
 #[schemars(crate = "::swiftide::reexports::schemars", deny_unknown_fields)]
 pub struct SearchCodeArgs {
+    #[schemars(description = "my param description")]
     pub code_query: Option<String>,
 }
 #[derive(Clone, Default)]

--- a/swiftide-macros/tests/tool_spec.rs
+++ b/swiftide-macros/tests/tool_spec.rs
@@ -28,6 +28,7 @@ impl DescribedDeriveTool {
         _agent_context: &dyn AgentContext,
         query: &str,
     ) -> Result<ToolOutput, ToolError> {
+        tokio::task::yield_now().await;
         Ok(format!("Searching for {query}").into())
     }
 }

--- a/swiftide-macros/tests/tool_spec.rs
+++ b/swiftide-macros/tests/tool_spec.rs
@@ -1,0 +1,76 @@
+use swiftide::chat_completion::{
+    ChatCompletionRequest, ChatMessage, Tool as _, ToolOutput, errors::ToolError,
+};
+use swiftide::traits::AgentContext;
+use swiftide_macros::Tool;
+
+#[swiftide_macros::tool(
+    description = "Searches indexed source code",
+    param(name = "query", description = "Search text used to find matching code")
+)]
+async fn described_attribute_tool(
+    _agent_context: &dyn AgentContext,
+    query: &str,
+) -> Result<ToolOutput, ToolError> {
+    Ok(format!("Searching for {query}").into())
+}
+
+#[derive(Clone, Tool)]
+#[tool(
+    description = "Searches indexed source code",
+    param(name = "query", description = "Search text used to find matching code")
+)]
+struct DescribedDeriveTool;
+
+impl DescribedDeriveTool {
+    async fn described_derive_tool(
+        &self,
+        _agent_context: &dyn AgentContext,
+        query: &str,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(format!("Searching for {query}").into())
+    }
+}
+
+#[test]
+fn attribute_macro_exposes_argument_description_in_request_tool_spec() {
+    let request = ChatCompletionRequest::builder()
+        .messages(vec![ChatMessage::User("search the repo".into())])
+        .tool(described_attribute_tool())
+        .build()
+        .unwrap();
+
+    let spec = request
+        .tools_spec()
+        .iter()
+        .find(|spec| spec.name == "described_attribute_tool")
+        .expect("attribute macro tool spec should be attached to the request");
+
+    assert_eq!(
+        argument_description(spec, "query").as_deref(),
+        Some("Search text used to find matching code")
+    );
+}
+
+#[test]
+fn derive_macro_exposes_argument_description_in_tool_spec() {
+    let spec = DescribedDeriveTool.tool_spec();
+
+    assert_eq!(
+        argument_description(&spec, "query").as_deref(),
+        Some("Search text used to find matching code")
+    );
+}
+
+fn argument_description(
+    spec: &swiftide::chat_completion::ToolSpec,
+    argument_name: &str,
+) -> Option<String> {
+    spec.canonical_parameters_schema_json()
+        .ok()?
+        .get("properties")?
+        .get(argument_name)?
+        .get("description")?
+        .as_str()
+        .map(ToOwned::to_owned)
+}


### PR DESCRIPTION
## Summary

- Add schemars field descriptions to macro-generated tool argument structs so `param(description = ...)` is included in the emitted tool schema.
- Add high-level macro tests covering both attribute and derive macro tool specs.
- Add provider-path regression coverage for OpenAI, Anthropic, and Bedrock schema serialization.

## Root cause

The macro stored parameter descriptions in `ToolArgs`, but the generated args struct fields did not attach that metadata to schemars. As a result, compiled tools could produce valid schemas while omitting argument descriptions from the final provider-facing spec.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p swiftide-macros`
- `cargo test -p swiftide-macros --test tool_spec`
- `cargo test -p swiftide-integrations --features openai openai_tool_schema_preserves_property_descriptions`
- `cargo test -p swiftide-integrations --features anthropic anthropic::chat_completion::tests::test_tools_to_anthropic`
- `cargo test -p swiftide-integrations --features aws-bedrock test_tool_config_from_specs_builds_schema`
- `git diff --check`