### PR TITLE
fix(ci): ignore external FastEmbed tests

### DIFF
--- a/swiftide-integrations/src/fastembed/mod.rs
+++ b/swiftide-integrations/src/fastembed/mod.rs
@@ -122,6 +122,7 @@ impl FastEmbedBuilder {
 mod tests {
     use super::*;
 
+    #[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
     #[tokio::test]
     async fn test_fastembed() {
         let fastembed = FastEmbed::try_default().unwrap();
@@ -129,6 +130,7 @@ mod tests {
         assert_eq!(embeddings.len(), 1);
     }
 
+    #[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
     #[tokio::test]
     async fn test_sparse_fastembed() {
         let fastembed = FastEmbed::try_default_sparse().unwrap();

--- a/swiftide/tests/dyn_traits.rs
+++ b/swiftide/tests/dyn_traits.rs
@@ -15,6 +15,7 @@ use swiftide_core::{
 use swiftide_indexing::{loaders, transformers};
 use swiftide_integrations::fastembed::FastEmbed;
 
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 async fn test_name_on_dyn() {
     let fastembed: Box<dyn EmbeddingModel> = Box::new(FastEmbed::try_default().unwrap());

--- a/swiftide/tests/lancedb.rs
+++ b/swiftide/tests/lancedb.rs
@@ -23,6 +23,7 @@ use swiftide_test_utils::{mock_chat_completions, openai_client};
 use temp_dir::TempDir;
 use wiremock::MockServer;
 
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 async fn test_lancedb() {
     // Setup temporary directory and file for testing
@@ -100,6 +101,7 @@ async fn test_lancedb() {
     );
 }
 
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 async fn test_lancedb_retrieve_dynamic_search() {
     // Setup temporary directory and file for testing

--- a/swiftide/tests/pgvector.rs
+++ b/swiftide/tests/pgvector.rs
@@ -139,6 +139,7 @@ async fn test_pgvector_indexing() {
 /// a mock `OpenAI` client, configures `PgVector`, and executes a query
 /// to ensure the pipeline retrieves the correct data and generates
 /// an expected response.
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 async fn test_pgvector_retrieve() {
     // Setup temporary directory and file for testing
@@ -267,6 +268,7 @@ async fn test_pgvector_retrieve() {
 /// - Define search parameters as constants in the implementation scope
 /// - Pass configuration through the query generator closure
 /// - Keep the strategy struct minimal and focused on query generation
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 #[allow(clippy::too_many_lines)]
 async fn test_pgvector_retrieve_dynamic_search() {

--- a/swiftide/tests/query_pipeline.rs
+++ b/swiftide/tests/query_pipeline.rs
@@ -14,6 +14,7 @@ use swiftide_test_utils::*;
 use temp_dir::TempDir;
 use wiremock::MockServer;
 
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 async fn test_query_pipeline() {
     // Setup temporary directory and file for testing
@@ -68,6 +69,7 @@ async fn test_query_pipeline() {
     assert!(!result.answer().is_empty());
 }
 
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 async fn test_hybrid_search_qdrant() {
     // Setup temporary directory and file for testing

--- a/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
+++ b/swiftide/tests/sparse_embeddings_and_hybrid_search.rs
@@ -29,6 +29,7 @@ use wiremock::MockServer;
 /// # Errors
 /// If the indexing pipeline encounters an error, the test will print the received requests
 /// for debugging purposes.
+#[ignore = "downloads HuggingFace embedding models and can hit external rate limits"]
 #[test_log::test(tokio::test)]
 #[allow(clippy::too_many_lines)]
 async fn test_sparse_indexing_pipeline() {


### PR DESCRIPTION
## Why

The master test run fails when Hugging Face rate-limits FastEmbed model downloads with HTTP 429.

## What changed

- Ignore the ten tests that download FastEmbed models
- Keep them available through `cargo test -- --ignored`

## Checks

- `cargo +nightly fmt --all -- --check`
- FastEmbed unit tests: 2 ignored, no failures
- Integration test sources compile; local linking is unavailable because DuckDB is not installed
- Cargo Hack left to hosted CI