### PR TITLE
feat(agents): pass mutable agent to hooks

### DIFF
--- a/swiftide-agents/src/agent.rs
+++ b/swiftide-agents/src/agent.rs
@@ -45,8 +45,8 @@ use tracing::{Instrument, debug};
 #[derive(Builder)]
 pub struct Agent {
     /// Hooks are functions that are called at specific points in the agent's lifecycle.
-    #[builder(default, setter(into))]
-    pub(crate) hooks: Vec<Hook>,
+    #[builder(default, setter(custom))]
+    pub(crate) hooks: Arc<Vec<Hook>>,
     /// The context in which the agent operates, by default this is the `DefaultContext`.
     #[builder(
         setter(custom),
@@ -209,9 +209,15 @@ impl AgentBuilder {
 
     /// Add a hook to the agent.
     pub fn add_hook(&mut self, hook: Hook) -> &mut Self {
-        let hooks = self.hooks.get_or_insert_with(Vec::new);
-        hooks.push(hook);
+        let hooks = self.hooks.get_or_insert_with(Arc::default);
+        Arc::make_mut(hooks).push(hook);
 
+        self
+    }
+
+    /// Set the hooks for the agent.
+    pub fn hooks(&mut self, hooks: impl Into<Vec<Hook>>) -> &mut Self {
+        self.hooks = Some(Arc::new(hooks.into()));
         self
     }
 
@@ -730,13 +736,6 @@ impl Agent {
         }
 
         Ok(())
-    }
-
-    fn hooks_by_type(&self, hook_type: HookTypes) -> Vec<&Hook> {
-        self.hooks
-            .iter()
-            .filter(|h| hook_type == (*h).into())
-            .collect()
     }
 
     fn find_tool_by_name(&self, tool_name: &str) -> Option<Box<dyn Tool>> {
@@ -1369,7 +1368,7 @@ mod tests {
             .before_tool(mock_before_tool.before_tool_fn())
             .after_completion(mock_after_completion.after_completion_fn())
             .after_tool(mock_after_tool.after_tool_fn())
-            .after_each(mock_after_each.hook_fn())
+            .after_each(mock_after_each.after_each_fn())
             .on_new_message(mock_on_message.message_hook_fn())
             .on_stop(mock_on_stop.stop_hook_fn())
             .build()

--- a/swiftide-agents/src/hooks.rs
+++ b/swiftide-agents/src/hooks.rs
@@ -11,7 +11,7 @@
 //! # use swiftide_agents::Agent;
 //! # fn test() {
 //! # let mut agent = swiftide_agents::Agent::builder();
-//! agent.before_all(move |agent: &Agent| {
+//! agent.before_all(move |agent: &mut Agent| {
 //!     Box::pin(async move {
 //!         agent.context().add_message(ChatMessage::new_user("Hello, world")).await;
 //!         Ok(())
@@ -38,7 +38,7 @@
 //!
 //! impl<'thing> SomeHook<'thing> {
 //!    fn return_hook<'tool>(&'thing self) -> impl BeforeAllFn + 'tool where 'thing: 'tool {
-//!     move |_: &Agent| {
+//!     move |_: &mut Agent| {
 //!      Box::pin(async move {{ Ok(())}})
 //!     }
 //!   }
@@ -55,7 +55,7 @@ use swiftide_core::chat_completion::{
 use crate::{Agent, errors::AgentError, state::StopReason};
 
 pub trait BeforeAllFn:
-    for<'a> Fn(&'a Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    for<'a> Fn(&'a mut Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
     + Send
     + Sync
     + DynClone
@@ -65,7 +65,7 @@ pub trait BeforeAllFn:
 dyn_clone::clone_trait_object!(BeforeAllFn);
 
 pub trait AfterEachFn:
-    for<'a> Fn(&'a Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    for<'a> Fn(&'a mut Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
     + Send
     + Sync
     + DynClone
@@ -76,7 +76,7 @@ dyn_clone::clone_trait_object!(AfterEachFn);
 
 pub trait BeforeCompletionFn:
     for<'a> Fn(
-        &'a Agent,
+        &'a mut Agent,
         &mut ChatCompletionRequest<'_>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
     + Send
@@ -89,7 +89,7 @@ dyn_clone::clone_trait_object!(BeforeCompletionFn);
 
 pub trait AfterCompletionFn:
     for<'a> Fn(
-        &'a Agent,
+        &'a mut Agent,
         &mut ChatCompletionResponse,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
     + Send
@@ -103,7 +103,7 @@ dyn_clone::clone_trait_object!(AfterCompletionFn);
 /// Hooks that are called after each tool
 pub trait AfterToolFn:
     for<'tool> Fn(
-        &'tool Agent,
+        &'tool mut Agent,
         &ToolCall,
         &'tool mut Result<ToolOutput, ToolError>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'tool>>
@@ -117,7 +117,7 @@ dyn_clone::clone_trait_object!(AfterToolFn);
 
 /// Hooks that are called before each tool
 pub trait BeforeToolFn:
-    for<'a> Fn(&'a Agent, &ToolCall) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    for<'a> Fn(&'a mut Agent, &ToolCall) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
     + Send
     + Sync
     + DynClone
@@ -139,7 +139,7 @@ dyn_clone::clone_trait_object!(MessageHookFn);
 
 /// Hooks that are called when the agent starts, either from pending or stopped
 pub trait OnStartFn:
-    for<'a> Fn(&'a Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    for<'a> Fn(&'a mut Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
     + Send
     + Sync
     + DynClone
@@ -151,7 +151,7 @@ dyn_clone::clone_trait_object!(OnStartFn);
 /// Hooks that are called when the agent stop
 pub trait OnStopFn:
     for<'a> Fn(
-        &'a Agent,
+        &'a mut Agent,
         StopReason,
         Option<&AgentError>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
@@ -204,7 +204,7 @@ pub enum Hook {
 }
 
 impl<F> BeforeAllFn for F where
-    F: for<'a> Fn(&'a Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    F: for<'a> Fn(&'a mut Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
         + Send
         + Sync
         + DynClone
@@ -212,7 +212,7 @@ impl<F> BeforeAllFn for F where
 }
 
 impl<F> AfterEachFn for F where
-    F: for<'a> Fn(&'a Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    F: for<'a> Fn(&'a mut Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
         + Send
         + Sync
         + DynClone
@@ -221,7 +221,7 @@ impl<F> AfterEachFn for F where
 
 impl<F> BeforeCompletionFn for F where
     F: for<'a> Fn(
-            &'a Agent,
+            &'a mut Agent,
             &mut ChatCompletionRequest<'_>,
         ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
         + Send
@@ -232,7 +232,7 @@ impl<F> BeforeCompletionFn for F where
 
 impl<F> AfterCompletionFn for F where
     F: for<'a> Fn(
-            &'a Agent,
+            &'a mut Agent,
             &mut ChatCompletionResponse,
         ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
         + Send
@@ -242,7 +242,10 @@ impl<F> AfterCompletionFn for F where
 }
 
 impl<F> BeforeToolFn for F where
-    F: for<'a> Fn(&'a Agent, &ToolCall) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    F: for<'a> Fn(
+            &'a mut Agent,
+            &ToolCall,
+        ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
         + Send
         + Sync
         + DynClone
@@ -250,7 +253,7 @@ impl<F> BeforeToolFn for F where
 }
 impl<F> AfterToolFn for F where
     F: for<'tool> Fn(
-            &'tool Agent,
+            &'tool mut Agent,
             &ToolCall,
             &'tool mut Result<ToolOutput, ToolError>,
         ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'tool>>
@@ -272,7 +275,7 @@ impl<F> MessageHookFn for F where
 }
 
 impl<F> OnStartFn for F where
-    F: for<'a> Fn(&'a Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
+    F: for<'a> Fn(&'a mut Agent) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>
         + Send
         + Sync
         + DynClone
@@ -281,7 +284,7 @@ impl<F> OnStartFn for F where
 
 impl<F> OnStopFn for F where
     F: for<'a> Fn(
-            &'a Agent,
+            &'a mut Agent,
             StopReason,
             Option<&AgentError>,
         ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>

--- a/swiftide-agents/src/test_utils.rs
+++ b/swiftide-agents/src/test_utils.rs
@@ -9,8 +9,8 @@ use swiftide_core::AgentContext;
 
 use crate::Agent;
 use crate::hooks::{
-    AfterCompletionFn, AfterToolFn, BeforeAllFn, BeforeCompletionFn, BeforeToolFn, MessageHookFn,
-    OnStartFn, OnStopFn, OnStreamFn,
+    AfterCompletionFn, AfterEachFn, AfterToolFn, BeforeAllFn, BeforeCompletionFn, BeforeToolFn,
+    MessageHookFn, OnStartFn, OnStopFn, OnStreamFn,
 };
 
 #[macro_export]
@@ -273,7 +273,20 @@ impl MockHook {
     #[allow(clippy::missing_panics_doc)]
     pub fn hook_fn(&self) -> impl BeforeAllFn + use<> {
         let called = Arc::clone(&self.called);
-        move |_: &Agent| {
+        move |_: &mut Agent| {
+            let called = Arc::clone(&called);
+            Box::pin(async move {
+                let mut called = called.lock().unwrap();
+                *called += 1;
+                Ok(())
+            })
+        }
+    }
+
+    #[allow(clippy::missing_panics_doc)]
+    pub fn after_each_fn(&self) -> impl AfterEachFn + use<> {
+        let called = Arc::clone(&self.called);
+        move |_: &mut Agent| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -286,7 +299,7 @@ impl MockHook {
     #[allow(clippy::missing_panics_doc)]
     pub fn on_start_fn(&self) -> impl OnStartFn + use<> {
         let called = Arc::clone(&self.called);
-        move |_: &Agent| {
+        move |_: &mut Agent| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -298,7 +311,7 @@ impl MockHook {
     #[allow(clippy::missing_panics_doc)]
     pub fn before_completion_fn(&self) -> impl BeforeCompletionFn + use<> {
         let called = Arc::clone(&self.called);
-        move |_: &Agent, _| {
+        move |_: &mut Agent, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -311,7 +324,7 @@ impl MockHook {
     #[allow(clippy::missing_panics_doc)]
     pub fn after_completion_fn(&self) -> impl AfterCompletionFn + use<> {
         let called = Arc::clone(&self.called);
-        move |_: &Agent, _| {
+        move |_: &mut Agent, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -324,7 +337,7 @@ impl MockHook {
     #[allow(clippy::missing_panics_doc)]
     pub fn after_tool_fn(&self) -> impl AfterToolFn + use<> {
         let called = Arc::clone(&self.called);
-        move |_: &Agent, _, _| {
+        move |_: &mut Agent, _, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -337,7 +350,7 @@ impl MockHook {
     #[allow(clippy::missing_panics_doc)]
     pub fn before_tool_fn(&self) -> impl BeforeToolFn + use<> {
         let called = Arc::clone(&self.called);
-        move |_: &Agent, _| {
+        move |_: &mut Agent, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();
@@ -363,7 +376,7 @@ impl MockHook {
     #[allow(clippy::missing_panics_doc)]
     pub fn stop_hook_fn(&self) -> impl OnStopFn + use<> {
         let called = Arc::clone(&self.called);
-        move |_: &Agent, _, _| {
+        move |_: &mut Agent, _, _| {
             let called = Arc::clone(&called);
             Box::pin(async move {
                 let mut called = called.lock().unwrap();

--- a/swiftide-agents/src/util.rs
+++ b/swiftide-agents/src/util.rs
@@ -5,7 +5,11 @@
 macro_rules! invoke_hooks {
     (OnStream, $self_expr:expr $(, $arg:expr)* ) => {{
         // For streaming we log less and only on the trace level
-        for hook in $self_expr.hooks_by_type(HookTypes::OnStream) {
+        let hooks = std::sync::Arc::clone(&$self_expr.hooks);
+        for hook in hooks
+            .iter()
+            .filter(|hook| HookTypes::OnStream == (*hook).into())
+        {
             // Downcast to the correct closure variant
             if let Hook::OnStream(hook_fn) = hook {
                 // Create a tracing span for instrumentation
@@ -29,7 +33,11 @@ macro_rules! invoke_hooks {
     }};
     ($hook_type:ident, $self_expr:expr $(, $arg:expr)* ) => {{
         // Iterate through every hook matching `HookTypes::$hook_type`
-        for hook in $self_expr.hooks_by_type(HookTypes::$hook_type) {
+        let hooks = std::sync::Arc::clone(&$self_expr.hooks);
+        for hook in hooks
+            .iter()
+            .filter(|hook| HookTypes::$hook_type == (*hook).into())
+        {
             // Downcast to the correct closure variant
             if let Hook::$hook_type(hook_fn) = hook {
                 // Create a tracing span for instrumentation


### PR DESCRIPTION
## Summary

- Store agent hooks behind an `Arc<Vec<Hook>>` so hook invocation can snapshot the hook list without borrowing the agent.
- Pass `&mut Agent` to lifecycle, completion, tool, start, stop, and after-each hooks.
- Keep `OnNewMessage` and `OnStream` immutable so `add_message(&self, ...)` and streaming behavior remain unchanged.
- Collapse hook invocation back to the single `invoke_hooks!` macro.

## Validation

- `cargo check -p swiftide-agents`
- `cargo test -p swiftide-agents test_agent_hooks`
- `cargo +nightly fmt --all -- --check`
- `cargo clippy -p swiftide-agents --all-targets --all-features -- -D warnings`
- `cargo test --doc -p swiftide-agents`

Only the existing `edition2024` manifest warnings were emitted.