### PR TITLE
fix(integrations): return errors instead of panicking for unsupported tree-sitter languages

### DIFF
--- a/swiftide-integrations/src/treesitter/code_tree.rs
+++ b/swiftide-integrations/src/treesitter/code_tree.rs
@@ -54,6 +54,7 @@ pub struct CodeTree<'a> {
     language: SupportedLanguages,
 }
 
+#[derive(Debug)]
 pub struct ReferencesAndDefinitions {
     pub references: Vec<String>,
     pub definitions: Vec<String>,
@@ -67,7 +68,7 @@ impl CodeTree<'_> {
     ///
     /// Errors if the query is invalid or fails
     pub fn references_and_definitions(&self) -> Result<ReferencesAndDefinitions> {
-        let (defs, refs) = ts_queries_for_language(self.language);
+        let (defs, refs) = ts_queries_for_language(self.language)?;
 
         let defs_query = Query::new(&self.language.into(), defs)?;
         let refs_query = Query::new(&self.language.into(), refs)?;
@@ -108,13 +109,13 @@ impl CodeTree<'_> {
     }
 }
 
-fn ts_queries_for_language(language: SupportedLanguages) -> (&'static str, &'static str) {
+fn ts_queries_for_language(language: SupportedLanguages) -> Result<(&'static str, &'static str)> {
     use SupportedLanguages::{
         C, CSharp, Cpp, Elixir, Go, HTML, Java, Javascript, PHP, Python, Ruby, Rust, Solidity,
         Typescript,
     };
 
-    match language {
+    let queries = match language {
         Rust => (rust::DEFS, rust::REFS),
         Python => (python::DEFS, python::REFS),
         // The univocal proof that TS is just a linter
@@ -125,8 +126,11 @@ fn ts_queries_for_language(language: SupportedLanguages) -> (&'static str, &'sta
         Go => (go::DEFS, go::REFS),
         CSharp => (csharp::DEFS, csharp::REFS),
         Solidity => (solidity::DEFS, solidity::REFS),
-        C | Cpp | Elixir | PHP | HTML => unimplemented!(),
-    }
+        C | Cpp | Elixir | PHP | HTML => {
+            anyhow::bail!("References and definitions are not implemented for {language:?}")
+        }
+    };
+    Ok(queries)
 }
 
 #[cfg(test)]
@@ -148,6 +152,21 @@ mod tests {
         assert_eq!(result.references, vec!["println"]);
 
         assert_eq!(result.definitions, vec!["main"]);
+    }
+
+    #[test]
+    fn test_references_and_definitions_unimplemented_language_errors_instead_of_panicking() {
+        // C is a valid `SupportedLanguages` with a linked grammar but has no defs/refs queries,
+        // so this path used to `unimplemented!()` and panic. It must now return a clean error.
+        let parser = CodeParser::from_language(SupportedLanguages::C);
+        let tree = parser.parse("int main(void) { return 0; }").unwrap();
+        let err = tree.references_and_definitions().expect_err(
+            "references_and_definitions for an unimplemented language must error, not panic",
+        );
+        assert!(
+            err.to_string().contains("not implemented"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/swiftide-integrations/src/treesitter/outliner.rs
+++ b/swiftide-integrations/src/treesitter/outliner.rs
@@ -93,12 +93,12 @@ impl CodeOutliner {
         let mut cursor = root_node.walk();
         let mut summary = String::with_capacity(code.len());
         let mut last_end = 0;
-        self.outline_node(&mut cursor, code, &mut summary, &mut last_end);
+        self.outline_node(&mut cursor, code, &mut summary, &mut last_end)?;
         Ok(summary)
     }
 
-    fn is_unneeded_node(&self, node: Node) -> bool {
-        match self.language {
+    fn is_unneeded_node(&self, node: Node) -> Result<bool> {
+        let unneeded = match self.language {
             SupportedLanguages::Rust | SupportedLanguages::Java | SupportedLanguages::CSharp => {
                 matches!(node.kind(), "block")
             }
@@ -121,14 +121,17 @@ impl CodeOutliner {
                 }
                 _ => false,
             },
-            SupportedLanguages::Go => unimplemented!(),
-            SupportedLanguages::Solidity => unimplemented!(),
-            SupportedLanguages::C => unimplemented!(),
-            SupportedLanguages::Cpp => unimplemented!(),
-            SupportedLanguages::Elixir => unimplemented!(),
-            SupportedLanguages::HTML => unimplemented!(),
-            SupportedLanguages::PHP => unimplemented!(),
-        }
+            SupportedLanguages::Go
+            | SupportedLanguages::Solidity
+            | SupportedLanguages::C
+            | SupportedLanguages::Cpp
+            | SupportedLanguages::Elixir
+            | SupportedLanguages::HTML
+            | SupportedLanguages::PHP => {
+                anyhow::bail!("Outlining is not implemented for {:?}", self.language)
+            }
+        };
+        Ok(unneeded)
     }
 
     /// outlines a syntax node
@@ -148,23 +151,23 @@ impl CodeOutliner {
         source: &str,
         summary: &mut String,
         last_end: &mut usize,
-    ) {
+    ) -> Result<()> {
         let node = cursor.node();
         // If the node is not needed in the summary, skip it and go to the next sibling
-        if self.is_unneeded_node(node) {
+        if self.is_unneeded_node(node)? {
             summary.push_str(&source[*last_end..node.start_byte()]);
             *last_end = node.end_byte();
             if cursor.goto_next_sibling() {
-                self.outline_node(cursor, source, summary, last_end);
+                self.outline_node(cursor, source, summary, last_end)?;
             }
-            return;
+            return Ok(());
         }
 
         let mut next_cursor = cursor.clone();
 
         // If the node is a non-leaf, recursively outline its children
         if next_cursor.goto_first_child() {
-            self.outline_node(&mut next_cursor, source, summary, last_end);
+            self.outline_node(&mut next_cursor, source, summary, last_end)?;
         // If the node is a leaf, add the text to the summary
         } else {
             summary.push_str(&source[*last_end..node.end_byte()]);
@@ -172,10 +175,11 @@ impl CodeOutliner {
         }
 
         if cursor.goto_next_sibling() {
-            self.outline_node(cursor, source, summary, last_end);
+            self.outline_node(cursor, source, summary, last_end)?;
         } else {
             // Done with this node
         }
+        Ok(())
     }
 }
 
@@ -307,6 +311,22 @@ class Bla {
         assert_eq!(
             summary,
             "\nimport { Context as _, Result } from 'anyhow';\n// This is a comment\nfunction main(a, b) \n\nclass Bla {\n    constructor() \n\n    ok() \n}"
+        );
+    }
+
+    #[test]
+    fn test_outline_unimplemented_language_errors_instead_of_panicking() {
+        // Go is a valid `SupportedLanguages` variant with a linked grammar, so the code parses
+        // and reaches `is_unneeded_node`, which has no outline rules for it. That path used to
+        // `unimplemented!()` and panic; it must now surface a clean error.
+        let code = "package main\nfunc main() {\n\tprintln(\"hello\")\n}\n";
+        let outliner = CodeOutliner::new(SupportedLanguages::Go);
+        let err = outliner
+            .outline(code)
+            .expect_err("outlining an unimplemented language must return an error, not panic");
+        assert!(
+            err.to_string().contains("not implemented"),
+            "unexpected error: {err}"
         );
     }
 


### PR DESCRIPTION
CodeOutliner::outline and CodeTree::references_and_definitions call unimplemented!() for SupportedLanguages variants that have a linked grammar but no outline/query rules (Go, C, C++, Elixir, Solidity, HTML, PHP). These are reachable through the public OutlineCodeTreeSitter and MetadataRefsDefsCode transformers, which build for any valid language via try_from_language, so indexing code in one of those languages panics the pipeline.

Both methods already return Result, so this threads the error through and bails with a clear message instead of panicking. Regression tests added for the Go and C paths; ReferencesAndDefinitions now derives Debug so the error path is testable.