### PR TITLE
fix(core): avoid panic truncating multibyte data URLs

### DIFF
--- a/swiftide-core/src/chat_completion/chat_message.rs
+++ b/swiftide-core/src/chat_completion/chat_message.rs
@@ -398,10 +398,58 @@ fn truncate_data_url(url: &str) -> Cow<'_, str> {
         return Cow::Borrowed(url);
     }
 
-    let preview = &data[..MAX_DATA_PREVIEW];
-    let truncated = data.len() - MAX_DATA_PREVIEW;
+    // `MAX_DATA_PREVIEW` is a byte offset; back it up to the nearest char
+    // boundary so a multibyte payload cannot panic the slice.
+    let mut end = MAX_DATA_PREVIEW;
+    while !data.is_char_boundary(end) {
+        end -= 1;
+    }
+    let preview = &data[..end];
+    let truncated = data.len() - end;
 
     Cow::Owned(format!(
         "{prefix},{preview}...[truncated {truncated} chars]"
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_data_url_handles_multibyte_boundary() {
+        // 31 ASCII bytes followed by a 4-byte char put a character across byte
+        // 32, so the previous `&data[..32]` slice panicked. Guard the fix.
+        let data = format!("{}{}", "a".repeat(31), '\u{1F600}');
+        assert!(
+            !data.is_char_boundary(32),
+            "test setup: byte 32 must split a char"
+        );
+
+        let url = format!("data:text/plain,{data}");
+        let out = truncate_data_url(&url);
+
+        let expected = format!("data:text/plain,{}...[truncated 4 chars]", "a".repeat(31));
+        assert_eq!(out.as_ref(), expected);
+    }
+
+    #[test]
+    fn debug_url_source_does_not_panic_on_multibyte_data_url() {
+        let data = format!("{}{}", "a".repeat(31), '\u{1F600}');
+        let source = ChatMessageContentSource::url(format!("data:text/plain,{data}"));
+        // The Debug impl routes through `truncate_data_url`; it must not panic.
+        let _ = format!("{source:?}");
+    }
+
+    #[test]
+    fn truncate_data_url_leaves_non_data_and_short_urls_untouched() {
+        assert_eq!(
+            truncate_data_url("https://example.com/x").as_ref(),
+            "https://example.com/x"
+        );
+        assert_eq!(
+            truncate_data_url("data:text/plain,short").as_ref(),
+            "data:text/plain,short"
+        );
+    }
 }

--- a/swiftide-integrations/src/aws_bedrock_v2/mod.rs
+++ b/swiftide-integrations/src/aws_bedrock_v2/mod.rs
@@ -770,8 +770,14 @@ fn truncate_data_url(url: &str) -> Option<String> {
         return None;
     }
 
-    let preview = &data[..MAX_DATA_PREVIEW];
-    let truncated = data.len() - MAX_DATA_PREVIEW;
+    // `MAX_DATA_PREVIEW` is a byte offset; back it up to the nearest char
+    // boundary so a multibyte payload cannot panic the slice.
+    let mut end = MAX_DATA_PREVIEW;
+    while !data.is_char_boundary(end) {
+        end -= 1;
+    }
+    let preview = &data[..end];
+    let truncated = data.len() - end;
 
     Some(format!(
         "{prefix},{preview}...[truncated {truncated} chars]"

--- a/swiftide-integrations/src/openai/chat_completion.rs
+++ b/swiftide-integrations/src/openai/chat_completion.rs
@@ -541,8 +541,14 @@ fn truncate_data_url(url: &str) -> Option<String> {
         return None;
     }
 
-    let preview = &data[..MAX_DATA_PREVIEW];
-    let truncated = data.len() - MAX_DATA_PREVIEW;
+    // `MAX_DATA_PREVIEW` is a byte offset; back it up to the nearest char
+    // boundary so a multibyte payload cannot panic the slice.
+    let mut end = MAX_DATA_PREVIEW;
+    while !data.is_char_boundary(end) {
+        end -= 1;
+    }
+    let preview = &data[..end];
+    let truncated = data.len() - end;
 
     Some(format!(
         "{prefix},{preview}...[truncated {truncated} chars]"


### PR DESCRIPTION
## Problem

`truncate_data_url` slices a `data:` URL payload at a fixed byte offset:

```rust
let preview = &data[..MAX_DATA_PREVIEW]; // MAX_DATA_PREVIEW = 32
```

The preceding `data.len() <= MAX_DATA_PREVIEW` check guards against an out-of-bounds slice, but not against slicing in the middle of a multibyte UTF-8 character. When byte 32 lands inside a multibyte char, the slice panics with `byte index 32 is not a char boundary`.

In `swiftide-core` this helper backs the `Debug` impl for `ChatMessageContentSource::Url`, so any `{:?}` / tracing of a chat message whose content is such a `data:` URL panics. It is not feature gated.

Minimal reproduction:

```rust
let data = format!("{}{}", "a".repeat(31), '\u{1F600}'); // 4-byte char spanning byte 32
let _ = format!("{:?}", ChatMessageContentSource::url(format!("data:text/plain,{data}")));
// panics: byte index 32 is not a char boundary
```

The same helper is duplicated in the `langfuse`-gated `openai` and `aws_bedrock_v2` integrations with the identical bug.

## Fix

Back the cut down to the nearest char boundary with `str::is_char_boundary` before slicing, and report the actual truncated byte count. Applied to all three copies.

Added regression tests in `swiftide-core` covering the multibyte boundary, the `Debug` path, and the non-`data:` / short-url passthrough.

## Verification

- `cargo test -p swiftide-core` passes (including the new tests)
- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy -p swiftide-core --all-features -- -D warnings` clean
- `cargo check -p swiftide-integrations --features langfuse,openai,aws-bedrock` builds
