### PR TITLE
fix(release): limit changelog to latest release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,35 @@ jobs:
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Match package changelogs to the shared release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_tag="$(git tag --list 'v*' --sort=-version:refname | head -n 1)"
+          test -n "$release_tag"
+          release_version="${release_tag#v}"
+
+          cargo metadata --no-deps --format-version 1 |
+            jq -r '.packages[] | select(.publish != []) | .name' |
+            while read -r package; do
+              status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' \
+                --user-agent 'swiftide-release-workflow' \
+                "https://crates.io/api/v1/crates/${package}/${release_version}")"
+
+              case "$status" in
+                200)
+                  package_tag="${package}-v${release_version}"
+                  git rev-parse --verify --quiet "refs/tags/${package_tag}" >/dev/null ||
+                    git tag "$package_tag" "$release_tag"
+                  ;;
+                404) ;;
+                *)
+                  echo "crates.io returned HTTP ${status} for ${package} ${release_version}" >&2
+                  exit 1
+                  ;;
+              esac
+            done
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,6 +6,9 @@ changelog_update = false
 git_tag_enable = false
 git_release_enable = false
 release_always = false
+# swiftide-tasks is unpublished and shares the root README. Five relevant path commits exist
+# after v0.32.1; release-plz ignores this limit once the crate has been published.
+max_analyze_commits = 5
 repo_url = "https://github.com/bosun-ai/swiftide"
 
 [[package]]


### PR DESCRIPTION
## What changed

- create local package tag aliases from the latest shared release tag before release-plz runs
- only create aliases for package versions that already exist on crates.io
- limit first-release history for the unpublished `swiftide-tasks` crate

## Why

The workspace now uses package-specific tags for changelog ranges, while recent releases only have a shared `v0.32.1` tag. Without local aliases, release-plz scans older package history and includes changes from previous releases.

The aliases remain local to the release job, so public releases continue to use one shared Swiftide tag and GitHub release.

## Validation

- regenerated the release with release-plz 0.3.160
- confirmed all nine publishable crates update from 0.32.1 to 0.33.0
- confirmed all 44 crate-path commits since `v0.32.1` are included, plus one README-only fix
- confirmed no generated entry predates `v0.32.1`
- `actionlint .github/workflows/release.yml`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`