### PR TITLE
fix(ci): restore master checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,7 @@
 [workspace]
 changelog_path = "./CHANGELOG.md"
 #changelog_config = "cliff.toml"
-git_tag_name = "v{{ version }}"
+git_tag_name = "{{ package }}-v{{ version }}"
 changelog_update = false
 git_tag_enable = false
 git_release_enable = false
@@ -24,6 +24,8 @@ changelog_include = [
   "swiftide-test-utils",
   "swiftide-agents",
   "swiftide-macros",
+  "swiftide-tasks",
+  "swiftide-langfuse",
 ]
 changelog_update = true
 

--- a/swiftide-core/src/chat_completion/chat_completion_response.rs
+++ b/swiftide-core/src/chat_completion/chat_completion_response.rs
@@ -484,7 +484,7 @@ impl ChatCompletionResponse {
         completion_tokens: u32,
         total_tokens: u32,
     ) -> &mut Self {
-        debug_assert!(prompt_tokens + completion_tokens == total_tokens);
+        debug_assert_eq!(prompt_tokens + completion_tokens, total_tokens);
 
         if let Some(usage) = &mut self.usage {
             usage.prompt_tokens += prompt_tokens;

--- a/swiftide-core/src/document.rs
+++ b/swiftide-core/src/document.rs
@@ -134,7 +134,7 @@ mod tests {
         let doc1 = Document::new("A", None);
         let doc2 = Document::new("B", None);
 
-        assert!(doc1.cmp(&doc2) == std::cmp::Ordering::Less);
+        assert_eq!(doc1.cmp(&doc2), std::cmp::Ordering::Less);
     }
 
     #[test]

--- a/swiftide-core/src/query.rs
+++ b/swiftide-core/src/query.rs
@@ -277,8 +277,8 @@ impl std::fmt::Debug for TransformationEvent {
                 write!(
                     f,
                     "Transformed: {} -> {}",
-                    &debug_long_utf8(before, 100),
-                    &debug_long_utf8(after, 100)
+                    debug_long_utf8(before, 100),
+                    debug_long_utf8(after, 100)
                 )
             }
             TransformationEvent::Retrieved {
@@ -289,8 +289,8 @@ impl std::fmt::Debug for TransformationEvent {
                 write!(
                     f,
                     "Retrieved: {} -> {}\nDocuments: {:?}",
-                    &debug_long_utf8(before, 100),
-                    &debug_long_utf8(after, 100),
+                    debug_long_utf8(before, 100),
+                    debug_long_utf8(after, 100),
                     documents.len()
                 )
             }

--- a/swiftide-integrations/src/duckdb/node_cache.rs
+++ b/swiftide-integrations/src/duckdb/node_cache.rs
@@ -37,7 +37,7 @@ impl<T: Chunk> NodeCache for Duckdb<T> {
 
         let sql = format!(
             "SELECT EXISTS(SELECT 1 FROM {} WHERE uuid = ?)",
-            &self.cache_table
+            self.cache_table
         );
 
         let lock = self.connection.lock().unwrap();
@@ -68,7 +68,7 @@ impl<T: Chunk> NodeCache for Duckdb<T> {
 
         let sql = format!(
             "INSERT INTO {} (uuid, path) VALUES (?, ?) ON CONFLICT (uuid) DO NOTHING",
-            &self.cache_table
+            self.cache_table
         );
 
         let lock = self.connection.lock().unwrap();
@@ -95,7 +95,7 @@ impl<T: Chunk> NodeCache for Duckdb<T> {
     }
 
     async fn clear(&self) -> anyhow::Result<()> {
-        let sql = format!("DROP TABLE IF EXISTS {}", &self.cache_table);
+        let sql = format!("DROP TABLE IF EXISTS {}", self.cache_table);
         let lock = self.connection.lock().unwrap();
         let mut stmt = lock
             .prepare(&sql)

--- a/swiftide-integrations/src/openai/responses_api.rs
+++ b/swiftide-integrations/src/openai/responses_api.rs
@@ -129,11 +129,8 @@ fn convert_metadata(value: &serde_json::Value) -> Option<HashMap<String, String>
         serde_json::Value::Object(map) => {
             let mut out = HashMap::with_capacity(map.len());
             for (key, val) in map {
-                if let Some(s) = val.as_str() {
-                    out.insert(key.clone(), s.to_owned());
-                } else {
-                    return None;
-                }
+                let value = val.as_str()?;
+                out.insert(key.clone(), value.to_owned());
             }
             Some(out)
         }

--- a/swiftide-integrations/src/parquet/loader.rs
+++ b/swiftide-integrations/src/parquet/loader.rs
@@ -41,7 +41,7 @@ impl Loader for Parquet {
                     None
                 }
             })
-            .unwrap_or_else(|| panic!("Column {} not found in dataset", &self.column_name));
+            .unwrap_or_else(|| panic!("Column {} not found in dataset", self.column_name));
 
         let mask = ProjectionMask::roots(file_metadata.schema_descr(), [column_idx]);
         builder = builder.with_projection(mask);

--- a/swiftide-integrations/src/pgvector/pgv_table_types.rs
+++ b/swiftide-integrations/src/pgvector/pgv_table_types.rs
@@ -227,7 +227,7 @@ impl PgVector {
 
         Ok(format!(
             "CREATE INDEX IF NOT EXISTS {} ON {} USING hnsw ({} vector_cosine_ops)",
-            index_name, &self.table_name, vector_field
+            index_name, self.table_name, vector_field
         ))
     }
 

--- a/swiftide-macros/src/test_utils.rs
+++ b/swiftide-macros/src/test_utils.rs
@@ -1,6 +1,6 @@
 pub fn pretty_macro_output(item: &proc_macro2::TokenStream) -> String {
     let file = syn::parse_file(&item.to_string())
-        .unwrap_or_else(|_| panic!("Failed to parse token stream: {}", &item.to_string()));
+        .unwrap_or_else(|_| panic!("Failed to parse token stream: {item}"));
     prettyplease::unparse(&file)
 }
 


### PR DESCRIPTION
## What changed

- update `ethnum` to `1.5.3`, which compiles with the current stable Rust toolchain
- resolve new Rust 1.97 Clippy findings without changing behavior
- give internal crates package-specific tag namespaces while retaining the single `swiftide` release tag
- include `swiftide-tasks` and `swiftide-langfuse` changes in the shared changelog

## Why

Master CI failed before reaching Swiftide because `ethnum 1.5.2` relied on a `TryFromIntError`
size assumption that changed in the current Rust toolchain. Once that was fixed, the lint job
exposed new deny-by-default Clippy findings.

Release automation also treated the old global `v0.32.1` tag as the baseline for the new
unpublished `swiftide-tasks` crate. Package-specific internal tag namespaces avoid that collision
without creating extra tags; `swiftide` remains the only package that emits a Git tag and GitHub
release.

## Validation

- `cargo check --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo test -p swiftide-core`
- `cargo test -p swiftide-integrations responses_api --all-features`
- `cargo test -p swiftide-macros`
- `cargo test --doc --all-features --no-fail-fast`
- isolated `release-plz update -p swiftide-tasks --allow-dirty`
