### PR TITLE
fix(ci): restore master checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,8 @@ jobs:
         uses: crate-ci/typos@master
       - name: Lint dependencies
         uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "1.97.1"
       - name: clippy
         run: cargo clippy --all-targets --all-features --workspace
         env:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -5,6 +5,7 @@ git_tag_name = "{{ package }}-v{{ version }}"
 changelog_update = false
 git_tag_enable = false
 git_release_enable = false
+release_always = false
 repo_url = "https://github.com/bosun-ai/swiftide"
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.97.1"
+components = ["clippy"]


### PR DESCRIPTION
## What changed

- publish crates only after merging the release pull request
- install Clippy for the pinned Rust toolchain
- run cargo-deny with that same Rust version

## Why

Ordinary master pushes tried to publish the new swiftide-tasks crate as version 0.32.1. Its source targets the newer workspace swiftide-core API, so verification against the published swiftide-core 0.32.1 failed. The existing release pull request moves the workspace to 0.33.0 and can publish crates in dependency order.

The dependency update also pinned Rust 1.97.1 while CI installed tools for the moving stable alias. As a result, hosted Clippy could not find its component and the cargo-deny container did not have the selected toolchain.

## Checks

- cargo +nightly fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo deny --workspace check
- release-plz release --dry-run

Cargo Hack was left to hosted CI.