### PR TITLE
fix(indexing): cache nodes only after the pipeline finishes them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4434,9 +4434,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10205,6 +10205,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/swiftide-core/src/indexing_traits.rs
+++ b/swiftide-core/src/indexing_traits.rs
@@ -422,6 +422,11 @@ pub trait NodeCache: Send + Sync + Debug + DynClone {
     async fn get(&self, node: &Node<Self::Input>) -> bool;
     async fn set(&self, node: &Node<Self::Input>);
 
+    /// Marks the node identified by `id` as cached. Used by the pipeline to cache nodes only
+    /// after they made it through the whole pipeline, so a node that failed midway is not
+    /// skipped on the next run.
+    async fn set_by_id(&self, id: uuid::Uuid);
+
     /// Optionally provide a method to clear the cache
     async fn clear(&self) -> Result<()> {
         unimplemented!("Clear not implemented")
@@ -445,6 +450,7 @@ mock! {
         type Input = String;
         async fn get(&self, node: &Node<String>) -> bool;
         async fn set(&self, node: &Node<String>);
+        async fn set_by_id(&self, id: uuid::Uuid);
         async fn clear(&self) -> Result<()>;
         fn name(&self) -> &'static str;
 
@@ -465,6 +471,9 @@ impl<T: Chunk> NodeCache for Box<dyn NodeCache<Input = T>> {
     async fn set(&self, node: &Node<T>) {
         self.as_ref().set(node).await;
     }
+    async fn set_by_id(&self, id: uuid::Uuid) {
+        self.as_ref().set_by_id(id).await;
+    }
     async fn clear(&self) -> Result<()> {
         self.as_ref().clear().await
     }
@@ -482,6 +491,9 @@ impl<T: Chunk> NodeCache for Arc<dyn NodeCache<Input = T>> {
     async fn set(&self, node: &Node<T>) {
         self.as_ref().set(node).await;
     }
+    async fn set_by_id(&self, id: uuid::Uuid) {
+        self.as_ref().set_by_id(id).await;
+    }
     async fn clear(&self) -> Result<()> {
         self.as_ref().clear().await
     }
@@ -498,6 +510,9 @@ impl<T: Chunk> NodeCache for &dyn NodeCache<Input = T> {
     }
     async fn set(&self, node: &Node<T>) {
         (*self).set(node).await;
+    }
+    async fn set_by_id(&self, id: uuid::Uuid) {
+        (*self).set_by_id(id).await;
     }
     async fn clear(&self) -> Result<()> {
         (*self).clear().await

--- a/swiftide-core/src/node.rs
+++ b/swiftide-core/src/node.rs
@@ -71,6 +71,11 @@ pub struct Node<T: Chunk> {
     /// from in bytes
     #[builder(default)]
     pub offset: usize,
+    /// Id of the first node this node was derived from. Set when a node is created via
+    /// [`Node::build_from_other`] (chunking, conversions) so derived nodes keep pointing at the
+    /// node that entered the pipeline.
+    #[builder(default)]
+    pub parent_id: Option<uuid::Uuid>,
 }
 
 pub type TextNode = Node<String>;
@@ -136,6 +141,8 @@ impl<T: Chunk> Debug for Node<T> {
 impl<T: Chunk> Node<T> {
     /// Builds a new instance of `Node`, returning a `NodeBuilder`. Copies
     /// over the fields from the provided `Node`.
+    ///
+    /// The new node points at the node that entered the pipeline via [`Node::parent_id`].
     pub fn build_from_other(node: &Node<T>) -> NodeBuilder<T> {
         NodeBuilder::default()
             .path(node.path.clone())
@@ -146,6 +153,7 @@ impl<T: Chunk> Node<T> {
             .embed_mode(node.embed_mode)
             .original_size(node.original_size)
             .offset(node.offset)
+            .parent_id(node.parent_id.unwrap_or_else(|| node.id()))
             .to_owned()
     }
 
@@ -199,6 +207,11 @@ impl<T: Chunk> Node<T> {
         let bytes = [self.path.as_os_str().as_bytes(), self.chunk.as_ref()].concat();
 
         uuid::Uuid::new_v3(&uuid::Uuid::NAMESPACE_OID, &bytes)
+    }
+
+    /// Returns the id of the first node this node was derived from, if any.
+    pub fn parent_id(&self) -> Option<uuid::Uuid> {
+        self.parent_id
     }
 }
 
@@ -356,7 +369,12 @@ mod tests {
         let builder = Node::build_from_other(&original_node);
         let new_node = builder.build().unwrap();
 
-        assert_eq!(original_node, new_node);
+        assert_eq!(new_node.parent_id(), Some(original_node.id()));
+        assert_eq!(new_node.chunk, original_node.chunk);
+        assert_eq!(new_node.path, original_node.path);
+        assert_eq!(new_node.metadata, original_node.metadata);
+        assert_eq!(new_node.vectors, original_node.vectors);
+        assert_eq!(new_node.sparse_vectors, original_node.sparse_vectors);
     }
 
     #[test]
@@ -382,6 +400,20 @@ mod tests {
         let builder = Node::build_from_other(&original_node);
         let new_node = builder.build().unwrap();
 
-        assert_eq!(original_node, new_node);
+        assert_eq!(new_node.parent_id(), Some(original_node.id()));
+        assert_eq!(new_node.chunk, original_node.chunk);
+        assert_eq!(new_node.vectors, original_node.vectors);
+        assert_eq!(new_node.sparse_vectors, original_node.sparse_vectors);
+    }
+
+    #[test]
+    fn test_build_from_other_keeps_first_ancestor_as_parent() {
+        let original_node = Node::from("test_chunk");
+        let child_node = Node::build_from_other(&original_node).build().unwrap();
+        let grandchild_node = Node::build_from_other(&child_node).build().unwrap();
+
+        assert_eq!(original_node.parent_id(), None);
+        assert_eq!(child_node.parent_id(), Some(original_node.id()));
+        assert_eq!(grandchild_node.parent_id(), Some(original_node.id()));
     }
 }

--- a/swiftide-indexing/Cargo.toml
+++ b/swiftide-indexing/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 indoc = { workspace = true }
+uuid = { workspace = true }
 
 ignore = { workspace = true }
 text-splitter = { workspace = true, features = ["markdown"] }

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -12,9 +12,15 @@ use tokio::{
 };
 use tracing::Instrument;
 
-use std::{pin::Pin, sync::Arc, time::Duration};
+use std::{
+    collections::HashSet,
+    pin::Pin,
+    sync::{Arc, Mutex as StdMutex},
+    time::Duration,
+};
 
 use swiftide_core::indexing::{EmbedMode, IndexingStream, Node};
+use uuid::Uuid;
 
 macro_rules! trace_span {
     ($op:literal, $step:expr) => {
@@ -53,6 +59,7 @@ macro_rules! pipeline_with_new_stream {
             batch_size: $pipeline.batch_size,
             stats: $pipeline.stats.clone(),
             node_caches: $pipeline.node_caches.clone(),
+            failed_ids: $pipeline.failed_ids.clone(),
         }
     };
 }
@@ -82,6 +89,10 @@ pub struct Pipeline<T: Chunk> {
     batch_size: usize,
     stats: StatsCollector,
     node_caches: Vec<DynNodeCacheSet>,
+    // Source ids (the id a node entered the pipeline with, kept in `parent_id`)
+    // that had a failure anywhere in their fan-out. Populated by the pipeline
+    // stages while nodes flow through them so failures survive `filter_errors`.
+    failed_ids: Arc<FailedIds>,
 }
 
 type DynStorageSetupFn =
@@ -91,6 +102,63 @@ type DynStorageSetupFn =
 /// [`Pipeline::filter_cached`] survives the node type changing across pipeline stages.
 type DynNodeCacheSet =
     Arc<dyn Fn(uuid::Uuid) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+
+/// Shared registry of source ids whose processing failed. Pipelines produced
+/// by `split_by` share one registry; `merge` links independent registries so
+/// [`Pipeline::run`] sees failures recorded by either side.
+#[derive(Default)]
+struct FailedIds {
+    own: StdMutex<HashSet<Uuid>>,
+    linked: StdMutex<Vec<Arc<FailedIds>>>,
+}
+
+impl FailedIds {
+    fn record(&self, ids: &[Uuid]) {
+        self.own
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .extend(ids.iter().copied());
+    }
+
+    /// Whether `id` was recorded in this registry or in any registry linked
+    /// into it by [`Pipeline::merge`].
+    fn contains(id: &Uuid, root: &Arc<FailedIds>) -> bool {
+        let mut visited = HashSet::new();
+        let mut stack = vec![Arc::clone(root)];
+
+        while let Some(node) = stack.pop() {
+            let key = Arc::as_ptr(&node) as usize;
+            if !visited.insert(key) {
+                continue;
+            }
+
+            if node
+                .own
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .contains(id)
+            {
+                return true;
+            }
+
+            let linked = node
+                .linked
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            stack.extend(linked);
+        }
+
+        false
+    }
+}
+
+/// Records the source ids of nodes whose processing failed. The ids are
+/// checked by [`Pipeline::run`] when it decides which source nodes may be
+/// marked as cached.
+fn record_failed_ids(failed_ids: &Arc<FailedIds>, ids: &[Uuid]) {
+    failed_ids.record(ids);
+}
 
 impl<T: Chunk> Default for Pipeline<T> {
     /// Creates a default `Pipeline` with an empty stream, no storage, and a concurrency level equal
@@ -104,6 +172,7 @@ impl<T: Chunk> Default for Pipeline<T> {
             batch_size: DEFAULT_BATCH_SIZE,
             stats: StatsCollector::new(),
             node_caches: Vec::new(),
+            failed_ids: Arc::new(FailedIds::default()),
         }
     }
 }
@@ -259,16 +328,24 @@ impl<T: Chunk> Pipeline<T> {
         transformer.with_indexing_defaults(self.indexing_defaults.clone());
 
         let transformer = Arc::new(transformer);
+        let failed_ids = self.failed_ids.clone();
         let stream = self
             .stream
             .map_ok(move |node| {
                 let transformer = transformer.clone();
+                let failed_ids = failed_ids.clone();
                 let span = trace_span!("then", transformer);
 
                 task::spawn(
                     async move {
                         node_trace_log!(transformer, node, "Transforming node");
-                        transformer.transform_node(node).await
+
+                        let id = node.parent_id.unwrap_or_else(|| node.id());
+                        let result = transformer.transform_node(node).await;
+                        if result.is_err() {
+                            record_failed_ids(&failed_ids, &[id]);
+                        }
+                        result
                     }
                     .instrument(span.or_current()),
                 )
@@ -305,17 +382,32 @@ impl<T: Chunk> Pipeline<T> {
         transformer.with_indexing_defaults(self.indexing_defaults.clone());
 
         let transformer = Arc::new(transformer);
+        let failed_ids = self.failed_ids.clone();
         let stream = self
             .stream
             .try_chunks(transformer.batch_size().unwrap_or(self.batch_size))
             .map_ok(move |nodes| {
                 let transformer = Arc::clone(&transformer);
+                let failed_ids = failed_ids.clone();
                 let span = trace_span!("then_in_batch", transformer);
+
+                let parent_ids: Vec<Uuid> = nodes
+                    .iter()
+                    .map(|node| node.parent_id.unwrap_or_else(|| node.id()))
+                    .collect();
 
                 tokio::spawn(
                     async move {
                         batch_node_trace_log!(transformer, nodes, "batch transforming nodes");
-                        transformer.batch_transform(nodes).await
+
+                        transformer
+                            .batch_transform(nodes)
+                            .await
+                            .inspect(move |item| {
+                                if item.is_err() {
+                                    record_failed_ids(&failed_ids, &parent_ids);
+                                }
+                            })
                     }
                     .instrument(span.or_current()),
                 )
@@ -346,16 +438,24 @@ impl<T: Chunk> Pipeline<T> {
     ) -> Pipeline<Output> {
         let chunker = Arc::new(chunker);
         let concurrency = chunker.concurrency().unwrap_or(self.concurrency);
+        let failed_ids = self.failed_ids.clone();
         let stream = self
             .stream
             .map_ok(move |node| {
                 let chunker = Arc::clone(&chunker);
+                let failed_ids = failed_ids.clone();
                 let span = trace_span!("then_chunk", chunker);
 
                 tokio::spawn(
                     async move {
                         node_trace_log!(chunker, node, "Chunking node");
-                        chunker.transform_node(node).await
+
+                        let id = node.parent_id.unwrap_or_else(|| node.id());
+                        chunker.transform_node(node).await.inspect(move |item| {
+                            if item.is_err() {
+                                record_failed_ids(&failed_ids, &[id]);
+                            }
+                        })
                     }
                     .instrument(span.or_current()),
                 )
@@ -389,16 +489,24 @@ impl<T: Chunk> Pipeline<T> {
     ) -> Pipeline<Output> {
         let chunker = Arc::new(transformer);
         let concurrency = chunker.concurrency().unwrap_or(self.concurrency);
+        let failed_ids = self.failed_ids.clone();
         let stream = self
             .stream
             .map_ok(move |node| {
                 let chunker = Arc::clone(&chunker);
+                let failed_ids = failed_ids.clone();
                 let span = trace_span!("then_expand", chunker);
 
                 tokio::spawn(
                     async move {
                         node_trace_log!(chunker, node, "Expanding node");
-                        chunker.transform_node(node).await
+
+                        let id = node.parent_id.unwrap_or_else(|| node.id());
+                        chunker.transform_node(node).await.inspect(move |item| {
+                            if item.is_err() {
+                                record_failed_ids(&failed_ids, &[id]);
+                            }
+                        })
                     }
                     .instrument(span.or_current()),
                 )
@@ -451,17 +559,29 @@ impl<T: Chunk> Pipeline<T> {
         self.storage_setup_fns.push(setup_fn);
 
         // add storage to the stream instead of doing it at the end
+        let failed_ids = self.failed_ids.clone();
         let stream = if storage.batch_size().is_some() {
             self.stream
                 .try_chunks(storage.batch_size().unwrap())
                 .map_ok(move |nodes| {
                     let storage = Arc::clone(&storage);
+                    let failed_ids = failed_ids.clone();
                     let span = trace_span!("then_store_with_batched", storage);
+
+                    let parent_ids: Vec<Uuid> = nodes
+                        .iter()
+                        .map(|node| node.parent_id.unwrap_or_else(|| node.id()))
+                        .collect();
 
                     tokio::spawn(
                         async move {
                             batch_node_trace_log!(storage, nodes, "batch storing nodes");
-                            storage.batch_store(nodes).await
+
+                            storage.batch_store(nodes).await.inspect(move |item| {
+                                if item.is_err() {
+                                    record_failed_ids(&failed_ids, &parent_ids);
+                                }
+                            })
                         }
                         .instrument(span.or_current()),
                     )
@@ -475,13 +595,19 @@ impl<T: Chunk> Pipeline<T> {
             self.stream
                 .map_ok(move |node| {
                     let storage = Arc::clone(&storage);
+                    let failed_ids = failed_ids.clone();
                     let span = trace_span!("then_store_with", storage);
 
                     tokio::spawn(
                         async move {
                             node_trace_log!(storage, node, "Storing node");
 
-                            storage.store(node).await
+                            let id = node.parent_id.unwrap_or_else(|| node.id());
+                            let result = storage.store(node).await;
+                            if result.is_err() {
+                                record_failed_ids(&failed_ids, &[id]);
+                            }
+                            result
                         }
                         .instrument(span.or_current()),
                     )
@@ -562,8 +688,33 @@ impl<T: Chunk> Pipeline<T> {
     ///
     /// The full stream can then be processed using the `run` method.
     #[must_use]
-    pub fn merge(self, other: Self) -> Self {
+    pub fn merge(mut self, other: Self) -> Self {
         let stream = tokio_stream::StreamExt::merge(self.stream, other.stream);
+
+        // Combine the cache registrations of both pipelines so nodes that
+        // complete in either stream mark all caches. Pipelines produced by
+        // `split_by` share the same `Arc` allocations for registrations they
+        // inherited, so pointer equality dedupes those.
+        for cache in other.node_caches {
+            if !self
+                .node_caches
+                .iter()
+                .any(|existing| Arc::ptr_eq(existing, &cache))
+            {
+                self.node_caches.push(cache);
+            }
+        }
+
+        // Link the failure registries so `run` sees failures recorded by
+        // either side. Pipelines produced by `split_by` already share one
+        // registry; skip the link in that case.
+        if !Arc::ptr_eq(&self.failed_ids, &other.failed_ids) {
+            self.failed_ids
+                .linked
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(other.failed_ids);
+        }
 
         Self {
             stream: stream.boxed().into(),
@@ -717,22 +868,40 @@ impl<T: Chunk> Pipeline<T> {
         futures_util::future::try_join_all(setup_futures).await?;
 
         let mut total_nodes = 0u64;
-        let mut cached_ids = std::collections::HashSet::new();
+        let mut completed_ids = HashSet::new();
 
         while let Some(node) = self.stream.try_next().await? {
             total_nodes += 1;
             // Count successful nodes as stored (nodes that reach the end of the stream)
             self.stats.increment_nodes_stored(1);
 
-            // Nodes reaching the end of the stream made it through the whole pipeline; only
-            // now mark them in the cache. Chunked nodes share the id of the node that entered
-            // the pipeline, so each is cached once.
+            // Nodes reaching the end of the stream made it through the whole
+            // pipeline, but a source node is only marked as cached once every
+            // child it produced completed successfully. Collect the
+            // candidates now and mark them only after the stream finished
+            // without errors. Chunked nodes share the id of the node that
+            // entered the pipeline, so each is cached once.
             if !self.node_caches.is_empty() {
-                let id = node.parent_id.unwrap_or_else(|| node.id());
-                if cached_ids.insert(id) {
-                    for mark_cached in &self.node_caches {
-                        mark_cached(id).await;
-                    }
+                completed_ids.insert(node.parent_id.unwrap_or_else(|| node.id()));
+            }
+        }
+
+        // The stream completed without errors; only now mark the parents in
+        // the caches. Parents that had a failure recorded anywhere in their
+        // fan-out are skipped so their failed chunks are retried on the next
+        // run.
+        if !self.node_caches.is_empty() {
+            let to_mark: Vec<Uuid> = {
+                let failed = self.failed_ids.clone();
+                completed_ids
+                    .into_iter()
+                    .filter(|id| !FailedIds::contains(id, &failed))
+                    .collect()
+            };
+
+            for id in to_mark {
+                for mark_cached in &self.node_caches {
+                    mark_cached(id).await;
                 }
             }
         }
@@ -1317,5 +1486,155 @@ mod tests {
             .then_store_with(storage);
 
         pipeline.run().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_parent_not_cached_when_chunker_fails_after_success() {
+        let mut loader = MockLoader::new();
+        let mut cache = MockNodeCache::new();
+        let mut chunker = MockChunkerTransformer::new();
+        let storage = MemoryStorage::default();
+
+        let parent = Node::from("parent document");
+
+        loader
+            .expect_into_stream()
+            .returning(move || vec![Ok(parent.clone())].into());
+
+        cache.expect_name().returning(|| "test_cache");
+        cache.expect_get().times(1).returning(|_| false);
+        // The chunker yields one child and then errors: the source must not
+        // be cached, or its failed chunks would be skipped on the next run.
+        cache.expect_set_by_id().times(0);
+
+        chunker.expect_transform_node().returning(|node| {
+            vec![
+                Ok(Node::build_from_other(&node)
+                    .chunk("chunk 1".to_string())
+                    .build()
+                    .unwrap()),
+                Err(anyhow::anyhow!("chunking failed halfway")),
+            ]
+            .into()
+        });
+        chunker.expect_concurrency().returning(|| None);
+        chunker.expect_name().returning(|| "chunker");
+
+        let pipeline = Pipeline::from_loader(loader)
+            .filter_cached(cache)
+            .then_chunk(chunker)
+            .then_store_with(storage.clone())
+            .filter_errors();
+
+        pipeline.run().await.unwrap();
+
+        // The successful child was still stored
+        assert_eq!(storage.get_all().await.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_merge_marks_caches_from_both_pipelines() {
+        let mut loader = MockLoader::new();
+        let mut shared_cache = MockNodeCache::new();
+        let mut left_cache = MockNodeCache::new();
+        let mut right_cache = MockNodeCache::new();
+        let storage = MemoryStorage::default();
+
+        loader
+            .expect_into_stream()
+            .returning(|| vec![Ok(Node::default())].into());
+
+        shared_cache.expect_name().returning(|| "shared_cache");
+        shared_cache.expect_get().times(1).returning(|_| false);
+        // Registered before split_by, so both halves inherit the same
+        // registration; merge must not mark it twice.
+        shared_cache.expect_set_by_id().times(1).returning(|_| ());
+
+        left_cache.expect_name().returning(|| "left_cache");
+        left_cache.expect_get().times(0);
+        left_cache.expect_set_by_id().times(1).returning(|_| ());
+
+        right_cache.expect_name().returning(|| "right_cache");
+        right_cache.expect_get().times(1).returning(|_| false);
+        right_cache.expect_set_by_id().times(1).returning(|_| ());
+
+        let pipeline = Pipeline::from_loader(loader).filter_cached(shared_cache);
+        let (left, right) = pipeline.split_by(|_| false);
+        let left = left.filter_cached(left_cache);
+        let right = right.filter_cached(right_cache);
+
+        left.merge(right)
+            .then_store_with(storage)
+            .run()
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_merge_tracks_failures_from_independent_pipelines() {
+        let mut loader_left = MockLoader::new();
+        let mut loader_right = MockLoader::new();
+        let mut left_cache = MockNodeCache::new();
+        let mut right_cache = MockNodeCache::new();
+        let mut chunker = MockChunkerTransformer::new();
+        let storage = MemoryStorage::default();
+
+        let left_node = TextNode::new("left document");
+        let right_node = TextNode::new("right document");
+        let left_id = left_node.id();
+        let right_id = right_node.id();
+
+        loader_left
+            .expect_into_stream()
+            .returning(move || vec![Ok(left_node.clone())].into());
+        loader_right
+            .expect_into_stream()
+            .returning(move || vec![Ok(right_node.clone())].into());
+
+        left_cache.expect_name().returning(|| "left_cache");
+        left_cache.expect_get().times(1).returning(|_| false);
+        left_cache
+            .expect_set_by_id()
+            .times(1)
+            .withf(move |id| *id == left_id)
+            .returning(|_| ());
+
+        right_cache.expect_name().returning(|| "right_cache");
+        right_cache.expect_get().times(1).returning(|_| false);
+        // The right side fails midway, so its source must not be marked in
+        // either cache; only the left node completes.
+        right_cache
+            .expect_set_by_id()
+            .times(1)
+            .withf(move |id| *id == left_id && *id != right_id)
+            .returning(|_| ());
+
+        chunker.expect_transform_node().returning(|node| {
+            vec![
+                Ok(Node::build_from_other(&node)
+                    .chunk("chunk 1".to_string())
+                    .build()
+                    .unwrap()),
+                Err(anyhow::anyhow!("chunking failed halfway")),
+            ]
+            .into()
+        });
+        chunker.expect_concurrency().returning(|| None);
+        chunker.expect_name().returning(|| "chunker");
+
+        let left = Pipeline::from_loader(loader_left).filter_cached(left_cache);
+        let right = Pipeline::from_loader(loader_right)
+            .filter_cached(right_cache)
+            .then_chunk(chunker)
+            .filter_errors();
+
+        left.merge(right)
+            .then_store_with(storage.clone())
+            .run()
+            .await
+            .unwrap();
+
+        // The left node and the one successful right child were stored
+        assert_eq!(storage.get_all().await.len(), 2);
     }
 }

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -60,6 +60,7 @@ macro_rules! pipeline_with_new_stream {
             stats: $pipeline.stats.clone(),
             node_caches: $pipeline.node_caches.clone(),
             failed_ids: $pipeline.failed_ids.clone(),
+            passed_cache_ids: $pipeline.passed_cache_ids.clone(),
         }
     };
 }
@@ -93,6 +94,10 @@ pub struct Pipeline<T: Chunk> {
     // that had a failure anywhere in their fan-out. Populated by the pipeline
     // stages while nodes flow through them so failures survive `filter_errors`.
     failed_ids: Arc<FailedIds>,
+    // Pairs of (cache registration pointer, source id) for nodes that passed
+    // each cache's filter. `run` marks each source only in the caches that
+    // actually processed it instead of every cache combined by `merge`.
+    passed_cache_ids: Arc<PassedCacheIds>,
 }
 
 type DynStorageSetupFn =
@@ -153,6 +158,62 @@ impl FailedIds {
     }
 }
 
+/// Shared registry of cache-filter passes, keyed by the cache registration
+/// pointer and the source id of the node that passed. Pipelines produced by
+/// `split_by` share one registry; `merge` links independent registries so
+/// [`Pipeline::run`] sees passes recorded by either side.
+///
+/// `run` marks each source id only in the caches whose filter it actually
+/// passed. Without this scoping a merged pipeline would mark every completed
+/// source in every cache, and a later run with a changed `split_by` predicate
+/// could skip a node in a branch that never processed it.
+#[derive(Default)]
+struct PassedCacheIds {
+    own: StdMutex<HashSet<(usize, Uuid)>>,
+    linked: StdMutex<Vec<Arc<PassedCacheIds>>>,
+}
+
+impl PassedCacheIds {
+    fn record(&self, cache_key: usize, id: Uuid) {
+        self.own
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert((cache_key, id));
+    }
+
+    /// All `(cache registration, source id)` pairs recorded in this registry
+    /// or in any registry linked into it by [`Pipeline::merge`].
+    fn collect(root: &Arc<PassedCacheIds>) -> HashSet<(usize, Uuid)> {
+        let mut visited = HashSet::new();
+        let mut stack = vec![Arc::clone(root)];
+        let mut passes = HashSet::new();
+
+        while let Some(node) = stack.pop() {
+            let key = Arc::as_ptr(&node) as usize;
+            if !visited.insert(key) {
+                continue;
+            }
+
+            passes.extend(
+                node.own
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .iter()
+                    .copied(),
+            );
+
+            let linked = node
+                .linked
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone();
+            stack.extend(linked);
+        }
+
+        passes
+    }
+}
+
 /// Records the source ids of nodes whose processing failed. The ids are
 /// checked by [`Pipeline::run`] when it decides which source nodes may be
 /// marked as cached.
@@ -173,6 +234,7 @@ impl<T: Chunk> Default for Pipeline<T> {
             stats: StatsCollector::new(),
             node_caches: Vec::new(),
             failed_ids: Arc::new(FailedIds::default()),
+            passed_cache_ids: Arc::new(PassedCacheIds::default()),
         }
     }
 }
@@ -276,19 +338,24 @@ impl<T: Chunk> Pipeline<T> {
     pub fn filter_cached(mut self, cache: impl NodeCache<Input = T> + 'static) -> Self {
         let cache = Arc::new(cache);
 
-        self.node_caches.push({
+        let mark_cached: DynNodeCacheSet = Arc::new({
             let cache = Arc::clone(&cache);
-            Arc::new(move |id: uuid::Uuid| {
+            move |id: uuid::Uuid| {
                 let cache = Arc::clone(&cache);
                 Box::pin(async move { cache.set_by_id(id).await })
                     as Pin<Box<dyn Future<Output = ()> + Send>>
-            })
+            }
         });
+        let cache_key = Arc::as_ptr(&mark_cached).cast::<()>() as usize;
+        self.node_caches.push(mark_cached);
+
+        let passed_cache_ids = Arc::clone(&self.passed_cache_ids);
 
         self.stream = self
             .stream
             .try_filter_map(move |node| {
                 let cache = Arc::clone(&cache);
+                let passed_cache_ids = Arc::clone(&passed_cache_ids);
                 let span = trace_span!("filter_cached", cache);
 
                 async move {
@@ -297,6 +364,8 @@ impl<T: Chunk> Pipeline<T> {
                         Ok(None)
                     } else {
                         node_trace_log!(cache, node, "node not in cache, processing");
+                        let id = node.parent_id.unwrap_or_else(|| node.id());
+                        passed_cache_ids.record(cache_key, id);
                         Ok(Some(node))
                     }
                 }
@@ -716,6 +785,17 @@ impl<T: Chunk> Pipeline<T> {
                 .push(other.failed_ids);
         }
 
+        // Link the cache-pass registries so `run` sees which caches processed
+        // each node. Pipelines produced by `split_by` already share one
+        // registry; skip the link in that case.
+        if !Arc::ptr_eq(&self.passed_cache_ids, &other.passed_cache_ids) {
+            self.passed_cache_ids
+                .linked
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(other.passed_cache_ids);
+        }
+
         Self {
             stream: stream.boxed().into(),
             ..self
@@ -891,19 +971,37 @@ impl<T: Chunk> Pipeline<T> {
         // fan-out are skipped so their failed chunks are retried on the next
         // run.
         if !self.node_caches.is_empty() {
-            let to_mark: Vec<Uuid> = {
-                let failed = self.failed_ids.clone();
-                completed_ids
-                    .into_iter()
-                    .filter(|id| !FailedIds::contains(id, &failed))
-                    .collect()
-            };
+            // Each source id is marked only in the caches whose filter it
+            // actually passed. Marking every cache combined by `merge` would
+            // let one branch skip a node another branch processed when the
+            // `split_by` predicate changes between runs.
+            let passed = PassedCacheIds::collect(&self.passed_cache_ids);
 
-            for id in to_mark {
-                for mark_cached in &self.node_caches {
-                    mark_cached(id).await;
-                }
-            }
+            let to_mark: Vec<(DynNodeCacheSet, Uuid)> = completed_ids
+                .into_iter()
+                .filter(|id| !FailedIds::contains(id, &self.failed_ids))
+                .flat_map(|id| {
+                    let passed = &passed;
+                    self.node_caches
+                        .iter()
+                        .cloned()
+                        .filter_map(move |mark_cached| {
+                            let cache_key = Arc::as_ptr(&mark_cached).cast::<()>() as usize;
+                            passed
+                                .contains(&(cache_key, id))
+                                .then_some((mark_cached, id))
+                        })
+                })
+                .collect();
+
+            // Bound the marking work to the pipeline's concurrency so a large
+            // corpus does not issue one serial round-trip per source id.
+            futures_util::stream::iter(
+                to_mark.into_iter().map(|(mark_cached, id)| mark_cached(id)),
+            )
+            .buffer_unordered(self.concurrency)
+            .collect::<Vec<()>>()
+            .await;
         }
 
         self.stats.increment_nodes_processed(total_nodes);
@@ -1533,7 +1631,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_merge_marks_caches_from_both_pipelines() {
+    async fn test_merge_only_marks_caches_the_branch_processed() {
         let mut loader = MockLoader::new();
         let mut shared_cache = MockNodeCache::new();
         let mut left_cache = MockNodeCache::new();
@@ -1552,7 +1650,10 @@ mod tests {
 
         left_cache.expect_name().returning(|| "left_cache");
         left_cache.expect_get().times(0);
-        left_cache.expect_set_by_id().times(1).returning(|_| ());
+        // The node was routed to the right branch, so the left cache must
+        // not be marked; otherwise a later run with a changed predicate
+        // would skip the node on the left branch.
+        left_cache.expect_set_by_id().times(0);
 
         right_cache.expect_name().returning(|| "right_cache");
         right_cache.expect_get().times(1).returning(|_| false);
@@ -1582,7 +1683,6 @@ mod tests {
         let left_node = TextNode::new("left document");
         let right_node = TextNode::new("right document");
         let left_id = left_node.id();
-        let right_id = right_node.id();
 
         loader_left
             .expect_into_stream()
@@ -1601,13 +1701,10 @@ mod tests {
 
         right_cache.expect_name().returning(|| "right_cache");
         right_cache.expect_get().times(1).returning(|_| false);
-        // The right side fails midway, so its source must not be marked in
-        // either cache; only the left node completes.
-        right_cache
-            .expect_set_by_id()
-            .times(1)
-            .withf(move |id| *id == left_id && *id != right_id)
-            .returning(|_| ());
+        // The right source fails midway, so it must never be marked, and the
+        // left node never passed the right cache's filter, so the right cache
+        // gets no marks at all.
+        right_cache.expect_set_by_id().times(0);
 
         chunker.expect_transform_node().returning(|node| {
             vec![

--- a/swiftide-indexing/src/pipeline.rs
+++ b/swiftide-indexing/src/pipeline.rs
@@ -52,6 +52,7 @@ macro_rules! pipeline_with_new_stream {
             indexing_defaults: $pipeline.indexing_defaults.clone(),
             batch_size: $pipeline.batch_size,
             stats: $pipeline.stats.clone(),
+            node_caches: $pipeline.node_caches.clone(),
         }
     };
 }
@@ -80,10 +81,16 @@ pub struct Pipeline<T: Chunk> {
     indexing_defaults: IndexingDefaults,
     batch_size: usize,
     stats: StatsCollector,
+    node_caches: Vec<DynNodeCacheSet>,
 }
 
 type DynStorageSetupFn =
     Arc<dyn Fn() -> Pin<Box<dyn Future<Output = Result<()>> + Send>> + Send + Sync>;
+
+/// Marks a node id as processed in a `NodeCache`. Type erased so the cache registered in
+/// [`Pipeline::filter_cached`] survives the node type changing across pipeline stages.
+type DynNodeCacheSet =
+    Arc<dyn Fn(uuid::Uuid) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
 
 impl<T: Chunk> Default for Pipeline<T> {
     /// Creates a default `Pipeline` with an empty stream, no storage, and a concurrency level equal
@@ -96,6 +103,7 @@ impl<T: Chunk> Default for Pipeline<T> {
             indexing_defaults: IndexingDefaults::default(),
             batch_size: DEFAULT_BATCH_SIZE,
             stats: StatsCollector::new(),
+            node_caches: Vec::new(),
         }
     }
 }
@@ -185,6 +193,9 @@ impl<T: Chunk> Pipeline<T> {
 
     /// Filters out cached nodes using the provided cache.
     ///
+    /// Nodes are only marked in the cache once they have made it through the whole pipeline, so
+    /// a node that fails partway is retried on the next run instead of being skipped.
+    ///
     /// # Arguments
     ///
     /// * `cache` - A cache that implements the `NodeCache` trait.
@@ -195,6 +206,16 @@ impl<T: Chunk> Pipeline<T> {
     #[must_use]
     pub fn filter_cached(mut self, cache: impl NodeCache<Input = T> + 'static) -> Self {
         let cache = Arc::new(cache);
+
+        self.node_caches.push({
+            let cache = Arc::clone(&cache);
+            Arc::new(move |id: uuid::Uuid| {
+                let cache = Arc::clone(&cache);
+                Box::pin(async move { cache.set_by_id(id).await })
+                    as Pin<Box<dyn Future<Output = ()> + Send>>
+            })
+        });
+
         self.stream = self
             .stream
             .try_filter_map(move |node| {
@@ -207,7 +228,6 @@ impl<T: Chunk> Pipeline<T> {
                         Ok(None)
                     } else {
                         node_trace_log!(cache, node, "node not in cache, processing");
-                        cache.set(&node).await;
                         Ok(Some(node))
                     }
                 }
@@ -697,11 +717,24 @@ impl<T: Chunk> Pipeline<T> {
         futures_util::future::try_join_all(setup_futures).await?;
 
         let mut total_nodes = 0u64;
+        let mut cached_ids = std::collections::HashSet::new();
 
-        while let Some(_result) = self.stream.try_next().await? {
+        while let Some(node) = self.stream.try_next().await? {
             total_nodes += 1;
             // Count successful nodes as stored (nodes that reach the end of the stream)
             self.stats.increment_nodes_stored(1);
+
+            // Nodes reaching the end of the stream made it through the whole pipeline; only
+            // now mark them in the cache. Chunked nodes share the id of the node that entered
+            // the pipeline, so each is cached once.
+            if !self.node_caches.is_empty() {
+                let id = node.parent_id.unwrap_or_else(|| node.id());
+                if cached_ids.insert(id) {
+                    for mark_cached in &self.node_caches {
+                        mark_cached(id).await;
+                    }
+                }
+            }
         }
 
         self.stats.increment_nodes_processed(total_nodes);
@@ -1119,5 +1152,170 @@ mod tests {
         // Verify storage has the nodes
         let nodes = storage.get_all().await;
         assert_eq!(nodes.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_nodes_only_cached_on_success() {
+        let mut loader = MockLoader::new();
+        let mut cache = MockNodeCache::new();
+        let mut storage = MockPersist::new();
+        let mut transformer = MockTransformer::new();
+
+        loader
+            .expect_into_stream()
+            .returning(|| vec![Ok(Node::default())].into());
+
+        cache.expect_get().times(1).returning(|_| false);
+        cache.expect_name().returning(|| "test_cache");
+
+        transformer
+            .expect_transform_node()
+            .returning(|_| Err(anyhow::anyhow!("Transformation failed")));
+        transformer.expect_concurrency().returning(|| None);
+        transformer
+            .expect_name()
+            .returning(|| "failing_transformer");
+
+        storage.expect_setup().returning(|| Ok(()));
+        storage.expect_batch_size().returning(|| None);
+
+        // The node never makes it through the pipeline, so nothing may be cached
+        cache.expect_set().times(0);
+        cache.expect_set_by_id().times(0);
+
+        let pipeline = Pipeline::from_loader(loader)
+            .filter_cached(cache)
+            .then(transformer)
+            .then_store_with(storage)
+            .filter_errors();
+
+        pipeline.run().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_nodes_cached_on_successful_run() {
+        let mut loader = MockLoader::new();
+        let mut cache = MockNodeCache::new();
+        let storage = MemoryStorage::default();
+
+        loader
+            .expect_into_stream()
+            .returning(|| vec![Ok(Node::default())].into());
+
+        cache.expect_name().returning(|| "test_cache");
+        cache.expect_get().times(1).returning(|_| false);
+
+        cache.expect_set().times(0);
+        cache.expect_set_by_id().times(1).returning(|_| ());
+
+        let pipeline = Pipeline::from_loader(loader)
+            .filter_cached(cache)
+            .then_store_with(storage);
+
+        pipeline.run().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cached_nodes_are_skipped() {
+        let mut loader = MockLoader::new();
+        let mut cache = MockNodeCache::new();
+        let storage = MemoryStorage::default();
+
+        loader
+            .expect_into_stream()
+            .returning(|| vec![Ok(Node::default())].into());
+
+        cache.expect_name().returning(|| "test_cache");
+        cache.expect_get().times(1).returning(|_| true);
+
+        // Already cached, so no marking either
+        cache.expect_set_by_id().times(0);
+
+        let pipeline = Pipeline::from_loader(loader)
+            .filter_cached(cache)
+            .then_store_with(storage.clone());
+
+        pipeline.run().await.unwrap();
+        assert!(storage.get_all().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_chunked_nodes_cache_their_parent_once() {
+        let mut loader = MockLoader::new();
+        let mut cache = MockNodeCache::new();
+        let mut chunker = MockChunkerTransformer::new();
+        let storage = MemoryStorage::default();
+
+        let parent = Node::from("parent document");
+        let parent_id = parent.id();
+
+        loader
+            .expect_into_stream()
+            .returning(move || vec![Ok(parent.clone())].into());
+
+        cache.expect_name().returning(|| "test_cache");
+        cache.expect_get().times(1).returning(|_| false);
+
+        chunker.expect_transform_node().returning(|node| {
+            vec![
+                Ok(Node::build_from_other(&node)
+                    .chunk("chunk 1".to_string())
+                    .build()
+                    .unwrap()),
+                Ok(Node::build_from_other(&node)
+                    .chunk("chunk 2".to_string())
+                    .build()
+                    .unwrap()),
+                Ok(Node::build_from_other(&node)
+                    .chunk("chunk 3".to_string())
+                    .build()
+                    .unwrap()),
+            ]
+            .into()
+        });
+        chunker.expect_concurrency().returning(|| None);
+        chunker.expect_name().returning(|| "chunker");
+
+        // Three chunks make it through, but only the shared parent id gets cached
+        cache
+            .expect_set_by_id()
+            .times(1)
+            .withf(move |id| *id == parent_id)
+            .returning(|_| ());
+
+        let pipeline = Pipeline::from_loader(loader)
+            .filter_cached(cache)
+            .then_chunk(chunker)
+            .then_store_with(storage.clone());
+
+        pipeline.run().await.unwrap();
+        assert_eq!(storage.get_all().await.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_caches_all_marked_on_success() {
+        let mut loader = MockLoader::new();
+        let mut first_cache = MockNodeCache::new();
+        let mut second_cache = MockNodeCache::new();
+        let storage = MemoryStorage::default();
+
+        loader
+            .expect_into_stream()
+            .returning(|| vec![Ok(Node::default())].into());
+
+        first_cache.expect_name().returning(|| "first_cache");
+        first_cache.expect_get().times(1).returning(|_| false);
+        first_cache.expect_set_by_id().times(1).returning(|_| ());
+
+        second_cache.expect_name().returning(|| "second_cache");
+        second_cache.expect_get().times(1).returning(|_| false);
+        second_cache.expect_set_by_id().times(1).returning(|_| ());
+
+        let pipeline = Pipeline::from_loader(loader)
+            .filter_cached(first_cache)
+            .filter_cached(second_cache)
+            .then_store_with(storage);
+
+        pipeline.run().await.unwrap();
     }
 }

--- a/swiftide-integrations/src/duckdb/mod.rs
+++ b/swiftide-integrations/src/duckdb/mod.rs
@@ -192,7 +192,53 @@ impl<T: Chunk> Duckdb<T> {
 
     /// Formats a node key for the cache table
     pub fn node_key(&self, node: &swiftide_core::indexing::Node<T>) -> String {
-        format!("{}.{}", self.cache_key_prefix, node.id())
+        let cache_id = node.parent_id().unwrap_or_else(|| node.id());
+        self.node_key_for_id(cache_id)
+    }
+
+    /// Formats a cache key for a given node id
+    pub fn node_key_for_id(&self, id: uuid::Uuid) -> String {
+        format!("{}.{}", self.cache_key_prefix, id)
+    }
+
+    /// Inserts a key into the cache table, creating the table if needed. Errors are logged, not
+    /// propagated, matching the other cache writes.
+    async fn insert_cache_key(&self, key: String, path: String) {
+        if let Err(err) = self
+            .lazy_create_cache()
+            .await
+            .context("failed to create cache table")
+        {
+            tracing::error!("Failed to create cache table: {:#}", err);
+            return;
+        }
+
+        let sql = format!(
+            "INSERT INTO {} (uuid, path) VALUES (?, ?) ON CONFLICT (uuid) DO NOTHING",
+            self.cache_table
+        );
+
+        let lock = self.connection.lock().unwrap();
+        let mut stmt = match lock
+            .prepare(&sql)
+            .context("Failed to prepare duckdb statement for cache set")
+        {
+            Ok(stmt) => stmt,
+            Err(err) => {
+                tracing::error!(
+                    "Failed to prepare duckdb statement for cache set: {:#}",
+                    err
+                );
+                return;
+            }
+        };
+
+        if let Err(err) = stmt
+            .execute([key, path])
+            .context("failed to insert into cache table")
+        {
+            tracing::error!("Failed to insert into cache table: {:#}", err);
+        }
     }
 
     fn hybrid_query_sql(

--- a/swiftide-integrations/src/duckdb/node_cache.rs
+++ b/swiftide-integrations/src/duckdb/node_cache.rs
@@ -57,41 +57,15 @@ impl<T: Chunk> NodeCache for Duckdb<T> {
     }
 
     async fn set(&self, node: &Node<T>) {
-        if let Err(err) = self
-            .lazy_create_cache()
-            .await
-            .context("failed to create cache table")
-        {
-            tracing::error!("Failed to create cache table: {:#}", err);
-            return;
-        }
+        let key = self.node_key(node);
+        let path = node.path.to_string_lossy().into_owned();
+        self.insert_cache_key(key, path).await;
+    }
 
-        let sql = format!(
-            "INSERT INTO {} (uuid, path) VALUES (?, ?) ON CONFLICT (uuid) DO NOTHING",
-            self.cache_table
-        );
-
-        let lock = self.connection.lock().unwrap();
-        let mut stmt = match lock
-            .prepare(&sql)
-            .context("Failed to prepare duckdb statement for cache set")
-        {
-            Ok(stmt) => stmt,
-            Err(err) => {
-                tracing::error!(
-                    "Failed to prepare duckdb statement for cache set: {:#}",
-                    err
-                );
-                return;
-            }
-        };
-
-        if let Err(err) = stmt
-            .execute([self.node_key(node), node.path.to_string_lossy().into()])
-            .context("failed to insert into cache table")
-        {
-            tracing::error!("Failed to insert into cache table: {:#}", err);
-        }
+    async fn set_by_id(&self, id: uuid::Uuid) {
+        // The path is unknown for deferred cache writes; it is not read anywhere.
+        self.insert_cache_key(self.node_key_for_id(id), String::new())
+            .await;
     }
 
     async fn clear(&self) -> anyhow::Result<()> {

--- a/swiftide-integrations/src/redb/mod.rs
+++ b/swiftide-integrations/src/redb/mod.rs
@@ -74,7 +74,13 @@ impl Redb {
         RedbBuilder::default()
     }
     pub fn node_key(&self, node: &swiftide_core::indexing::TextNode) -> String {
-        format!("{}.{}", self.cache_key_prefix, node.id())
+        let cache_id = node.parent_id().unwrap_or_else(|| node.id());
+        self.node_key_for_id(cache_id)
+    }
+
+    /// Formats a cache key for a given node id
+    pub fn node_key_for_id(&self, id: uuid::Uuid) -> String {
+        format!("{}.{}", self.cache_key_prefix, id)
     }
 
     pub fn table_definition(&self) -> redb::TableDefinition<'_, String, bool> {

--- a/swiftide-integrations/src/redb/node_cache.rs
+++ b/swiftide-integrations/src/redb/node_cache.rs
@@ -63,12 +63,17 @@ impl NodeCache for Redb {
     }
 
     async fn set(&self, node: &TextNode) {
+        self.set_by_id(node.parent_id().unwrap_or_else(|| node.id()))
+            .await;
+    }
+
+    async fn set_by_id(&self, id: uuid::Uuid) {
         let write_txn = self.database.begin_write().unwrap();
 
         {
             let mut table = write_txn.open_table(self.table_definition()).unwrap();
 
-            table.insert(self.node_key(node), true).unwrap();
+            table.insert(self.node_key_for_id(id), true).unwrap();
         }
         write_txn.commit().unwrap();
     }

--- a/swiftide-integrations/src/redis/mod.rs
+++ b/swiftide-integrations/src/redis/mod.rs
@@ -142,7 +142,13 @@ impl<T: Chunk> Redis<T> {
     ///
     /// A `String` representing the Redis key for the node.
     fn cache_key_for_node(&self, node: &Node<T>) -> String {
-        format!("{}:{}", self.cache_key_prefix, node.id())
+        let cache_id = node.parent_id().unwrap_or_else(|| node.id());
+        format!("{}:{}", self.cache_key_prefix, cache_id)
+    }
+
+    /// Generates a cache key for a given node id.
+    fn cache_key_for_id(&self, id: uuid::Uuid) -> String {
+        format!("{}:{}", self.cache_key_prefix, id)
     }
 
     /// Generates a key for a given node to be persisted in Redis.

--- a/swiftide-integrations/src/redis/node_cache.rs
+++ b/swiftide-integrations/src/redis/node_cache.rs
@@ -62,9 +62,20 @@ impl<T: Chunk> NodeCache for Redis<T> {
     /// Logs an error if the node cannot be set in the cache.
     #[tracing::instrument(skip_all, level = "trace")]
     async fn set(&self, node: &Node<T>) {
+        self.set_by_id(node.parent_id().unwrap_or_else(|| node.id()))
+            .await;
+    }
+
+    /// Marks the node identified by `id` as cached.
+    ///
+    /// # Errors
+    ///
+    /// Logs an error if the node cannot be set in the cache.
+    #[tracing::instrument(skip_all, level = "trace")]
+    async fn set_by_id(&self, id: uuid::Uuid) {
         if let Some(mut cm) = self.lazy_connect().await {
             let result: Result<(), redis::RedisError> = redis::cmd("SET")
-                .arg(self.cache_key_for_node(node))
+                .arg(self.cache_key_for_id(id))
                 .arg(1)
                 .query_async(&mut cm)
                 .await;


### PR DESCRIPTION
Was running a continuously restarting indexing job against Qdrant and noticed documents silently vanishing from the index whenever the embed or store step hiccuped. `filter_cached` writes the cache entry the moment a node passes the filter, so anything that fails further down the pipeline is still marked as processed and gets skipped forever on the next run.

Same underlying thing as #151, and it's the caching half of what #1044 ran into with `filter_cached` being unsafe for them. I saw #800 fixed this once by moving the set to the end of the run but got reverted in #852, so this take avoids the background task and channel entirely: the pipeline just keeps the caches registered with `filter_cached` around and, inside `run()`, marks a node only once it actually reaches the end of the stream. Nothing to drain, nothing to await.

To make that work with chunking, nodes now carry a `parent_id` pointing at the first node they were derived from (set in `build_from_other`), and the cache key functions in the redis/redb/duckdb integrations prefer that id. A document that fans out into 50 chunks is cached once, under the same id `filter_cached` originally checked.

`NodeCache` gains a `set_by_id` for the deferred write. I made it a required method, so custom cache implementations will need to add it — seemed better than a default that silently does the wrong thing.

What this doesn't fix: if one chunk out of fifty fails and the pipeline has `filter_errors`, the other 49 still mark the document as cached. Doing that properly needs per-document chunk accounting, which felt out of scope here.

Tests: new unit tests in swiftide-indexing cover failure (nothing cached), success (cached once), already-cached skip, chunk dedup to the parent id, and multiple caches. `cargo test -p swiftide-core -p swiftide-indexing --all-features` and `cargo check -p swiftide-integrations --features redis,redb,duckdb` pass locally, plus clippy on the two core crates. Full workspace `--all-features` needs to build datafusion and bundled duckdb from source which my box didn't survive, so I left that to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lineage tracking for derived pipeline nodes, preserving their original source identity.
  * Added support for marking completed nodes as cached by identifier.
  * Improved cache key consistency for derived and chunked outputs across supported backends.

* **Bug Fixes**
  * Cache completion tracking now respects the filters and branches that processed each source.
  * Cache entries avoid duplicate registrations.
  * Cache table initialization and insertion errors no longer interrupt processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->